### PR TITLE
set child tasks to SKIPPED

### DIFF
--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -503,7 +503,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 task["results"] = task["process"].outputs
                 # self.ctx.new_data[name] = task["results"]
                 self.ctx.tasks[name]["state"] = "FAILED"
-                # set child state to SKIPPED
+                # set child tasks state to SKIPPED
                 self.set_task_state(
                     self.ctx.connectivity["child_node"][name], "SKIPPED"
                 )
@@ -604,7 +604,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 is_finished = not should_run
         print("is workgraph finished: ", is_finished)
         if is_finished and len(failed_tasks) > 0:
-            message = f"WorkGraph finished, but tasks: {failed_tasks} failed."
+            message = f"WorkGraph finished, but tasks: {failed_tasks} failed. Thus all their child tasks are skipped."
             self.report(message)
             result = ExitCode(302, message)
         else:
@@ -767,7 +767,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
                     self.ctx.tasks[name]["state"] = "FAILED"
                     # set child state to FAILED
                     self.set_task_state(
-                        self.ctx.connectivity["child_node"][name], "FAILED"
+                        self.ctx.connectivity["child_node"][name], "SKIPPED"
                     )
                     print(f"Task: {name} failed.")
                     self.report(f"Task: {name} failed.")

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -503,8 +503,10 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 task["results"] = task["process"].outputs
                 # self.ctx.new_data[name] = task["results"]
                 self.ctx.tasks[name]["state"] = "FAILED"
-                # set child state to FAILED
-                self.set_task_state(self.ctx.connectivity["child_node"][name], "FAILED")
+                # set child state to SKIPPED
+                self.set_task_state(
+                    self.ctx.connectivity["child_node"][name], "SKIPPED"
+                )
                 self.report(f"Task: {name} failed.")
         else:
             task["results"] = None

--- a/tests/test_failed_node.py
+++ b/tests/test_failed_node.py
@@ -11,7 +11,12 @@ def test_failed_node(decorated_sqrt: Callable, decorated_add: Callable) -> None:
 
     wg = WorkGraph(name="test_failed_node")
     wg.tasks.new(decorated_add, "add1", x=Float(1), y=Float(2))
-    wg.tasks.new(decorated_sqrt, "sqrt1", x=Float(-1))
+    sqrt1 = wg.tasks.new(decorated_sqrt, "sqrt1", x=Float(-1))
+    wg.tasks.new(decorated_sqrt, "sqrt2", x=sqrt1.outputs["result"])
     wg.submit(wait=True)
     # print("results: ", results[])
     assert wg.process.exit_status == 302
+    assert (
+        wg.process.exit_message
+        == "WorkGraph finished, but tasks: ['sqrt1'] failed. Thus all their child tasks are skipped."
+    )


### PR DESCRIPTION
When a task is failed, set the state of all its child tasks to `SKIPPED`.