### PR TITLE
support max_retries and load error_handlers back

### DIFF
--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -303,12 +303,17 @@ class WorkGraph(node_graph.NodeGraph):
         if "tasks" in wgdata:
             wgdata["nodes"] = wgdata.pop("tasks")
         wg = super().from_dict(wgdata)
-        wg.max_iteration = wgdata["max_iteration"]
-        wg.execution_count = wgdata["execution_count"]
-        wg.workgraph_type = wgdata["workgraph_type"]
-        wg.conditions = wgdata["conditions"]
-        wg.max_number_jobs = wgdata["max_number_jobs"]
-        wg.error_handlers = pickle.loads(wgdata["error_handlers"])
+        for key in [
+            "max_iteration",
+            "execution_count",
+            "workgraph_type",
+            "conditions",
+            "max_number_jobs",
+        ]:
+            if key in wgdata:
+                setattr(wg, key, wgdata[key])
+        if "error_handlers" in wgdata:
+            wg.error_handlers = pickle.loads(wgdata["error_handlers"])
         return wg
 
     @classmethod

--- a/docs/source/howto/error_resistant.ipynb
+++ b/docs/source/howto/error_resistant.ipynb
@@ -121,7 +121,7 @@
     "wg.reset()\n",
     "wg.submit(inputs={\"add1\": {\"code\": code,\n",
     "                            \"x\": orm.Int(1),\n",
-    "                           \"y\": orm.Int(-2)\n",
+    "                           \"y\": orm.Int(-6)\n",
     "                           }},\n",
     "          wait=True)\n",
     "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
@@ -197,8 +197,8 @@
     "from aiida.calculations.arithmetic.add import ArithmeticAddCalculation\n",
     "\n",
     "def handle_negative_sum(self, task_name: str):\n",
-    "    \"\"\"Handle negative sum by resetting the task and changing the inputs.\n",
-    "    self is the WorkGraph instance, thus we can access the tasks and the context.\n",
+    "    \"\"\"Handle the failure code 410 of the `ArithmeticAddCalculation`.\n",
+    "    Simply make the inputs positive by taking the absolute value.\n",
     "    \"\"\"\n",
     "    self.report(f\"Run error handler: handle_negative_sum.\")\n",
     "    # load the task from the WorkGraph engine\n",
@@ -220,7 +220,7 @@
     "#------------------------- Submit the calculation -------------------\n",
     "wg.submit(inputs={\"add1\": {\"code\": code,\n",
     "                            \"x\": orm.Int(1),\n",
-    "                           \"y\": orm.Int(-2)\n",
+    "                           \"y\": orm.Int(-6)\n",
     "                           },\n",
     "                },\n",
     "          wait=True)\n",
