### PR TITLE
Support typing hint in PythonJob

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -323,6 +323,22 @@ def build_node_from_workgraph(wg: any) -> Node:
     return node
 
 
+def get_required_imports(func):
+    """Retrieve type hints and the corresponding module"""
+    from typing import get_type_hints
+
+    type_hints = get_type_hints(func)
+    imports = {}
+    for name, type_hint in type_hints.items():
+        if hasattr(type_hint, "__module__"):
+            module_name = type_hint.__module__
+            type_name = type_hint.__name__
+            if module_name not in imports:
+                imports[module_name] = set()
+            imports[module_name].add(type_name)
+    return imports
+
+
 def serialize_function(func: Callable) -> Dict[str, Any]:
     """Serialize a function for storage or transmission."""
     import cloudpickle as pickle
@@ -331,14 +347,23 @@ def serialize_function(func: Callable) -> Dict[str, Any]:
 
     source_code = inspect.getsource(func)
     source_code_lines = source_code.split("\n")
+    # we need save the source code explicitly, because in the case of jupyter notebook,
+    # the source code is not saved in the pickle file
     function_source_code = "\n".join(source_code_lines[1:])
     function_source_code = textwrap.dedent(function_source_code)
-
+    # we also need to include the necessary imports for the types used in the type hints.
+    required_imports = get_required_imports(func)
+    # Generate import statements
+    import_statements = "\n".join(
+        f"from {module} import {', '.join(types)}"
+        for module, types in required_imports.items()
+    )
     return {
         "executor": pickle.dumps(func),
         "type": "function",
         "is_pickle": True,
         "function_source_code": function_source_code,
+        "import_statements": import_statements,
     }
 
 

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -876,7 +876,11 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 metadata.update({"call_link_label": name})
                 # get the source code of the function
                 function_name = executor.__name__
-                function_source_code = node["executor"]["function_source_code"]
+                function_source_code = (
+                    node["executor"]["import_statements"]
+                    + "\n"
+                    + node["executor"]["function_source_code"]
+                )
                 # outputs
                 output_name_list = [output["name"] for output in node["outputs"]]
                 # serialize the kwargs into AiiDA Data

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -10,7 +10,7 @@ def test_python_job():
 
     # define add node
     @node()
-    def add(x, y):
+    def add(x: float, y: float) -> float:
         return x + y
 
     # define multiply node

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,21 +1,23 @@
 import aiida
 from aiida_workgraph import WorkGraph, node
+from typing import Any
 
 aiida.load_profile()
 
 
-def test_python_job():
+def test_python_job_typing():
     """Test a simple python node."""
     from aiida_workgraph import node, WorkGraph
+    from numpy import array
 
     # define add node
     @node()
-    def add(x: float, y: float) -> float:
+    def add(x: array, y: array) -> array:
         return x + y
 
     # define multiply node
     @node()
-    def multiply(x, y):
+    def multiply(x: Any, y: Any) -> Any:
         return x * y
 
     wg = WorkGraph("test_python_job")
@@ -32,12 +34,17 @@ def test_python_job():
     }
     wg.run(
         inputs={
-            "add": {"x": 2, "y": 3, "computer": "localhost", "metadata": metadata},
+            "add": {
+                "x": array([1, 2]),
+                "y": array([2, 3]),
+                "computer": "localhost",
+                "metadata": metadata,
+            },
             "multiply": {"y": 4, "computer": "localhost", "metadata": metadata},
         },
         # wait=True,
     )
-    assert wg.nodes["multiply"].outputs["result"].value.value == 20
+    assert (wg.nodes["multiply"].outputs["result"].value.value == array([12, 20])).all()
 
 
 def test_python_job_outputs():


### PR DESCRIPTION
Users can use type hints in the function, which will be run on a remote computer. The requirement is that user need to use the imported class directly. For example, `np.array` will fail. Users need to `from numpy import array`, and then use `array` in the type hints.

```python
from aiida_workgraph import node
from numpy import array
from typing import Any

# use array
@node()
def add(x: array, y: array) -> array:
    return x + y

# use Any
@node()
def multiply(x: Any, y: Any) -> Any:
    return x * y
```