### PR TITLE
Add basic socket type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,8 +107,6 @@ jobs:
             run: |
                 aiida-pseudo install sssp -v 1.3 -x PBEsol -p efficiency
                 aiida-pseudo install sssp -v 1.3 -x PBE -p efficiency
-                aiida-pseudo install sssp -v 1.2 -x PBEsol -p efficiency
-                aiida-pseudo install sssp -v 1.2 -x PBE -p efficiency
 
         -   name: Start AiiDA daemon
             run: verdi daemon start 2

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -133,7 +133,6 @@ def build_node_from_callable(
         if getattr(executor, "node_class", False):
             ndata["node_type"] = node_types.get(executor.node_class, "NORMAL")
             ndata["executor"] = executor
-            print("ndata: ", ndata)
             return build_node_from_AiiDA(ndata, inputs=inputs, outputs=outputs)
         else:
             ndata["node_type"] = "NORMAL"

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -16,7 +16,7 @@ node_types = {
     WorkChain: "WORKCHAIN",
 }
 
-socket_types = {
+aiida_socket_maping = {
     orm.Int: "AiiDAInt",
     orm.Float: "AiiDAFloat",
     orm.Str: "AiiDAString",
@@ -59,11 +59,13 @@ def add_input_recursive(
         if port_name not in input_names:
             # port.valid_type can be a single type or a tuple of types,
             # we only support single type for now
-            if isinstance(port.valid_type, tuple):
+            if isinstance(port.valid_type, tuple) and len(port.valid_type) > 1:
                 socket_type = "General"
+            if isinstance(port.valid_type, tuple) and len(port.valid_type) == 1:
+                socket_type = aiida_socket_maping.get(port.valid_type[0], "General")
             else:
-                socket_type = socket_types.get(port.valid_type, "General")
-            inputs.append([socket_types.get(socket_type, "General"), port_name])
+                socket_type = aiida_socket_maping.get(port.valid_type, "General")
+            inputs.append([socket_type, port_name])
         if required:
             args.append(port_name)
         else:

--- a/aiida_workgraph/nodes/__init__.py
+++ b/aiida_workgraph/nodes/__init__.py
@@ -17,9 +17,6 @@ from .qe import (
     AiiDAKpoint,
     AiiDAPWPseudo,
     AiiDAStructure,
-    AiiDAPW,
-    AiiDADos,
-    AiiDAProjwfc,
 )
 
 node_list = [
@@ -41,9 +38,6 @@ node_list = [
     AiiDAKpoint,
     AiiDAPWPseudo,
     AiiDAStructure,
-    AiiDAPW,
-    AiiDADos,
-    AiiDAProjwfc,
 ]
 
 

--- a/aiida_workgraph/nodes/qe.py
+++ b/aiida_workgraph/nodes/qe.py
@@ -60,7 +60,7 @@ class AiiDAPWPseudo(Node):
 
     def create_properties(self) -> None:
         self.properties.new(
-            "AiiDAString", "psuedo_familay", default="SSSP/1.2/PBEsol/efficiency"
+            "AiiDAString", "psuedo_familay", default="SSSP/1.3/PBEsol/efficiency"
         )
 
     def create_sockets(self) -> None:
@@ -72,94 +72,4 @@ class AiiDAPWPseudo(Node):
             "path": "aiida_workgraph.executors.qe",
             "name": "get_pseudo_from_structure",
             "type": "function",
-        }
-
-
-class AiiDAPW(Node):
-    """DFT calculation using PW code."""
-
-    identifier = "AiiDAPW"
-    name = "PW"
-    node_type = "CALCJOB"
-    catalog = "QE"
-    args = []
-    kwargs = ["kpoints", "parameters", "pseudos", "structure", "code", "metadata"]
-
-    def create_properties(self) -> None:
-        self.properties.new("BaseDict", "metadata", default={})
-
-    def create_sockets(self) -> None:
-        self.inputs.new("General", "parameters")
-        self.inputs.new("General", "pseudos")
-        self.inputs.new("General", "code")
-        self.inputs.new("General", "structure")
-        self.inputs.new("General", "kpoints")
-        self.outputs.new("General", "output_parameters")
-        self.outputs.new("General", "remote_folder")
-        self.outputs.new("General", "output_structure")
-        self.outputs.new("General", "output_trajectory")
-        self.outputs.new("General", "output_band")
-
-    def get_executor(self) -> Dict[str, str]:
-        return {
-            "name": "quantumespresso.pw",
-            "type": "CalculationFactory",
-        }
-
-
-class AiiDADos(Node):
-    """DFT calculation using dos code."""
-
-    identifier = "AiiDADos"
-    name = "Dos"
-    node_type = "CALCJOB"
-    catalog = "QE"
-    args = []
-    kwargs = ["parent_folder", "code", "parameters", "metadata"]
-
-    def create_properties(self) -> None:
-        self.properties.new("BaseDict", "metadata", default={})
-
-    def create_sockets(self) -> None:
-        self.inputs.new("General", "parent_folder")
-        self.inputs.new("General", "code")
-        inp = self.inputs.new("General", "parameters")
-        inp.add_property("AiiDADict", "parameters", default={})
-        self.outputs.new("General", "output_dos")
-        self.outputs.new("General", "output_parameters")
-        self.outputs.new("General", "remote_folder")
-
-    def get_executor(self) -> Dict[str, str]:
-        return {
-            "name": "quantumespresso.dos",
-            "type": "CalculationFactory",
-        }
-
-
-class AiiDAProjwfc(Node):
-    """DFT calculation using Projwfc code."""
-
-    identifier = "AiiDAProjwfc"
-    name = "Projwfc"
-    node_type = "CALCJOB"
-    catalog = "QE"
-    args = []
-    kwargs = ["parent_folder", "code", "parameters", "metadata"]
-
-    def create_properties(self) -> None:
-        self.properties.new("BaseDict", "metadata", default={})
-
-    def create_sockets(self) -> None:
-        self.inputs.new("General", "parent_folder")
-        self.inputs.new("General", "code")
-        inp = self.inputs.new("General", "parameters")
-        inp.add_property("AiiDADict", "parameters", default={})
-        self.outputs.new("General", "Dos")
-        self.outputs.new("General", "output_parameters")
-        self.outputs.new("General", "remote_folder")
-
-    def get_executor(self) -> Dict[str, str]:
-        return {
-            "name": "quantumespresso.projwfc",
-            "type": "CalculationFactory",
         }

--- a/aiida_workgraph/properties/built_in.py
+++ b/aiida_workgraph/properties/built_in.py
@@ -39,14 +39,18 @@ class AiiDAIntProperty(NodeProperty, SerializeJson):
         self,
         name: str,
         description: str = "",
-        default: Union[int, None] = 0,
+        default: Union[int, None] = None,
         update: Callable = None,
     ) -> None:
         super().__init__(name, description, default, update)
 
     def set_value(self, value: Union[int, orm.Int, str]) -> None:
         # run the callback function
-        if isinstance(value, int):
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif isinstance(value, int):
             self._value = orm.Int(value)
             if self.update is not None:
                 self.update()
@@ -74,14 +78,18 @@ class AiiDAFloatProperty(NodeProperty, SerializeJson):
         self,
         name: str,
         description: str = "",
-        default: Union[int, None] = 0.0,
+        default: Union[int, None] = None,
         update: Callable = None,
     ) -> None:
         super().__init__(name, description, default, update)
 
     def set_value(self, value: Union[float, orm.Float, int, orm.Int, str]) -> None:
         # run the callback function
-        if isinstance(value, (int, float)):
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif isinstance(value, (int, float)):
             self._value = orm.Float(value)
             if self.update is not None:
                 self.update()
@@ -109,14 +117,18 @@ class AiiDABoolProperty(NodeProperty, SerializeJson):
         self,
         name: str,
         description: str = "",
-        default: Union[bool, None] = True,
+        default: Union[bool, None] = None,
         update: Callable = None,
     ) -> None:
         super().__init__(name, description, default, update)
 
     def set_value(self, value: Union[bool, orm.Bool, int, str]) -> None:
         # run the callback function
-        if isinstance(value, (bool, int)):
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif isinstance(value, (bool, int)):
             self._value = orm.Bool(value)
             if self.update is not None:
                 self.update()
@@ -144,13 +156,17 @@ class AiiDAStringProperty(NodeProperty, SerializeJson):
         self,
         name: str,
         description: str = "",
-        default: Union[str, orm.Str, None] = True,
+        default: Union[str, orm.Str, None] = None,
         update: Callable = None,
     ) -> None:
         super().__init__(name, description, default, update)
 
     def set_value(self, value: Union[str, orm.Str]) -> None:
