### PR TITLE
Use dictionary for the inputs and outputs of the decorator parameters

### DIFF
--- a/aiida_workgraph/collection.py
+++ b/aiida_workgraph/collection.py
@@ -18,8 +18,8 @@ class TaskCollection(NodeCollection):
     ) -> Any:
         from aiida_workgraph.decorator import (
             build_task_from_callable,
-            build_python_task,
-            build_shell_task,
+            build_pythonjob_task,
+            build_shelljob_task,
         )
 
         # build the task on the fly if the identifier is a callable
@@ -31,13 +31,13 @@ class TaskCollection(NodeCollection):
                         "GraphBuilder task cannot be run remotely. Please set run_remotely=False."
                     )
                 # this is a PythonJob
-                identifier, _ = build_python_task(identifier)
+                identifier, _ = build_pythonjob_task(identifier)
             return super().new(identifier, name, uuid, **kwargs)
         if isinstance(identifier, str) and identifier.upper() == "PythonJob":
-            identifier, _ = build_python_task(kwargs.pop("function"))
+            identifier, _ = build_pythonjob_task(kwargs.pop("function"))
             return super().new(identifier, name, uuid, **kwargs)
         if isinstance(identifier, str) and identifier.upper() == "SHELLJOB":
-            identifier, _, links = build_shell_task(
+            identifier, _, links = build_shelljob_task(
                 nodes=kwargs.get("nodes", {}),
                 outputs=kwargs.get("outputs", None),
                 parser_outputs=kwargs.pop("parser_outputs", None),

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -386,7 +386,7 @@ def build_task_from_workgraph(wg: any) -> Task:
             group_outputs.append(
                 [f"{task.name}.{socket.name}", f"{task.name}.{socket.name}"]
             )
-    kwargs = [input[1] for input in inputs]
+    kwargs = [input["name"] for input in inputs]
     # add built-in sockets
     outputs.append({"identifier": "General", "name": "_outputs"})
     outputs.append({"identifier": "General", "name": "_wait"})

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -86,7 +86,7 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
     function_source_code = (
         task["executor"]["import_statements"]
         + "\n"
-        + task["executor"]["function_source_code"]
+        + task["executor"]["function_source_code_without_decorator"]
     )
     # outputs
     output_name_list = [output["name"] for output in task["outputs"]]

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -608,7 +608,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 task_to_run.append(name)
         #
         self.report("tasks ready to run: {}".format(",".join(task_to_run)))
-        self.run_taskss(task_to_run)
+        self.run_tasks(task_to_run)
 
     def update_task_state(self, name: str) -> None:
         """Update task state if task is a Awaitable."""
@@ -680,7 +680,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
             task_name, socket_name = c.split(".")
             if "task_name" != "context":
                 condition_tasks.append(task_name)
-        self.run_taskss(condition_tasks, continue_workgraph=False)
+        self.run_tasks(condition_tasks, continue_workgraph=False)
         conditions = []
         for c in self.ctx.workgraph["conditions"]:
             task_name, socket_name = c.split(".")
@@ -698,7 +698,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
     def check_for_conditions(self) -> bool:
         print("Is a for workgraph")
         condition_tasks = [c[0] for c in self.ctx.workgraph["conditions"]]
-        self.run_taskss(condition_tasks)
+        self.run_tasks(condition_tasks)
         conditions = [self.ctx._count < len(self.ctx.sequence)] + [
             self.ctx.tasks[c[0]]["results"][c[1]]
             for c in self.ctx.workgraph["conditions"]
@@ -712,7 +712,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.ctx._count += 1
         return should_run
 
-    def run_taskss(self, names: t.List[str], continue_workgraph: bool = True) -> None:
+    def run_tasks(self, names: t.List[str], continue_workgraph: bool = True) -> None:
         """Run task
         Here we use ToContext to pass the results of the run to the next step.
         This will force the engine to wait for all the submitted processes to
@@ -889,7 +889,9 @@ class WorkGraphEngine(Process, metaclass=Protect):
                     self.set_task_state_info(name, "state", "CREATED")
                     process = process.node
                 else:
+                    print("inputs: ", inputs)
                     process = self.submit(PythonJob, **inputs)
+                    print("process: ", process)
                     self.set_task_state_info(name, "state", "RUNNING")
                 process.label = name
                 self.set_task_state_info(task["name"], "process", process)

--- a/aiida_workgraph/executors/qe.py
+++ b/aiida_workgraph/executors/qe.py
@@ -4,8 +4,11 @@ from aiida.orm import StructureData, UpfData
 
 
 @task(
-    inputs=[["String", "pseudo_family"], [StructureData, "structure"]],
-    outputs=[[UpfData, "Pseudo"]],
+    inputs=[
+        {"identifier": "String", "name": "pseudo_family"},
+        {"identifier": StructureData, "name": "structure"},
+    ],
+    outputs=[{"identifier": UpfData, "name": "Pseudo"}],
 )
 def get_pseudo_from_structure(
     pseudo_family: str, structure: StructureData

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -454,3 +454,84 @@ def recursive_to_dict(attr_dict):
         return {k: recursive_to_dict(v) for k, v in attr_dict.items()}
     else:
         return attr_dict
+
+
+def get_required_imports(func):
+    """Retrieve type hints and the corresponding module"""
+    from typing import get_type_hints, _SpecialForm
+
+    type_hints = get_type_hints(func)
+    imports = {}
+
+    def add_imports(type_hint):
+        if isinstance(
+            type_hint, _SpecialForm
+        ):  # Handle special forms like Any, Union, Optional
+            module_name = "typing"
+            type_name = type_hint._name or str(type_hint)
+        elif hasattr(
+            type_hint, "__origin__"
+        ):  # This checks for higher-order types like List, Dict
+            module_name = type_hint.__module__
+            type_name = type_hint._name
+            for arg in type_hint.__args__:
+                if arg is type(None):  # noqa: E721
+                    continue
+                add_imports(arg)  # Recursively add imports for each argument
+        elif hasattr(type_hint, "__module__"):
+            module_name = type_hint.__module__
+            type_name = type_hint.__name__
+        else:
+            return  # If no module or origin, we can't import it, e.g., for literals
+
+        if module_name not in imports:
+            imports[module_name] = set()
+        if type_name is not None:
+            imports[module_name].add(type_name)
+
+    for _, type_hint in type_hints.items():
+        add_imports(type_hint)
+
+    return imports
+
+
+def serialize_function(func: Callable) -> Dict[str, Any]:
+    """Serialize a function for storage or transmission."""
+    import inspect
+    import textwrap
+    import cloudpickle as pickle
+
+    # we need save the source code explicitly, because in the case of jupyter notebook,
+    # the source code is not saved in the pickle file
+    source_code = inspect.getsource(func)
+    # Split the source into lines for processing
+    source_code_lines = source_code.split("\n")
+    function_source_code = "\n".join(source_code_lines)
+    # Find the first line of the actual function definition
+    for i, line in enumerate(source_code_lines):
+        if line.strip().startswith("def "):
+            break
+    function_source_code_without_decorator = "\n".join(source_code_lines[i:])
+    function_source_code_without_decorator = textwrap.dedent(
+        function_source_code_without_decorator
+    )
+    # we also need to include the necessary imports for the types used in the type hints.
+    try:
+        required_imports = get_required_imports(func)
+    except Exception as e:
+        required_imports = {}
+        print(f"Failed to get required imports for function {func.__name__}: {e}")
+    # Generate import statements
+    import_statements = "\n".join(
+        f"from {module} import {', '.join(types)}"
+        for module, types in required_imports.items()
+    )
+    return {
+        "executor": pickle.dumps(func),
+        "type": "function",
+        "is_pickle": True,
+        "function_name": func.__name__,
+        "function_source_code": function_source_code,
+        "function_source_code_without_decorator": function_source_code_without_decorator,
+        "import_statements": import_statements,
+    }

--- a/docs/source/concept/socket.ipynb
+++ b/docs/source/concept/socket.ipynb
@@ -106,8 +106,9 @@
    "source": [
     "from aiida_workgraph import task\n",
     "\n",
-    "@task(outputs=[[\"General\", \"sum\"],\n",
-    "               [\"General\", \"difference\"]])\n",
+    "@task(outputs=[{\"identifier\": \"General\", \"name\": \"sum\"},\n",
+    "               {\"identifier\": \"General\", \"name\": \"diff\"},\n",
+    "               ])\n",
     "def add_minus(x, y):\n",
     "   return {\"sum\": x + y, \"difference\": x - y}\n",
     "\n",
@@ -121,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Two values are needed to define a port, e.g., `[\"General\", \"sum\"]`, where the first value `General` indicates the data type, and the second value is the name of the port. We use `General` for any data type.\n",
+    "Two values are needed to define a port, e.g., `{\"identifier\": \"General\", \"name\": \"sum\"}`, where the `identifier` indicates the data type, and the name of the port. We use `General` for any data type.\n",
     "\n",
     "## Assign socket type based on typing hints\n",
     "The type hints in the function signature can be used to assign the socket type. The following table shows the mapping between the type hints and the socket type.\n",
@@ -249,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.1.-1"
   }
  },
  "nbformat": 4,

--- a/docs/source/concept/task.ipynb
+++ b/docs/source/concept/task.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "source": [
     "If you want to change the name of the output ports, or if there are more than one output. You can define the outputs explicitly.\n",
-    "For example: `[\"General\", \"sum\"]`, where the first value `General` indicates the data type, and the second value is the name of the port. The data type tell the code how to display the port in the GUI, validate the data, and serialize data into database. We use `General` for any data type. For the moment, the data validation is experimentally supported, and the GUI display is not implemented. Thus, I suggest you to always `General` for the port."
+    "For example: `{\"identifier\": \"General\", \"name\": \"sum\"}`, where the `identifier` indicates the data type. The data type tell the code how to display the port in the GUI, validate the data, and serialize data into database. We use `General` for any data type. For the moment, the data validation is experimentally supported, and the GUI display is not implemented. Thus, I suggest you to always `General` for the port."
    ]
   },
   {
@@ -112,8 +112,9 @@
    ],
    "source": [
     "# define add calcfunction task\n",
-    "@task(outputs=[[\"General\", \"sum\"],\n",
-    "               [\"General\", \"difference\"]])\n",
+    "@task(outputs=[{\"identifier\": \"General\", \"name\": \"sum\"},\n",
+    "               {\"identifier\": \"General\", \"name\": \"diff\"},\n",
+    "               ])\n",
     "def add_minus(x, y):\n",
     "   return {\"sum\": x + y, \"difference\": x - y}\n",
     "\n",
@@ -207,7 +208,7 @@
     "The inputs and outputs of the task are automatically generated. One can also define the outputs explicitly.\n",
     "\n",
     "```python\n",
-    "NormTask = build_task(norm, outputs=[[\"General\", \"norm\"]])\n",
+    "NormTask = build_task(norm, outputs=[{\"identifier\": \"General\", \"name\": \"norm\"}])\n",
     "```"
    ]
   },
@@ -350,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.1.-1"
   }
  },
  "nbformat": 4,

--- a/tests/test_build_task.py
+++ b/tests/test_build_task.py
@@ -50,7 +50,11 @@ def test_calcfunction():
     assert issubclass(AddTask, Task)
     # define outputs explicitly
     AddTask = build_task(
-        add_minus, outputs=[["General", "sum"], ["General", "difference"]]
+        add_minus,
+        outputs=[
+            {"identifier": "General", "name": "sum"},
+            {"identifier": "General", "name": "difference"},
+        ],
     )
     assert issubclass(AddTask, Task)
     assert "sum" in AddTask().outputs.keys()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -75,7 +75,12 @@ def test_PythonJob_typing():
 def test_PythonJob_outputs():
     """Test function with multiple outputs."""
 
-    @task(outputs=[["General", "sum"], ["General", "diff"]])
+    @task(
+        outputs=[
+            {"identifier": "General", "name": "sum"},
+            {"identifier": "General", "name": "diff"},
+        ]
+    )
     def add(x, y):
         return {"sum": x + y, "diff": x - y}
 
@@ -89,7 +94,8 @@ def test_PythonJob_outputs():
         #  code=code,
         computer="localhost",
     )
-    wg.submit(wait=True)
+    # wg.submit(wait=True)
+    wg.run()
     assert wg.tasks["add"].outputs["sum"].value.value == 3
     assert wg.tasks["add"].outputs["diff"].value.value == -1
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -96,7 +96,7 @@ def test_shell_workflow():
         nodes={"expression": job1.outputs["stdout"]},
         parser=PickledData(parser),
         parser_outputs=[
-            ["General", "result"]
+            {"identifier": "General", "name": "result"}
         ],  # add a "result" output socket from the parser
     )
     # echo result + y expression
@@ -116,7 +116,7 @@ def test_shell_workflow():
         nodes={"expression": job3.outputs["stdout"]},
         parser=PickledData(parser),
         parser_outputs=[
-            ["General", "result"]
+            {"identifier": "General", "name": "result"}
         ],  # add a "result" output socket from the parser
     )
     # there is a bug in aiida-shell, the following line will raise an error

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -9,7 +9,7 @@ def test_socket(decorated_multiply) -> None:
     from aiida_workgraph import task
 
     @task(
-        outputs=[[float, "result"]],
+        outputs=[{"identifier": float, "name": "result"}],
     )
     def add(x: int, y: float):
         result = x + y
@@ -38,7 +38,7 @@ def test_AiiDA_socket():
     from aiida import orm
 
     @task.calcfunction(
-        outputs=[[orm.Float, "result"]],
+        outputs=[{"identifier": orm.Float, "name": "result"}],
     )
     def add(x: int, y: float):
         result = x + y


### PR DESCRIPTION
Fix #114 .
Using a dictionary with keys and values is more clear to the user. Besides, we can pass more stuff.

```python
@task(outputs=[{"name": "sum"}, {"name": "difference", "identifier": "General"}])
```