### PR TITLE
add error handler

### DIFF
--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -54,6 +54,7 @@ class WorkGraph(node_graph.NodeGraph):
         self.nodes.post_creation_hooks = [task_creation_hook]
         self.links.post_creation_hooks = [link_creation_hook]
         self.links.post_deletion_hooks = [link_deletion_hook]
+        self.error_handlers = []
         self._widget = NodeGraphWidget(parent=self)
 
     @property
@@ -173,6 +174,8 @@ class WorkGraph(node_graph.NodeGraph):
         saver.save()
 
     def to_dict(self) -> Dict[str, Any]:
+        import cloudpickle as pickle
+
         wgdata = super().to_dict()
         self.context["sequence"] = self.sequence
         # only alphanumeric and underscores are allowed
@@ -188,6 +191,7 @@ class WorkGraph(node_graph.NodeGraph):
                 "max_number_jobs": self.max_number_jobs,
             }
         )
+        wgdata["error_handlers"] = pickle.dumps(self.error_handlers)
         wgdata["tasks"] = wgdata.pop("nodes")
 
         return wgdata

--- a/docs/source/howto/error_resistant.ipynb
+++ b/docs/source/howto/error_resistant.ipynb
@@ -1,0 +1,311 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "22d177dc-6cfb-4de2-9509-f1eb45e10cf2",
+   "metadata": {},
+   "source": [
+    "# How to write error-resistant workflows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58696c91",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "In this tutorial, we will show how to implement the error handling in a WorkGraph.\n",
+    "\n",
+    "\n",
+    "Load the AiiDA profile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c6b83fb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The aiida extension is already loaded. To reload it, use:\n",
+      "  %reload_ext aiida\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Profile<uuid='57ccbf7d9e2b41b39edb2bfdaf725feb' name='default'>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%load_ext aiida\n",
+    "from aiida import load_profile\n",
+    "load_profile()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4270e3e3",
+   "metadata": {},
+   "source": [
+    "## Normal WorkGraph\n",
+    "We will show how to implement the error handlers for the `ArithmeticAddCalculation`. We start by creating a normal WorkGraph:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f4db68af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 77278\n",
+      "Task finished OK?  True\n",
+      "Exit code:  None\n",
+      "Exit Message:  None\n"
+     ]
+    }
+   ],
+   "source": [
+    "from aiida_workgraph import WorkGraph\n",
+    "from aiida import orm\n",
+    "from aiida.calculations.arithmetic.add import ArithmeticAddCalculation\n",
+    "\n",
+    "\n",
+    "wg = WorkGraph(\"normal_graph\")\n",
+    "wg.tasks.new(ArithmeticAddCalculation, name=\"add1\")\n",
+    "\n",
+    "#------------------------- Submit the calculation -------------------\n",
+    "code = orm.load_code(\"add@localhost\")\n",
+    "wg.submit(inputs={\"add1\": {\"code\": code,\n",
+    "                            \"x\": orm.Int(1),\n",
+    "                           \"y\": orm.Int(2)\n",
+    "                           }},\n",
+    "          wait=True)\n",
+    "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
+    "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e322ccf",
+   "metadata": {},
+   "source": [
+    "## Error code\n",
+    "\n",
+    "If the computed sum of the inputs x and y is negative, the `ArithmeticAddCalculation` fails with exit code 410. Let's reset the WorkGraph and modify the inputs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f0a84499",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 77286\n",
+      "Task finished OK?  False\n",
+      "Exit code:  ExitCode(status=410, message='The sum of the operands is a negative number.', invalidates_cache=False)\n",
+      "Exit Message:  The sum of the operands is a negative number.\n"
+     ]
+    }
+   ],
+   "source": [
+    "wg.reset()\n",
+    "wg.submit(inputs={\"add1\": {\"code\": code,\n",
+    "                            \"x\": orm.Int(1),\n",
+    "                           \"y\": orm.Int(-2)\n",
+    "                           }},\n",
+    "          wait=True)\n",
+    "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
+    "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ae5d5dd",
+   "metadata": {},
+   "source": [
+    "## Error handling\n",
+    "\n",
+    "To “register” a error handler for a WorkGraph, you simply define a function that takes the `self` as its single argument and set it as the `error_hanlders` of the WorkGraph:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "70bcb8af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 77293\n",
+      "Task finished OK?  True\n",
+      "Exit code:  None\n",
+      "Exit Message:  None\n"
+     ]
+    }
+   ],
+   "source": [
+    "from aiida_workgraph import WorkGraph\n",
+    "from aiida import orm\n",
+    "from aiida.calculations.arithmetic.add import ArithmeticAddCalculation\n",
+    "\n",
+    "def handle_negative_sum(self):\n",
+    "    \"\"\"Handle negative sum by resetting the task and changing the inputs.\n",
+    "    self is the WorkGraph instance, thus we can access the tasks and the context.\n",
+    "    \"\"\"\n",
+    "    node = self.get_task_state_info(\"add1\", \"process\")\n",
+    "    if node and node.exit_code and node.exit_code.status == 410:\n",
+    "        self.report(f\"Run error handler: handle_negative_sum.\")\n",
+    "        self.reset_task(\"add1\")\n",
+    "        # modify task inputs\n",
+    "        task = self.ctx.tasks[\"add1\"]\n",
+    "        # the actual input values are stored in the properties dictionary\n",
+    "        task[\"properties\"][\"x\"][\"value\"] = orm.Int(abs(-task[\"properties\"][\"x\"][\"value\"]))\n",
+    "        task[\"properties\"][\"y\"][\"value\"] = orm.Int(abs(-task[\"properties\"][\"y\"][\"value\"]))\n",
+    "\n",
+    "wg = WorkGraph(\"normal_graph\")\n",
+    "wg.tasks.new(ArithmeticAddCalculation, name=\"add1\")\n",
+    "# register error handler\n",
+    "wg.error_handlers = [handle_negative_sum]\n",
+    "\n",
+    "#------------------------- Submit the calculation -------------------\n",
+    "wg.submit(inputs={\"add1\": {\"code\": code,\n",
+    "                            \"x\": orm.Int(1),\n",
+    "                           \"y\": orm.Int(-2)\n",
+    "                           },\n",
+    "                },\n",
+    "          wait=True)\n",
+    "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
+    "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f46d277",
+   "metadata": {},
+   "source": [
+    "## Compare to the `BaseRestartWorkChain`\n",
+    "AiiDA provides a `BaseRestartWorkChain` class that can be used to write workflows that can handle known failure modes of processes and calculations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ece10d89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiida.engine import BaseRestartWorkChain\n",
+    "from aiida.plugins import CalculationFactory\n",
+    "from aiida import orm\n",
+    "from aiida.engine import while_\n",
+    "from aiida.engine import process_handler, ProcessHandlerReport\n",
+    "\n",
+    "ArithmeticAddCalculation = CalculationFactory('core.arithmetic.add')\n",
+    "\n",
+    "class ArithmeticAddBaseWorkChain(BaseRestartWorkChain):\n",
+    "\n",
+    "    _process_class = ArithmeticAddCalculation\n",
+    "\n",
+    "\n",
+    "    @classmethod\n",
+    "    def define(cls, spec):\n",
+    "        \"\"\"Define the process specification.\"\"\"\n",
+    "        super().define(spec)\n",
+    "        spec.expose_inputs(ArithmeticAddCalculation, namespace='add')\n",
+    "        spec.expose_outputs(ArithmeticAddCalculation)\n",
+    "        spec.outline(\n",
+    "            cls.setup,\n",
+    "            while_(cls.should_run_process)(\n",
+    "                cls.run_process,\n",
+    "                cls.inspect_process,\n",
+    "            ),\n",
+    "            cls.results,\n",
+    "        )\n",
+    "\n",
+    "    def setup(self):\n",
+    "        \"\"\"Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.\n",
+    "\n",
+    "        This `self.ctx.inputs` dictionary will be used by the `BaseRestartWorkChain` to submit the process in the\n",
+    "        internal loop.\n",
+    "        \"\"\"\n",
+    "        super().setup()\n",
+    "        self.ctx.inputs = self.exposed_inputs(ArithmeticAddCalculation, 'add')\n",
+    "    \n",
+    "    @process_handler\n",
+    "    def handle_negative_sum(self, node):\n",
+    "        \"\"\"Check if the calculation failed with `ERROR_NEGATIVE_NUMBER`.\n",
+    "\n",
+    "        If this is the case, simply make the inputs positive by taking the absolute value.\n",
+    "\n",
+    "        :param node: the node of the subprocess that was ran in the current iteration.\n",
+    "        :return: optional :class:`~aiida.engine.processes.workchains.utils.ProcessHandlerReport` instance to signal\n",
+    "            that a problem was detected and potentially handled.\n",
+    "        \"\"\"\n",
+    "        if node.exit_status == ArithmeticAddCalculation.exit_codes.ERROR_NEGATIVE_NUMBER.status:\n",
+    "            self.ctx.inputs['x'] = orm.Int(abs(node.inputs.x.value))\n",
+    "            self.ctx.inputs['y'] = orm.Int(abs(node.inputs.y.value))\n",
+    "            return ProcessHandlerReport()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b530d443",
+   "metadata": {},
+   "source": [
+    "In the `BaseRestartWorkChain`, the error handling is implemented for a specific Calculation class. While, the error handling in a WorkGraph is more general and can be applied to any task in the WorkGraph.\n",
+    "\n",
+    "## Summary\n",
+    "Here we have shown how to implement error handling in a WorkGraph."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('scinode')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "2f450c1ff08798c4974437dd057310afef0de414c25d1fd960ad375311c3f6ff"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/howto/error_resistant.ipynb
+++ b/docs/source/howto/error_resistant.ipynb
@@ -22,25 +22,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "id": "c6b83fb5",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The aiida extension is already loaded. To reload it, use:\n",
-      "  %reload_ext aiida\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "Profile<uuid='57ccbf7d9e2b41b39edb2bfdaf725feb' name='default'>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -62,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "id": "f4db68af",
    "metadata": {},
    "outputs": [
@@ -70,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77278\n",
+      "WorkGraph process created, PK: 77323\n",
       "Task finished OK?  True\n",
       "Exit code:  None\n",
       "Exit Message:  None\n"
@@ -95,8 +87,7 @@
     "          wait=True)\n",
     "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
     "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
-    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n",
-    "\n"
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n"
    ]
   },
   {
@@ -111,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "id": "f0a84499",
    "metadata": {},
    "outputs": [
@@ -119,7 +110,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77286\n",
+      "WorkGraph process created, PK: 77331\n",
       "Task finished OK?  False\n",
       "Exit code:  ExitCode(status=410, message='The sum of the operands is a negative number.', invalidates_cache=False)\n",
       "Exit Message:  The sum of the operands is a negative number.\n"
@@ -135,7 +126,34 @@
     "          wait=True)\n",
     "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
     "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
-    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n"
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "580f5781",
+   "metadata": {},
+   "source": [
+    "We can confirm that the task fails by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "527ef91e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[22mWorkGraph<normal_graph><77331> Finished [302]\n",
+      "    └── ArithmeticAddCalculation<77332> Finished [410]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%verdi process status 77331"
    ]
   },
   {
@@ -150,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "id": "70bcb8af",
    "metadata": {},
    "outputs": [
@@ -158,7 +176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77293\n",
+      "WorkGraph process created, PK: 77338\n",
       "Task finished OK?  True\n",
       "Exit code:  None\n",
       "Exit Message:  None\n"
@@ -199,6 +217,34 @@
     "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
     "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
     "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42f8110",
+   "metadata": {},
+   "source": [
+    "We can confirm that the task first fails again with a 410. Then the WorkGraph restarts the task with the new inputs, and it finishes successfully. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1fe4a1a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[22mWorkGraph<normal_graph><77338> Finished [0]\n",
+      "    ├── ArithmeticAddCalculation<77339> Finished [410]\n",
+      "    └── ArithmeticAddCalculation<77345> Finished [0]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%verdi process status 77338"
    ]
   },
   {

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -17,6 +17,7 @@ This section contains a collection of HowTos for various topics.
    wait
    combine_workgraph
    restart
+   error_resistant
    continue_finished_workgraph
    protocol
    queue

--- a/docs/source/howto/restart.ipynb
+++ b/docs/source/howto/restart.ipynb
@@ -162,10 +162,12 @@
    "source": [
     "from aiida_workgraph import WorkGraph\n",
     "wg2 = WorkGraph.load(wg.pk)\n",
+    "# restart the workflow, this will create a new process\n",
+    "wg2.restart()\n",
     "wg2.name = \"restart_workflow\"\n",
     "wg2.tasks[\"add2\"].set({\"y\": Int(10).store()})\n",
     "# use the `restart` flag to restart the workflow\n",
-    "wg2.submit(wait=True, restart=True)"
+    "wg2.submit(wait=True)"
    ]
   },
   {

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,43 @@
+from aiida_workgraph import WorkGraph
+from aiida import load_profile, orm
+from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+
+load_profile()
+
+code = orm.load_code("add@localhost")
+
+
+def test_error_handlers():
+    """Test error handlers."""
+    from aiida.cmdline.utils.common import get_workchain_report
+
+    def handle_negative_sum(self):
+        """Handle negative sum by resetting the task and changing the inputs.
+        self is the WorkGraph instance, thus we can access the tasks and the context.
+        """
+        node = self.get_task_state_info("add1", "process")
+        if node and node.exit_code and node.exit_code.status == 410:
+            self.report("Run error handler: handle_negative_sum.")
+            self.reset_task("add1")
+            # modify task inputs
+            task = self.ctx.tasks["add1"]
+            # the actual input values are stored in the properties dictionary
+            task["properties"]["x"]["value"] = orm.Int(
+                abs(-task["properties"]["x"]["value"])
+            )
+            task["properties"]["y"]["value"] = orm.Int(
+                abs(-task["properties"]["y"]["value"])
+            )
+
+    wg = WorkGraph("restart_graph")
+    wg.tasks.new(ArithmeticAddCalculation, name="add1")
+    wg.error_handlers = [handle_negative_sum]
+    wg.submit(
+        inputs={
+            "add1": {"code": code, "x": orm.Int(1), "y": orm.Int(-2)},
+        },
+        wait=True,
+    )
+    report = get_workchain_report(wg.process, "REPORT")
+    assert "Run error handler: handle_negative_sum." in report
+    assert wg.tasks["add1"].outputs["sum"].value == 3


### PR DESCRIPTION
## Error handling

To “register” a error handler for a WorkGraph, you simply define a function that takes the `self` as its single argument and set it as the `error_hanlders` of the WorkGraph:

```python

def handle_negative_sum(self):
    """Handle negative sum by resetting the task and changing the inputs.
    self is the WorkGraph instance, thus we can access the tasks and the context.
    """
    node = self.get_task_state_info("add1", "process")
    if node and node.exit_code and node.exit_code.status == 410:
        self.report(f"Run error handler: handle_negative_sum.")
        self.reset_task("add1")
        # modify task inputs
        task = self.ctx.tasks["add1"]
        # the actual input values are stored in the properties dictionary
        task["properties"]["x"]["value"] = orm.Int(abs(-task["properties"]["x"]["value"]))
        task["properties"]["y"]["value"] = orm.Int(abs(-task["properties"]["y"]["value"]))

wg = WorkGraph("normal_graph")
wg.tasks.new(ArithmeticAddCalculation, name="add1")
# register error handler
wg.error_handlers = [handle_negative_sum]
```

