### PR TITLE
Set the nodes during/after the creation of the task.

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -300,10 +300,11 @@ def build_shell_task(
     nodes = {} if nodes is None else nodes
     keys = list(nodes.keys())
     for key in keys:
+        inputs.append(["General", f"nodes.{key}"])
+        # input is a output of another task, we make a link
         if isinstance(nodes[key], NodeSocket):
-            inputs.append(["General", f"nodes.{key}"])
             links[f"nodes.{key}"] = nodes[key]
-            # not it read input from link, so need to remove the key from the nodes
+            # Output socket itself is not a value, so we remove the key from the nodes
             nodes.pop(key)
     for input in inputs:
         if input not in tdata["inputs"]:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -40,6 +40,30 @@ def test_shell_code():
     assert job1.node.outputs.stdout.get_content() == "string astring b"
 
 
+def test_shell_set():
+    """Set the nodes during/after the creation of the task."""
+    wg = WorkGraph(name="test_shell_set")
+    echo_task = wg.tasks.new(
+        "ShellTask",
+        name="echo",
+        command="cp",
+        arguments=["{file}", "copied_file"],
+        nodes={"file": SinglefileData.from_string("1 5 1")},
+        outputs=["copied_file"],
+    )
+
+    cat_task = wg.tasks.new(
+        "ShellTask",
+        name="cat",
+        command="cat",
+        arguments=["{input}"],
+        nodes={"input": None},
+    )
+    wg.links.new(echo_task.outputs["copied_file"], cat_task.inputs["nodes.input"])
+    wg.submit(wait=True)
+    assert cat_task.outputs["stdout"].value.get_content() == "1 5 1"
+
+
 def test_shell_workflow():
     from aiida_workgraph import WorkGraph
     from aiida.orm import Int


### PR DESCRIPTION
In the `ShellJob`, the nodes port is a namespace, thus dynamic. When the user specifies the `nodes` as a dict, No matter the value of the item is a AiiDA data, `None`, or an output socket from another node, we create an input socket for it. Thus, users can pass data/link to this socket later.
 