### PR TITLE
Use the workgraph name as the process label.

### DIFF
--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -394,6 +394,10 @@ class WorkGraphEngine(Process, metaclass=Protect):
         except Exception as e:
             print(e)
 
+    def _build_process_label(self) -> str:
+        """Use the workgraph name as the process label."""
+        return f"WorkGraph<{self.inputs.wg['name']}>"
+
     def setup(self) -> None:
         # track if the awaitable callback is added to the runner
         self.ctx._awaitable_actions = []
@@ -404,7 +408,6 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.init_ctx(wgdata)
         #
         self.ctx.msgs = []
-        self.node.set_process_label(f"WorkGraph: {self.ctx.workgraph['name']}")
         self.ctx._execution_count = 0
         # init node results
         self.set_node_results()

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -35,8 +35,10 @@ def test_new_node(wg_calcjob):
 def test_save_load(wg_calcjob):
     """Save the workgraph"""
     wg = wg_calcjob
+    wg.name = "test_save_load"
     wg.save()
     assert wg.process.process_state.value.upper() == "CREATED"
+    assert wg.process.process_label == "WorkGraph<test_save_load>"
     wg2 = WorkGraph.load(wg.process.pk)
     assert len(wg.nodes) == len(wg2.nodes)
 


### PR DESCRIPTION
use `_builder_process_label` is the right way to set the process label, instead of setting it from `node`