-        if isinstance(value, str):
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif isinstance(value, str):
             self._value = orm.Str(value)
             if self.update is not None:
                 self.update()
@@ -184,7 +200,11 @@ class AiiDADictProperty(NodeProperty, SerializeJson):
         super().__init__(name, description, default, update)
 
     def set_value(self, value: Union[Dict, orm.Dict, str]) -> None:
-        if isinstance(value, dict):
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif isinstance(value, dict):
             self._value = orm.Dict(value)
             if self.update is not None:
                 self.update()
@@ -220,7 +240,11 @@ class AiiDAIntVectorProperty(VectorProperty):
 
     def set_value(self, value: List[int]) -> None:
         # run the callback function
-        if len(value) == self.size:
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif len(value) == self.size:
             for i in range(self.size):
                 if isinstance(value[i], int):
                     self._value[i] = value[i]
@@ -254,7 +278,11 @@ class AiiDAFloatVectorProperty(VectorProperty):
 
     def set_value(self, value: List[Union[int, float]]) -> None:
         # run the callback function
-        if len(value) == self.size:
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif len(value) == self.size:
             for i in range(self.size):
                 if isinstance(value[i], (int, float)):
                     self._value[i] = value[i]
@@ -294,7 +322,11 @@ class BoolVectorProperty(VectorProperty):
 
     def set_value(self, value: List[Union[bool, int]]) -> None:
         # run the callback function
