### PR TITLE
speed up loading workgraph in web

### DIFF
--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -466,14 +466,22 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Get task state info from base.extras."""
         from aiida.orm.utils.serialize import deserialize_unsafe
 
-        value = deserialize_unsafe(self.node.base.extras.get(f"_task_{key}_{name}", ""))
+        if key == "process":
+            value = deserialize_unsafe(
+                self.node.base.extras.get(f"_task_{key}_{name}", "")
+            )
+        else:
+            value = self.node.base.extras.get(f"_task_{key}_{name}", "")
         return value
 
     def set_task_state_info(self, name: str, key: str, value: any) -> None:
         """Set task state info to base.extras."""
         from aiida.orm.utils.serialize import serialize
 
-        self.node.base.extras.set(f"_task_{key}_{name}", serialize(value))
+        if key == "process":
+            self.node.base.extras.set(f"_task_{key}_{name}", serialize(value))
+        else:
+            self.node.base.extras.set(f"_task_{key}_{name}", value)
 
     def init_ctx(self, wgdata: t.Dict[str, t.Any]) -> None:
         """Init the context from the workgraph data."""

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -439,7 +439,10 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Read workgraph data from base.extras."""
         from aiida.orm.utils.serialize import deserialize_unsafe
 
-        wgdata = deserialize_unsafe(self.node.base.extras.get("_workgraph"))
+        wgdata = self.node.base.extras.get("_workgraph")
+        for name, task in wgdata["tasks"].items():
+            wgdata["tasks"][name] = deserialize_unsafe(task)
+        wgdata["error_handlers"] = deserialize_unsafe(wgdata["error_handlers"])
         return wgdata
 
     def update_workgraph_from_base(self) -> None:

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -110,6 +110,8 @@ class WorkGraphSaver:
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():
             self.wgdata["tasks"][name] = serialize(task)
+        # nodes is a copy of tasks, so we need to pop it out
+        self.wgdata.pop("nodes")
         self.wgdata["error_handlers"] = serialize(self.wgdata["error_handlers"])
         self.process.base.extras.set("_workgraph", self.wgdata)
 
@@ -168,7 +170,11 @@ class WorkGraphSaver:
         if wgdata is None:
             print("No workgraph data found in the process node.")
             return
