### PR TITLE
show required sockets (the args)

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -104,9 +104,14 @@ def build_node_from_AiiDA(ndata, outputs=None):
     outputs = [] if outputs is None else outputs
     executor = ndata["executor"]
     spec = executor.spec()
+    args = []
+    kwargs = []
     for _key, port in spec.inputs.ports.items():
         add_input_recursive(inputs, port)
-    kwargs = [input[1] for input in inputs]
+        if port.required:
+            args.append(port.name)
+        else:
+            kwargs.append(port.name)
     for _key, port in spec.outputs.ports.items():
         outputs.append(["General", port.name])
     if spec.inputs.dynamic:
@@ -122,6 +127,7 @@ def build_node_from_AiiDA(ndata, outputs=None):
     outputs.append(["General", "_wait"])
     inputs.append(["General", "_wait", {"link_limit": 1e6}])
     ndata["node_class"] = Node
+    ndata["args"] = args
     ndata["kwargs"] = kwargs
     ndata["inputs"] = inputs
     ndata["outputs"] = outputs

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -754,7 +754,10 @@ class WorkGraph(Process, metaclass=Protect):
                 print("node  type: calcjob/workchain.")
                 kwargs.setdefault("metadata", {})
                 kwargs["metadata"].update({"call_link_label": name})
-                process = self.submit(executor, *args, **kwargs)
+                # transfer the args to kwargs
+                for i, key in enumerate(self.ctx.nodes[name]["metadata"]["args"]):
+                    kwargs[key] = args[i]
+                process = self.submit(executor, **kwargs)
                 node["process"] = process
                 self.ctx.nodes[name]["state"] = "RUNNING"
                 self.to_context(**{name: process})

--- a/aiida_workgraph/nodes/test.py
+++ b/aiida_workgraph/nodes/test.py
@@ -120,7 +120,7 @@ class AiiDANode(Node):
     name = "AiiDANode"
     node_type = "node"
     catalog = "Test"
-    args = ["value"]
+    kwargs = ["identifier", "pk", "uuid", "label"]
 
     def create_properties(self):
         pass
@@ -128,7 +128,10 @@ class AiiDANode(Node):
     def create_sockets(self):
         self.inputs.clear()
         self.outputs.clear()
-        self.inputs.new("General", "value")
+        self.inputs.new("General", "identifier")
+        self.inputs.new("General", "pk")
+        self.inputs.new("General", "uuid")
+        self.inputs.new("General", "label")
         self.outputs.new("General", "node")
 
     def get_executor(self):
@@ -145,14 +148,15 @@ class AiiDACode(Node):
     name = "AiiDACode"
     node_type = "node"
     catalog = "Test"
-    args = ["value"]
-
-    def create_properties(self):
-        self.properties.new("General", "value", default=1)
+    kwargs = ["identifier", "pk", "uuid", "label"]
 
     def create_sockets(self):
         self.inputs.clear()
         self.outputs.clear()
+        self.inputs.new("General", "identifier")
+        self.inputs.new("General", "pk")
+        self.inputs.new("General", "uuid")
+        self.inputs.new("General", "label")
         self.outputs.new("General", "Code")
 
     def get_executor(self):

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -28,6 +28,7 @@ def get_executor(data):
 
 
 def create_data_node(executor, args, kwargs):
+    """Create an AiiDA data node from the executor and args and kwargs."""
     from aiida import orm
 
     # print("Create data node: ", executor, args, kwargs)

--- a/aiida_workgraph/web/backend/app/utils.py
+++ b/aiida_workgraph/web/backend/app/utils.py
@@ -15,12 +15,19 @@ def workgraph_to_short_json(wgdata):
     }
     #
     for name, node in wgdata["nodes"].items():
+        # Add required inputs to nodes
+        inputs = [
+            input
+            for input in node["inputs"]
+            if input["name"] in node["metadata"]["args"]
+        ]
         wgdata_short["nodes"][name] = {
             "label": node["name"],
-            "inputs": [],
+            "inputs": inputs,
             "outputs": [],
             "position": node["position"],
         }
