### PR TITLE
Support appending worktree

### DIFF
--- a/aiida_worktree/utils/__init__.py
+++ b/aiida_worktree/utils/__init__.py
@@ -8,7 +8,11 @@ def get_executor(data):
     if is_pickle:
         import cloudpickle as pickle
 
-        executor = pickle.loads(data["executor"])
+        try:
+            executor = pickle.loads(data["executor"])
+        except Exception as e:
+            print("Error in loading executor: ", e)
+            executor = None
     else:
         if type == "WorkflowFactory":
             executor = WorkflowFactory(data["name"])

--- a/aiida_worktree/worktree.py
+++ b/aiida_worktree/worktree.py
@@ -278,8 +278,8 @@ class WorkTree(node_graph.NodeGraph):
         prefix is used to add a prefix to the node names.
         """
         for node in wt.nodes:
-            node.name = prefix + "_" + node.name
-            node.wait = [prefix + "_" + w for w in node.wait] if node.wait else []
+            node.name = prefix + node.name
+            node.wait = [prefix + w for w in node.wait] if node.wait else []
             node.parent = self
             self.nodes.append(node)
         # self.sequence.extend([prefix + node for node in wt.sequence])

--- a/aiida_worktree/worktree.py
+++ b/aiida_worktree/worktree.py
@@ -272,3 +272,19 @@ class WorkTree(node_graph.NodeGraph):
         self.conditions = []
         self.ctx = {}
         self.state = "CREATED"
+
+    def append(self, wt, prefix=""):
+        """Append a worktree to the current worktree.
+        prefix is used to add a prefix to the node names.
+        """
+        for node in wt.nodes:
+            node.name = prefix + "_" + node.name
+            node.wait = [prefix + "_" + w for w in node.wait] if node.wait else []
+            node.parent = self
+            self.nodes.append(node)
+        # self.sequence.extend([prefix + node for node in wt.sequence])
+        # self.conditions.extend(wt.conditions)
+        self.ctx.update(wt.ctx)
+        # links
+        for link in wt.links:
+            self.links.append(link)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,11 +156,11 @@ def decorated_add_multiply(decorated_add, decorated_multiply):
 def decorated_add_multiply_group(decorated_add, decorated_multiply):
     """Generate a decorated node for test."""
 
-    @node.group(outputs=[["multiply.result", "result"]])
+    @node.group(outputs=[["multiply1.result", "result"]])
     def add_multiply_group(x, y, z):
         wt = WorkTree("add_multiply_group")
         add1 = wt.nodes.new(decorated_add, name="add1", x=x, y=y)
-        multiply = wt.nodes.new(decorated_multiply, name="multiply", x=z)
+        multiply = wt.nodes.new(decorated_multiply, name="multiply1", x=z)
         # link the output of int node to the input of add node
         wt.links.new(add1.outputs[0], multiply.inputs["y"])
         return wt

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -79,3 +79,16 @@ def test_restart(wt_calcjob):
     assert wt1.nodes["add3"].node.outputs.sum == 13
     assert wt1.nodes["add1"].node.pk == wt.nodes["add1"].pk
     assert wt1.nodes["add2"].node.pk != wt.nodes["add2"].pk
+
+
+def test_append_worktree(decorated_add_multiply_group):
+    from aiida_worktree import WorkTree
+
+    wt = WorkTree("test_node_group")
+    add1 = wt.nodes.new("AiiDAAdd", "add1", x=2, y=3)
+    add_multiply_wt = decorated_add_multiply_group(x=0, y=4, z=5)
+    # append worktree
+    wt.append(add_multiply_wt, prefix="group_")
+    wt.links.new(add1.outputs[0], wt.nodes["group_add1"].inputs["x"])
+    wt.submit(wait=True)
+    assert wt.nodes["group_multiply1"].node.outputs.result == 45


### PR DESCRIPTION
## Use case
There are two ways to combine worktrees:
- Use the worktree as a node (group) inside another worktree. 
- Append the worktree directly to another worktree.

This PR adds support for the second case.

## Example
To append a worktree into another worktree, there are two steps:
- append the worktree
- adjust the links, add new links between nodes, and remove old links if needed.

Here is an example to combine `bands` worktree, `pdos` worktree with a `relax` node to form a new worktree.

```python
from aiida_quantumespresso.worktrees.bands_group import bands_worktree
from aiida_quantumespresso.worktrees.pdos_group import pdos_worktree
from aiida_worktree import WorkTree, build_node

PwRelaxChainNode = build_node({'path': 'aiida_quantumespresso.workflows.pw.relax.PwRelaxWorkChain'})

# create a new worktree
wt = WorkTree('Electronic Structure of Si')
# add relax node
relax_node = wt.nodes.new(PwRelaxChainNode, name='relax')
relax_node.set(relax_inputs)
# create the bands worktree
bands_wt = bands_worktree(structure=structure_si,
                        inputs=bands_inputs,
                        run_relax=False)
# create the pdos worktree
pdos_wt = pdos_worktree(structure=structure_si,
                        inputs=pdos_inputs,
                        run_scf=True)
# append bands and pdos wroktrees
wt.append(bands_wt, prefix='bands')
wt.append(pdos_wt, prefix='pdos')
# adjust the links
wt.links.new(relax_node.outputs['output_structure'], wt.nodes["bands_scf"].inputs['pw.structure'])
wt.links.new(relax_node.outputs['output_structure'], wt.nodes["pdos_scf"].inputs['pw.structure'])
wt.run()
```

This final worktree:

![Screenshot from 2024-04-12 16-53-50](https://github.com/superstar54/aiida-worktree/assets/11457659/e612d398-ecb9-4d16-be51-d213cbcf8f53)

