### PR TITLE
rename `append` to `extend`

### DIFF
--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -337,8 +337,8 @@ class WorkGraph(node_graph.NodeGraph):
         self.ctx = {}
         self.state = "CREATED"
 
-    def append(self, wg, prefix=""):
-        """Append a workgraph to the current workgraph.
+    def extend(self, wg, prefix=""):
+        """Add a workgraph to the current workgraph.
         prefix is used to add a prefix to the node names.
         """
         for node in wg.nodes:

--- a/docs/source/howto/combine_workgraph.ipynb
+++ b/docs/source/howto/combine_workgraph.ipynb
@@ -5,11 +5,11 @@
    "id": "22d177dc-6cfb-4de2-9509-f1eb45e10cf2",
    "metadata": {},
    "source": [
-    "# How to append workgraph\n",
+    "# How to combine workgraphs\n",
     "## Introduction\n",
     "There are two ways to combine workgraphs:\n",
     "- Use the graph builder inside another workgraph. \n",
-    "- Append the workgraph directly to another workgraph.\n",
+    "- Add the workgraph directly to another workgraph.\n",
     "\n",
     "This tutorial will show an example for the second case.\n",
     "\n"
@@ -58,7 +58,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f56b2b640aeb45a1994870498a03408c",
+       "model_id": "ab072c6730374feeba82b369b73bf7e9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -97,7 +97,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f77f1ec455cd43c6bd917ce8472b5317",
+       "model_id": "06bcddcdab504915ad448a86ee024fa7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -121,7 +121,7 @@
    "id": "0f46d277",
    "metadata": {},
    "source": [
-    "### Append workgraph\n",
+    "### Extend workgraph\n",
     "\n",
     "First, create a workgraph with `relax` node:"
    ]
@@ -135,7 +135,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a782fb0a5c884effa679745fd4481a5d",
+       "model_id": "05ac445fc796410982dc14ce7d4def0c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -164,38 +164,36 @@
    "source": [
     "Now let's combine `bands` workgraph, `pdos` workgraph with a `relax` node to form a new workgraph.\n",
     "\n",
-    "To append a workgraph into another workgraph, there are two steps:\n",
-    "- append the workgraph\n",
+    "To add a workgraph into another workgraph, there are two steps:\n",
+    "- extend the workgraph\n",
     "- adjust the links, add new links between nodes, and remove old links if needed.\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "11e3bca1-dda6-44e9-9585-54feeda7e7db",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a782fb0a5c884effa679745fd4481a5d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NodeGraphWidget(settings={'minimap': True}, style={'width': '90%', 'height': '600px'}, value={'name': 'Electro…"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "Exception",
+     "evalue": "bands_bands_bands_scf already exist, please choose another name.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_1298951/2690407025.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# extend a wroktree\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mwg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mbands_wg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprefix\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'bands_'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mwg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpdos_wg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprefix\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'pdos_'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# adjust the links\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mwg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlinks\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnew\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrelax_node\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'output_structure'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnodes\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'bands_scf'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'pw.structure'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/repos/superstar54/aiida-workgraph/aiida_workgraph/workgraph.py\u001b[0m in \u001b[0;36mextend\u001b[0;34m(self, wg, prefix)\u001b[0m\n\u001b[1;32m    346\u001b[0m             \u001b[0mnode\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwait\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mprefix\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mw\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mw\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mnode\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwait\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mnode\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwait\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    347\u001b[0m             \u001b[0mnode\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparent\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 348\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnodes\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    349\u001b[0m         \u001b[0;31m# self.sequence.extend([prefix + node for node in wg.sequence])\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    350\u001b[0m         \u001b[0;31m# self.conditions.extend(wg.conditions)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/repos/scinode/node-graph/node_graph/collection.py\u001b[0m in \u001b[0;36mappend\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m     76\u001b[0m         \u001b[0;34m\"\"\"Append item into this collection.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mitem\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 78\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"{item.name} already exist, please choose another name.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     79\u001b[0m         \u001b[0mitem\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minner_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_inner_id\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     80\u001b[0m         \u001b[0msetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"parent\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: bands_bands_bands_scf already exist, please choose another name."
+     ]
     }
    ],
    "source": [
-    "# append a wroktree\n",
-    "wg.append(bands_wg, prefix='bands_')\n",
-    "wg.append(pdos_wg, prefix='pdos_')\n",
+    "# extend a wroktree\n",
+    "wg.extend(bands_wg, prefix='bands_')\n",
+    "wg.extend(pdos_wg, prefix='pdos_')\n",
     "# adjust the links\n",
     "wg.links.new(relax_node.outputs['output_structure'], wg.nodes['bands_scf'].inputs['pw.structure'])\n",
     "wg.links.new(relax_node.outputs['output_structure'], wg.nodes['pdos_scf'].inputs['pw.structure'])\n",
@@ -214,14 +212,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "345f250f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "42f9eb1b04a7415793ea7a626a527927",
+       "model_id": "49ba8919a6794b67b58920a6aa55f60c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -229,7 +227,7 @@
        "NodeGraphWidget(settings={'minimap': True}, style={'width': '90%', 'height': '600px'}, value={'name': 'Electro…"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -16,7 +16,7 @@ This section contains a collection of HowTos for various topics.
    ctx
    aiida_shell
    wait
-   append_workgraph
+   combine_workgraph
    restart
    continue_finished_workgraph
    protocol

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -87,8 +87,8 @@ def test_append_workgraph(decorated_add_multiply_group):
     wg = WorkGraph("test_graph_build")
     add1 = wg.nodes.new("AiiDAAdd", "add1", x=2, y=3)
     add_multiply_wg = decorated_add_multiply_group(x=0, y=4, z=5)
-    # append workgraph
-    wg.append(add_multiply_wg, prefix="group_")
+    # extend workgraph
+    wg.extend(add_multiply_wg, prefix="group_")
     wg.links.new(add1.outputs[0], wg.nodes["group_add1"].inputs["x"])
     wg.submit(wait=True)
     assert wg.nodes["group_multiply1"].node.outputs.result == 45


### PR DESCRIPTION
WorkGraph has nodes and links collections, which are like lists. When combining WorkGraph B to WorkGraph A, it basically adds all the nodes (links) from B to the nodes (links) of A. 

In Python's list, `append` adds a single element to the end of the list, while `extend` adds multiple elements by appending each element of an iterable individually. Thus `extend` is more suitable in this case.