-        if len(value) == self.size:
+        if value is None:
+            self._value = value
+            if self.update is not None:
+                self.update()
+        elif len(value) == self.size:
             for i in range(self.size):
                 if isinstance(value[i], (bool, int)):
                     self._value[i] = value[i]

--- a/aiida_workgraph/sockets/built_in.py
+++ b/aiida_workgraph/sockets/built_in.py
@@ -2,6 +2,10 @@ from typing import Optional, Any
 from aiida_workgraph.socket import NodeSocket
 from node_graph.serializer import SerializeJson, SerializePickle
 from node_graph.sockets.builtin import (
+    SocketInt,
+    SocketFloat,
+    SocketString,
+    SocketBool,
     SocketBaseDict,
     SocketBaseList,
 )
@@ -135,6 +139,10 @@ class SocketAiiDAFloatVector(NodeSocket, SerializeJson):
 
 socket_list = [
     SocketGeneral,
+    SocketInt,
+    SocketFloat,
+    SocketString,
+    SocketBool,
     SocketBaseDict,
     SocketBaseList,
     SocketAiiDAInt,

--- a/docs/source/concept/socket.ipynb
+++ b/docs/source/concept/socket.ipynb
@@ -76,6 +76,55 @@
    "source": [
     "Two values are needed to define a port, e.g., `[\"General\", \"sum\"]`, where the first value `General` indicates the data type, and the second value is the name of the port. We use `General` for any data type.\n",
     "\n",
+    "## Assign socket type based on typing hints\n",
+    "The type hints in the function signature can be used to assign the socket type. The following table shows the mapping between the type hints and the socket type.\n",
+    "\n",
+    "| Type hint     | Socket type   |\n",
+    "|---------------|---------------|\n",
+    "| `orm.Int`     | `AiiDAInt`    |\n",
+    "| `orm.Str`     | `AiiDAString` |\n",
+    "| `orm.Float`   | `AiiDAFloat`  |\n",
+    "| `orm.Bool`    | `AiiDABool`   |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aiida_socket_maping:  {<class 'aiida.orm.nodes.data.int.Int'>: 'AiiDAInt', <class 'aiida.orm.nodes.data.float.Float'>: 'AiiDAFloat', <class 'aiida.orm.nodes.data.str.Str'>: 'AiiDAString', <class 'aiida.orm.nodes.data.bool.Bool'>: 'AiiDABool'}\n",
+      "metadata                      : General             \n",
+      "metadata.store_provenance     : General             \n",
+      "metadata.description          : General             \n",
+      "metadata.label                : General             \n",
+      "metadata.call_link_label      : General             \n",
+      "x                             : AiiDAInt            \n",
+      "y                             : AiiDAFloat          \n",
+      "_wait                         : General             \n"
+     ]
+    }
+   ],
+   "source": [
+    "from aiida_workgraph import node\n",
+    "\n",
+    "@node.calcfunction()\n",
+    "def add(x: int, y: float) -> float:\n",
+    "   return x + y\n",
+    "\n",
+    "for input in add.node().inputs:\n",
+    "   print(\"{:30s}: {:20s}\".format(input.name, input.identifier))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
     "## Data validation (**Experimental**)\n",
     "One can use the class of the data directly when defining the port.\n",
     "\n",
@@ -110,7 +159,9 @@
     "\n",
     "### Property\n",
     "\n",
-    "A socket can has a property. The data of the property will be used when there is no connection to the input port. The property can be added when define a custom port. Or it can be added later by using ``add_property`` method."
+    "A socket can has a property. The data of the property will be used when there is no connection to the input port. The property can be added when define a custom port. Or it can be added later by using ``add_property`` method.\n",
+    "\n",
+    "In `aiida-workgraph`, all socket must have a property. The value of the property will be used when there is no connection to the input port."
    ]
   },
   {
@@ -151,7 +202,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -9,10 +9,9 @@ def test_socket(decorated_multiply) -> None:
     from aiida_workgraph import node
 
     @node(
-        inputs=[[int, "x"], [float, "y"]],
         outputs=[[float, "result"]],
     )
-    def add(x, y):
+    def add(x: int, y: float):
         result = x + y
         return result
 
@@ -26,7 +25,7 @@ def test_socket(decorated_multiply) -> None:
     with pytest.raises(Exception) as excinfo:
         add1.set({"x": 1.0, "y": 2})  # Direct integers instead of orm.Int or orm.Float
 
-    assert "is not an {}".format(int.__name__) in str(excinfo.value)
+    assert "is not" in str(excinfo.value) and int.__name__ in str(excinfo.value)
     # This should be successful
     add1.set({"x": 1, "y": 2.0})
     wg.submit(wait=True)
@@ -39,10 +38,9 @@ def test_AiiDA_socket():
     from aiida import orm
 
     @node.calcfunction(
-        inputs=[[orm.Int, "x"], [orm.Float, "y"]],
         outputs=[[orm.Float, "result"]],
     )
-    def add(x, y):
+    def add(x: int, y: float):
         result = x + y
         return result
 
@@ -54,7 +52,7 @@ def test_AiiDA_socket():
             {"x": orm.Float(1.0), "y": 2}
         )  # Direct integers instead of orm.Int or orm.Float
 
-    assert "is not an {}".format(orm.Int.__name__) in str(excinfo.value)
+    assert "is not" in str(excinfo.value)
     # This should be successful
     add1.set({"x": orm.Int(1), "y": orm.Float(2.0)})
     wg.run()


### PR DESCRIPTION
- inspect the data type of the inputs using typing hint.
- adds basic types: Int, Float, String, Bool

```python
from aiida_workgraph import node

@node.calcfunction()
def add(x: int, y: float) -> float:
   return x + y

for input in add.node().inputs:
   print("{:30s}: {:20s}".format(input.name, input.identifier))
```

```console
metadata                      : General             
metadata.store_provenance     : General             
metadata.description          : General             
metadata.label                : General             
metadata.call_link_label      : General             
x                             : AiiDAInt            
y                             : AiiDAFloat          
_wait                         : General 
```



Fix
- return decorated `calcfunction` and `workfunction`
- use basic AiiDA port valid type as the type of the socket