+    # Add links to nodes
     for link in wgdata["links"]:
         wgdata_short["nodes"][link["to_node"]]["inputs"].append(
             {

--- a/aiida_workgraph/web/frontend/src/rete/default.ts
+++ b/aiida_workgraph/web/frontend/src/rete/default.ts
@@ -50,7 +50,7 @@ interface NodeMap {
 
 class Node extends ClassicPreset.Node {
   width = 180;
-  height = 120;
+  height = 100;
 }
 class Connection<N extends Node> extends ClassicPreset.Connection<N, N> {}
 
@@ -60,22 +60,25 @@ type AreaExtra = ReactArea2D<any> | MinimapExtra | ContextMenuExtra;
 
 function createDynamicNode(nodeData: any) {
   const node = new Node(nodeData.label);
-
+  // resize the node based on the max length of the input/output names
+  let maxSocketNameLength = 0;
   nodeData.inputs.forEach((input: NodeInput) => {
     let socket = new ClassicPreset.Socket(input.name);
     if (!node.inputs.hasOwnProperty(input.name)) {
       node.addInput(input.name, new ClassicPreset.Input(socket, input.name));
-      node.height += 25; // Increase height of node for each input
+      maxSocketNameLength = Math.max(maxSocketNameLength, input.name.length);
     }
-});
+  });
 
   nodeData.outputs.forEach((output: NodeOutput) => {
     let socket = new ClassicPreset.Socket(output.name);
     if (!node.outputs.hasOwnProperty(output.name)) {
       node.addOutput(output.name, new ClassicPreset.Output(socket, output.name));
-      node.height += 25; // Increase height of node for each output
-  }
+      maxSocketNameLength = Math.max(maxSocketNameLength, output.name.length);
+    }
   });
+  node.height = Math.max(140, node.height + (nodeData.inputs.length + nodeData.outputs.length) * 35)
+  node.width += maxSocketNameLength * 5;
 
   return node;
 }

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -12,55 +12,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e1d3116aca234eb6a81f853b35b07973",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NodeGraphWidget(settings={'minimap': True}, style={'width': '90%', 'height': '600px'}, value={'name': 'WorkGra…"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from aiida_workgraph import node\n",
-    "from aiida_workgraph import WorkGraph, build_node\n",
+    "from aiida_quantumespresso.workgraphs.bands import bands_workgraph\n",
     "from aiida import load_profile\n",
-    "from aiida.orm import Int\n",
-    "\n",
     "load_profile()\n",
     "\n",