-        wgdata = deserialize_unsafe(wgdata)
+        for name, task in wgdata["tasks"].items():
+            wgdata["tasks"][name] = deserialize_unsafe(task)
+        # also make a alias for nodes
+        wgdata["nodes"] = wgdata["tasks"]
+        wgdata["error_handlers"] = deserialize_unsafe(wgdata["error_handlers"])
         return wgdata
 
     def check_diff(

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -121,9 +121,9 @@ class WorkGraphSaver:
         task_processes = {}
         task_actions = {}
         for name, task in self.wgdata["tasks"].items():
-            task_states[f"_task_state_{name}"] = serialize(task["state"])
+            task_states[f"_task_state_{name}"] = task["state"]
             task_processes[f"_task_process_{name}"] = serialize(task["process"])
-            task_actions[f"_task_action_{name}"] = serialize(task["action"])
+            task_actions[f"_task_action_{name}"] = task["action"]
         self.process.base.extras.set_many(task_states)
         self.process.base.extras.set_many(task_processes)
         self.process.base.extras.set_many(task_actions)

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, Tuple, List
-import datetime
+
+# import datetime
 from aiida.orm import ProcessNode
 
 
@@ -99,12 +100,18 @@ class WorkGraphSaver:
         - all tasks
         """
         from aiida.orm.utils.serialize import serialize
+        from aiida_workgraph.utils import workgraph_to_short_json
 
         # pprint(self.wgdata)
-        self.wgdata["created"] = datetime.datetime.utcnow()
-        self.wgdata["lastUpdate"] = datetime.datetime.utcnow()
-        self.process.base.extras.set("_workgraph", serialize(self.wgdata))
+        # self.wgdata["created"] = datetime.datetime.utcnow()
+        # self.wgdata["lastUpdate"] = datetime.datetime.utcnow()
+        short_wgdata = workgraph_to_short_json(self.wgdata)
+        self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
+        for name, task in self.wgdata["tasks"].items():
+            self.wgdata["tasks"][name] = serialize(task)
+        self.wgdata["error_handlers"] = serialize(self.wgdata["error_handlers"])
+        self.process.base.extras.set("_workgraph", self.wgdata)
 
     def save_task_states(self) -> Dict:
         """Get task states."""

--- a/aiida_workgraph/utils/control.py
+++ b/aiida_workgraph/utils/control.py
@@ -21,7 +21,10 @@ def get_task_state_info(node, name: str, key: str) -> str:
     """Get task state info from base.extras."""
     from aiida.orm.utils.serialize import deserialize_unsafe
 
-    value = deserialize_unsafe(node.base.extras.get(f"_task_{key}_{name}", ""))
+    if key == "process":
+        value = deserialize_unsafe(node.base.extras.get(f"_task_{key}_{name}", ""))
+    else:
+        value = node.base.extras.get(f"_task_{key}_{name}", "")
     return value
 
 
@@ -29,7 +32,10 @@ def set_task_state_info(node, name: str, key: str, value: any) -> None:
     """Set task state info to base.extras."""
     from aiida.orm.utils.serialize import serialize
 
-    node.base.extras.set(f"_task_{key}_{name}", serialize(value))
+    if key == "process":
+        node.base.extras.set(f"_task_{key}_{name}", serialize(value))
+    else:
+        node.base.extras.set(f"_task_{key}_{name}", value)
 
 
 def pause_tasks(pk: int, tasks: list, timeout: int = 5, wait: bool = False):

--- a/aiida_workgraph/web/backend/app/utils.py
+++ b/aiida_workgraph/web/backend/app/utils.py
@@ -5,46 +5,6 @@ from dateutil import relativedelta
 from dateutil.tz import tzlocal
 
 
-def workgraph_to_short_json(
-    wgdata: Dict[str, Union[str, List, Dict]]
-) -> Dict[str, Union[str, Dict]]:
-    """Export a workgraph to a rete js editor data."""
-    wgdata_short = {
-        "name": wgdata["name"],
-        "uuid": wgdata["uuid"],
-        "state": wgdata["state"],
-        "nodes": {},
-        "links": wgdata["links"],
-    }
-    #
-    for name, task in wgdata["tasks"].items():
-        # Add required inputs to nodes
-        inputs = [
-            input
-            for input in task["inputs"]
-            if input["name"] in task["metadata"]["args"]
-        ]
-        wgdata_short["nodes"][name] = {
-            "label": task["name"],
-            "inputs": inputs,
-            "outputs": [],
-            "position": task["position"],
-        }
-    # Add links to nodes
-    for link in wgdata["links"]:
-        wgdata_short["nodes"][link["to_node"]]["inputs"].append(
-            {
-                "name": link["to_socket"],
-            }
-        )
-        wgdata_short["nodes"][link["from_node"]]["outputs"].append(
-            {
-                "name": link["from_socket"],
-            }
-        )
-    return wgdata_short
-
-
 def get_executor_source(tdata: Any) -> Tuple[bool, Optional[str]]:
     """Get the source code of the executor."""
     import inspect

--- a/aiida_workgraph/web/backend/app/utils.py
+++ b/aiida_workgraph/web/backend/app/utils.py
@@ -87,7 +87,9 @@ def node_to_short_json(workgraph_pk: int, tdata: Dict[str, Any]) -> Dict[str, An
         ],
         "executor": executor,
     }
-    process_info = get_processes_latest(workgraph_pk).get(tdata["name"], {})
+    process_info = get_processes_latest(workgraph_pk, tdata["name"]).get(
+        tdata["name"], {}
+    )
     tdata_short["process"] = process_info
     if process_info is not None:
         tdata_short["metadata"].append(["pk", process_info.get("pk")])

--- a/aiida_workgraph/widget/src/widget/__init__.py
+++ b/aiida_workgraph/widget/src/widget/__init__.py
@@ -30,7 +30,7 @@ class NodeGraphWidget(anywidget.AnyWidget):
         super().__init__(**kwargs)
 
     def from_workgraph(self, workgraph: Any) -> None:
-        from aiida_workgraph.web.backend.app.utils import workgraph_to_short_json
+        from aiida_workgraph.utils import workgraph_to_short_json
 
         wgdata = workgraph.to_dict()
         wait_to_link(wgdata)

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -227,6 +227,9 @@ class WorkGraph(node_graph.NodeGraph):
         """
         # from aiida_workgraph.utils import get_executor
 
+        if self.process is None:
+            return
+
         self.state = self.process.process_state.value.upper()
         outgoing = self.process.base.links.get_outgoing()
         for link in outgoing.all():

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -385,6 +385,8 @@ class WorkGraph(node_graph.NodeGraph):
         """Pause the given tasks."""
         from aiida_workgraph.utils.control import pause_tasks
 
+        self.update()
+
         if self.process is None:
             for name in tasks:
                 self.tasks[name].action = "PAUSE"


### PR DESCRIPTION
- save short workgraph data in base.extras
- serialize each task, instead of whole workgraph
- only query task data for task detail
- don't serialize `state` and `action`, only serialize `process`