@@ -255,6 +255,171 @@
    ],
    "source": [
     "%verdi process status 78194"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec746bae",
+   "metadata": {},
+   "source": [
+    "## Custom parameters for error handlers\n",
+    "One can also pass custom parameters to the error handler. For example, instead of simply make the inputs positive by taking the absolute value, we add an increment to the inputs. And the `increment` is a custom parameter of the error handler, which the user can specify when attaching the error handler to the WorkGraph, or update it during the execution of the WorkGraph.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9406d4b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 78256\n",
+      "Task finished OK?  True\n",
+      "Exit code:  None\n",
+      "Exit Message:  None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def handle_negative_sum(self, task_name: str, increment: int = 1):\n",
+    "    \"\"\"Handle the failure code 410 of the `ArithmeticAddCalculation`.\n",
+    "    Simply add an increment to the inputs.\n",
+    "    \"\"\"\n",
+    "    self.report(f\"Run error handler: handle_negative_sum.\")\n",
+    "    # load the task from the WorkGraph engine\n",
+    "    task = self.get_task(task_name)\n",
+    "    # modify task inputs\n",
+    "    task.set({\"x\": orm.Int(task.inputs[\"x\"].value + increment),\n",
+    "              \"y\": orm.Int(task.inputs[\"y\"].value + increment)})\n",
+    "    # update the task in the WorkGraph engine\n",
+    "    self.update_task(task)\n",
+    "\n",
+    "\n",
+    "wg = WorkGraph(\"normal_graph\")\n",
+    "wg.tasks.new(ArithmeticAddCalculation, name=\"add1\")\n",
+    "# register error handler\n",
+    "wg.attach_error_handler(handle_negative_sum, name=\"handle_negative_sum\",\n",
+    "                           tasks={\"add1\": {\"exit_codes\": [410],\n",
+    "                                           \"max_retries\": 5,\n",
+    "                                           \"kwargs\": {\"increment\": 1}}\n",
+    "                           })\n",
+    "\n",
+    "#------------------------- Submit the calculation -------------------\n",
+    "wg.submit(inputs={\"add1\": {\"code\": code,\n",
+    "                            \"x\": orm.Int(1),\n",
+    "                           \"y\": orm.Int(-6)\n",
+    "                           },\n",
+    "                },\n",
+    "          wait=True)\n",
+    "print(\"Task finished OK? \", wg.tasks[\"add1\"].process.is_finished_ok)\n",
+    "print(\"Exit code: \", wg.tasks[\"add1\"].process.exit_code)\n",
+    "print(\"Exit Message: \", wg.tasks[\"add1\"].process.exit_message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17fa8052",
+   "metadata": {},
+   "source": [
+    "Since we increase the inputs by a `increment`, so it takes three retries before it finished successfully:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "62934e04",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[22mWorkGraph<normal_graph><78256> Finished [0]\n",
+      "    ├── ArithmeticAddCalculation<78257> Finished [410]\n",
+      "    ├── ArithmeticAddCalculation<78263> Finished [410]\n",
+      "    ├── ArithmeticAddCalculation<78269> Finished [410]\n",
+      "    └── ArithmeticAddCalculation<78275> Finished [0]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%verdi process status 78256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca8067ef",
+   "metadata": {},
+   "source": [
+    "One can increase the `increment` before submiting the WorkGraph:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "08b2eab5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 78302\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<WorkChainNode: uuid: 79bf8f75-d38a-4fae-bb26-1691ccf402b8 (pk: 78302) (aiida_workgraph.engine.workgraph.WorkGraphEngine)>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wg.reset()\n",
+    "wg.error_handlers[\"handle_negative_sum\"][\"tasks\"][\"add1\"][\"kwargs\"][\"increment\"] = 3\n",
+    "wg.submit(inputs={\"add1\": {\"code\": code,\n",
+    "                            \"x\": orm.Int(1),\n",
+    "                           \"y\": orm.Int(-6)\n",
+    "                           },\n",
+    "                },\n",
+    "          wait=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ea3d2bd",
+   "metadata": {},
+   "source": [
+    "In this case, it only needs one retry to finish successfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "f5b9b349",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[22mWorkGraph<normal_graph><78302> Finished [0]\n",
+      "    ├── ArithmeticAddCalculation<78303> Finished [410]\n",
+      "    └── ArithmeticAddCalculation<78309> Finished [0]\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%verdi process status 78302"
    ]
   },
   {
@@ -331,7 +496,7 @@
    "id": "b530d443",
    "metadata": {},
    "source": [
-    "In the `BaseRestartWorkChain`, the error handling is implemented for a specific Calculation class. While, the error handling in a WorkGraph is more general and can be applied to any task in the WorkGraph.\n",
+    "In the `BaseRestartWorkChain`, the error handling is implemented for a specific Calculation class. While, the error handling in a WorkGraph is more general and can be applied to any task in the WorkGraph, with custom parameters.\n",
     "\n",
     "## Summary\n",
     "Here we have shown how to implement error handling in a WorkGraph."

--- a/docs/source/howto/error_resistant.ipynb
+++ b/docs/source/howto/error_resistant.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "c6b83fb5",
    "metadata": {},
    "outputs": [
@@ -32,7 +32,7 @@
        "Profile<uuid='57ccbf7d9e2b41b39edb2bfdaf725feb' name='default'>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "id": "f4db68af",
    "metadata": {},
    "outputs": [
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77323\n",
+      "WorkGraph process created, PK: 78157\n",
       "Task finished OK?  True\n",
       "Exit code:  None\n",
       "Exit Message:  None\n"
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "f0a84499",
    "metadata": {},
    "outputs": [
@@ -110,7 +110,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77331\n",
+      "WorkGraph process created, PK: 78165\n",
       "Task finished OK?  False\n",
       "Exit code:  ExitCode(status=410, message='The sum of the operands is a negative number.', invalidates_cache=False)\n",
       "Exit Message:  The sum of the operands is a negative number.\n"
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "527ef91e",
    "metadata": {},
    "outputs": [
@@ -147,13 +147,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[22mWorkGraph<normal_graph><77331> Finished [302]\n",
-      "    └── ArithmeticAddCalculation<77332> Finished [410]\u001b[0m\n"
+      "\u001b[22mWorkGraph<normal_graph><78165> Finished [302]\n",
+      "    └── ArithmeticAddCalculation<78167> Finished [410]\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "%verdi process status 77331"
+    "%verdi process status 78165"
    ]
   },
   {
@@ -163,12 +163,20 @@
    "source": [
     "## Error handling\n",
     "\n",
-    "To “register” a error handler for a WorkGraph, you simply define a function that takes the `self` as its single argument and set it as the `error_hanlders` of the WorkGraph:"
+    "To “register” a error handler for a WorkGraph, you simply define a function that takes the `self` and `task_name` as its arguments, and attach it as the `error_hanlders` of the WorkGraph.\n",
+    "\n",
+    "You can specify the tasks and their exit codes that should trigger the error handler, as well as the maximum number of retries for a task:\n",
+    "\n",
+    "```python\n",
+    "tasks={\"add1\": {\"exit_codes\": [410],\n",
+    "                \"max_retries\": 5}\n",
+    "      }\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "id": "70bcb8af",
    "metadata": {},
    "outputs": [
@@ -176,7 +184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 77338\n",
+      "WorkGraph process created, PK: 78194\n",
       "Task finished OK?  True\n",
       "Exit code:  None\n",
       "Exit Message:  None\n"
@@ -188,24 +196,26 @@
     "from aiida import orm\n",
     "from aiida.calculations.arithmetic.add import ArithmeticAddCalculation\n",
     "\n",
-    "def handle_negative_sum(self):\n",
+    "def handle_negative_sum(self, task_name: str):\n",
     "    \"\"\"Handle negative sum by resetting the task and changing the inputs.\n",
     "    self is the WorkGraph instance, thus we can access the tasks and the context.\n",
     "    \"\"\"\n",
-    "    node = self.get_task_state_info(\"add1\", \"process\")\n",
-    "    if node and node.exit_code and node.exit_code.status == 410:\n",
-    "        self.report(f\"Run error handler: handle_negative_sum.\")\n",
-    "        self.reset_task(\"add1\")\n",
-    "        # modify task inputs\n",
-    "        task = self.ctx.tasks[\"add1\"]\n",
-    "        # the actual input values are stored in the properties dictionary\n",
-    "        task[\"properties\"][\"x\"][\"value\"] = orm.Int(abs(-task[\"properties\"][\"x\"][\"value\"]))\n",
-    "        task[\"properties\"][\"y\"][\"value\"] = orm.Int(abs(-task[\"properties\"][\"y\"][\"value\"]))\n",
+    "    self.report(f\"Run error handler: handle_negative_sum.\")\n",
+    "    # load the task from the WorkGraph engine\n",
+    "    task = self.get_task(task_name)\n",
+    "    # modify task inputs\n",
+    "    task.set({\"x\": orm.Int(abs(task.inputs[\"x\"].value)),\n",
+    "              \"y\": orm.Int(abs(task.inputs[\"y\"].value))})\n",
+    "    # update the task in the WorkGraph engine\n",
+    "    self.update_task(task)\n",
     "\n",
     "wg = WorkGraph(\"normal_graph\")\n",
     "wg.tasks.new(ArithmeticAddCalculation, name=\"add1\")\n",
     "# register error handler\n",
-    "wg.error_handlers = [handle_negative_sum]\n",
+    "wg.attach_error_handler(handle_negative_sum, name=\"handle_negative_sum\",\n",
+    "                           tasks={\"add1\": {\"exit_codes\": [410],\n",
+    "                                           \"max_retries\": 5}\n",
+    "                           })\n",
     "\n",
     "#------------------------- Submit the calculation -------------------\n",
     "wg.submit(inputs={\"add1\": {\"code\": code,\n",
@@ -229,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "id": "1fe4a1a9",
    "metadata": {},
    "outputs": [
@@ -237,14 +247,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[22mWorkGraph<normal_graph><77338> Finished [0]\n",
-      "    ├── ArithmeticAddCalculation<77339> Finished [410]\n",
-      "    └── ArithmeticAddCalculation<77345> Finished [0]\u001b[0m\n"
+      "\u001b[22mWorkGraph<normal_graph><78194> Finished [0]\n",
+      "    ├── ArithmeticAddCalculation<78195> Finished [410]\n",
+      "    └── ArithmeticAddCalculation<78201> Finished [0]\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "%verdi process status 77338"
+    "%verdi process status 78194"
    ]
   },
   {


### PR DESCRIPTION
You can specify the tasks and their exit codes that should trigger the error handler, as well as the maximum number of retries for a task.
One can also pass custom parameters to the error handler.

```python
# register error handler
wg.attach_error_handler(handle_negative_sum, name="handle_negative_sum",
                           tasks={"add1": {"exit_codes": [410],
                                           "max_retries": 5,
                                           "kwargs": {"increment": 1}}
                           })
```