-    "# define add calcfunction node\n",
-    "@node.calcfunction()\n",
-    "def add(x, y):\n",
-    "    return x + y\n",
-    "\n",
-    "# define multiply calcfunction node\n",
-    "@node.calcfunction()\n",
-    "def multiply(x, y):\n",
-    "    return x*y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wg = WorkGraph(\"test_add_multiply\")\n",
-    "wg.nodes.new(add, name=\"add1\", x=Int(2.0), y=Int(3.0))\n",
-    "wg.nodes.new(multiply, name=\"multiply1\", y=Int(4.0))\n",
-    "wg.links.new(wg.nodes[\"add1\"].outputs[0], wg.nodes[\"multiply1\"].inputs[\"x\"])\n",
-    "AddMultiplyNode = build_node(wg)\n",
-    "AddMultiplyNode\n",
-    "wg.to_dict()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wg = WorkGraph(\"test_graph_build\")\n",
-    "add1 = wg.nodes.new(\"AiiDAAdd\", \"add1\", x=2, y=3)\n",
-    "# add the workgraph as a node\n",
-    "add_mutiply1 = wg.nodes.new(AddMultiplyNode, \"add_mutiply1\")\n",
-    "wg.links.new(add1.outputs[0], add_mutiply1.inputs[\"add1.x\"])\n",
-    "wg"
+    "bands_wg = bands_workgraph(run_relax=True)\n",
+    "bands_wg"
    ]
   },
   {

--- a/examples/examples_widget.ipynb
+++ b/examples/examples_widget.ipynb
@@ -15,16 +15,16 @@
    },
    "outputs": [],
    "source": [
-    "from aiida_workgraph import node\n",
+    "from aiida.engine import calcfunction\n",
     "from aiida_workgraph import WorkGraph\n",
     "\n",
     "# define add calcfunction node\n",
-    "@node.calcfunction()\n",
+    "@calcfunction\n",
     "def add(x, y):\n",
     "    return x + y\n",
     "\n",
     "# define multiply calcfunction node\n",
-    "@node.calcfunction()\n",
+    "@calcfunction\n",
     "def multiply(x, y):\n",
     "    return x*y\n"
    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def wg_calcfunction():
     """A workgraph with calcfunction."""
 
     wg = WorkGraph(name="test_debug_math")
-    float1 = wg.nodes.new("AiiDANode", "float1", value=Float(3.0).store())
+    float1 = wg.nodes.new("AiiDANode", "float1", pk=Float(3.0).store().pk)
     sumdiff1 = wg.nodes.new("AiiDASumDiff", "sumdiff1", x=2)
     sumdiff2 = wg.nodes.new("AiiDASumDiff", "sumdiff2", x=4)
     sumdiff3 = wg.nodes.new("AiiDASumDiff", "sumdiff3", x=6)
@@ -34,8 +34,8 @@ def wg_calcjob(arithmetic_add):
 
     code = load_code("add@localhost")
     wg = WorkGraph(name="test_debug_math")
-    int1 = wg.nodes.new("AiiDANode", "int1", value=Int(3).store())
-    code1 = wg.nodes.new("AiiDACode", "code1", value=code.pk)
+    int1 = wg.nodes.new("AiiDANode", "int1", pk=Int(3).store().pk)
+    code1 = wg.nodes.new("AiiDACode", "code1", pk=code.pk)
     add1 = wg.nodes.new(arithmetic_add, "add1", x=Int(2).store())
     add2 = wg.nodes.new(arithmetic_add, "add2", x=Int(4).store())
     add3 = wg.nodes.new(arithmetic_add, "add3", x=Int(4).store())
@@ -54,9 +54,9 @@ def wg_workchain():
 
     code = load_code("add@localhost")
     wg = WorkGraph(name="test_debug_math")
-    int1 = wg.nodes.new("AiiDANode", "int1", value=Int(2).store())
-    int2 = wg.nodes.new("AiiDANode", "int2", value=Int(3).store())
-    code1 = wg.nodes.new("AiiDACode", "code1", value=code.pk)
+    int1 = wg.nodes.new("AiiDANode", "int1", pk=Int(2).store().pk)
+    int2 = wg.nodes.new("AiiDANode", "int2", pk=Int(3).store().pk)
+    code1 = wg.nodes.new("AiiDACode", "code1", pk=code.pk)
     multiply_add1 = wg.nodes.new(
         "AiiDAArithmeticMultiplyAdd", "multiply_add1", x=Int(4).store()
     )

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -12,8 +12,8 @@ def test_args():
 
     #
     n = test.node()
-    assert n.args == []
-    assert n.kwargs == ["a", "b"]
+    assert n.args == ["a"]
+    assert n.kwargs == ["b"]
     assert n.var_args is None
     assert n.var_kwargs == "c"
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -17,9 +17,9 @@ def test_multiply_link():
         return Float(total)
 
     wg = WorkGraph(name="test_multiply_link")
-    float1 = wg.nodes.new("AiiDANode", value=Float(1.0).store())
-    float2 = wg.nodes.new("AiiDANode", value=Float(2.0).store())
-    float3 = wg.nodes.new("AiiDANode", value=Float(3.0).store())
+    float1 = wg.nodes.new("AiiDANode", pk=Float(1.0).store().pk)
+    float2 = wg.nodes.new("AiiDANode", pk=Float(2.0).store().pk)
+    float3 = wg.nodes.new("AiiDANode", pk=Float(3.0).store().pk)
     gather1 = wg.nodes.new("AiiDAGather", "gather1")
     sum1 = wg.nodes.new(sum, "sum1")
     wg.links.new(float1.outputs[0], gather1.inputs[0])

--- a/tests/test_qe.py
+++ b/tests/test_qe.py
@@ -69,8 +69,7 @@ def test_pw_dos_projwfc(wg_structure_si):
     }
     pw_relax1.set({"metadata": metadata})
     #
-    pw_code = wg.nodes.new("AiiDACode", "pw_code")
-    pw_code.set({"value": "qe-7.2-pw@localhost"})
+    pw_code = wg.nodes.new("AiiDACode", "pw_code", label="qe-7.2-pw@localhost")
     #
     pw_parameters1 = wg.nodes.new("AiiDADict", "pw_parameters1")
     paras = {
@@ -91,14 +90,14 @@ def test_pw_dos_projwfc(wg_structure_si):
     #
     #
     dos1 = wg.nodes.new("AiiDADos", "dos1")
-    dos_code = wg.nodes.new("AiiDACode", "dos_code")
-    dos_code.set({"value": "qe-7.2-dos@localhost"})
+    dos_code = wg.nodes.new("AiiDACode", "dos_code", label="qe-7.2-dos@localhost")
     dos_parameters1 = wg.nodes.new("AiiDADict", "dos_parameters1")
     dos1.set({"metadata": metadata})
     #
     projwfc1 = wg.nodes.new("AiiDAProjwfc", "projwfc1")
-    projwfc_code = wg.nodes.new("AiiDACode", "projwfc_code")
-    projwfc_code.set({"value": "qe-7.2-projwfc@localhost"})
+    projwfc_code = wg.nodes.new(
+        "AiiDACode", "projwfc_code", label="qe-7.2-projwfc@localhost"
+    )
     projwfc_parameters1 = wg.nodes.new("AiiDADict", "projwfc_parameters1")
     projwfc1.set({"metadata": metadata})
     #
@@ -125,13 +124,9 @@ def test_pw_dos_projwfc(wg_structure_si):
 
 def test_pw_relax_workchain(structure_si):
     """Run simple calcfunction."""
-    from aiida_workgraph import build_node, node, WorkGraph
+    from aiida_workgraph import node, WorkGraph
     from aiida.orm import Dict, KpointsData, load_code, load_group
-
-    # register node
-    pw_relax_node = build_node(
-        "aiida_quantumespresso.workflows.pw.relax.PwRelaxWorkChain"
-    )
+    from aiida_quantumespresso.workflows.pw.relax import PwRelaxWorkChain
 
     @node.calcfunction()
     def pw_parameters(paras, relax_type):
@@ -139,6 +134,7 @@ def test_pw_relax_workchain(structure_si):
         paras1["CONTROL"]["calculation"] = relax_type
         return paras1
 
+    structure_si.store()
     #
     code = load_code("qe-7.2-pw@localhost")
     paras = Dict(
@@ -172,9 +168,9 @@ def test_pw_relax_workchain(structure_si):
 
     wg = WorkGraph("test_pw_relax")
     # structure node
-    wg.nodes.new("AiiDANode", "si", value=structure_si)
+    wg.nodes.new("AiiDANode", "si", pk=structure_si.pk)
     # pw node
-    pw_relax1 = wg.nodes.new(pw_relax_node, name="pw_relax1")
+    pw_relax1 = wg.nodes.new(PwRelaxWorkChain, name="pw_relax1")
     pw_relax1.set(
         {
             "base": {

--- a/tests/test_workchain.py
+++ b/tests/test_workchain.py
@@ -27,7 +27,7 @@ def test_build_workchain(build_workchain):
 
     code = load_code("add@localhost")
     wg = WorkGraph(name="test_debug_math")
-    code1 = wg.nodes.new("AiiDACode", "code1", value=code.pk)
+    code1 = wg.nodes.new("AiiDACode", "code1", pk=code.pk)
     multiply_add1 = wg.nodes.new(
         build_workchain,
         "multiply_add1",


### PR DESCRIPTION
Suggested by @giovannipizzi, to show the required inputs in the GUI

For example, in the following code,
- `add` node, `x` is args (required), and `y` is kwargs.
- `multiply` node, both `x` and `y` are required
```python
from aiida.engine import calcfunction
from aiida_workgraph import WorkGraph

# define add calcfunction
@calcfunction
def add(x, y=1):
    return x + y

# define multiply calcfunction
@calcfunction
def multiply(x, y):
    return x*y

wg = WorkGraph("test_add_multiply")
wg.nodes.new(add, name="add1")
wg.nodes.new(multiply, name="multiply1")
wg.links.new(wg.nodes["add1"].outputs[0], wg.nodes["multiply1"].inputs["x"])
wg
```

This is shown in the GUI:

![Screenshot from 2024-05-03 16-33-56](https://github.com/superstar54/aiida-workgraph/assets/11457659/c53c5c91-5207-4985-9da5-dfe81382ccde)
