### PR TITLE
Make widget feature optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
                 python-version: '3.10'
 
         -   name: Install Python dependencies
-            run: pip install -e .[pre-commit,tests]
+            run: pip install -e .[widget,pre-commit,tests]
 
         -   name: Run pre-commit
             run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
@@ -75,7 +75,7 @@ jobs:
 
         -   name: Install Python dependencies
             run: |
-                pip install -e .[pre-commit,tests]
+                pip install -e .[widget,pre-commit,tests]
                 playwright install
                 pip list
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ verdi node generate pk
 ### Pre-commit and Tests
 To contribute to this repository, please enable pre-commit so the code in commits are conform to the standards.
 ```console
-pip install -e .[tests, pre-commit]
+pip install -e .[tests,pre-commit]
 pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ To install the latest version from source, first clone the repository and then i
 
 ```console
 git clone https://github.com/aiidateam/aiida-workgraph
-pip install -e aiida-workgraph
+cd aiida-workgraph
+pip install -e .
+```
+
+To install the jupyter widget support you need to in addition build the JavaScript packages:
+
+```console
+pip install .[widget]
 # build widget
 cd aiida_workgraph/widget/
 npm install

--- a/aiida_workgraph/__init__.py
+++ b/aiida_workgraph/__init__.py
@@ -1,7 +1,13 @@
+try:
+    import anywidget  # noqa: F401
+
+    USE_WIDGET = True
+except ImportError:
+    USE_WIDGET = False
+
 from .workgraph import WorkGraph
 from .task import Task
 from .decorator import task, build_task
-
 
 __version__ = "0.3.12"
 

--- a/aiida_workgraph/task.py
+++ b/aiida_workgraph/task.py
@@ -1,7 +1,10 @@
 from node_graph.node import Node as GraphNode
+from aiida_workgraph import USE_WIDGET
 from aiida_workgraph.properties import property_pool
 from aiida_workgraph.sockets import socket_pool
-from aiida_workgraph.widget import NodeGraphWidget
+
+if USE_WIDGET:
+    from aiida_workgraph.widget import NodeGraphWidget
 from aiida_workgraph.collection import (
     WorkGraphPropertyCollection,
     WorkGraphInputSocketCollection,
@@ -43,10 +46,13 @@ class Task(GraphNode):
         self.wait = [] if wait is None else wait
         self.process = process
         self.pk = pk
-        self._widget = NodeGraphWidget(
-            settings={"minmap": False},
-            style={"width": "80%", "height": "600px"},
-        )
+        if USE_WIDGET:
+            self._widget = NodeGraphWidget(
+                settings={"minmap": False},
+                style={"width": "80%", "height": "600px"},
+            )
+        else:
+            self._widget = None
         self.state = "PLANNED"
         self.action = ""
 

--- a/aiida_workgraph/task.py
+++ b/aiida_workgraph/task.py
@@ -122,6 +122,11 @@ class Task(GraphNode):
         self.state = "PLANNED"
 
     def _repr_mimebundle_(self, *args: Any, **kwargs: Any) -> any:
+        from aiida_workgraph.utils.message import WIDGET_INSTALLATION_MESSAGE
+
+        if self._widget is None:
+            print(WIDGET_INSTALLATION_MESSAGE)
+            return
         # if ipywdigets > 8.0.0, use _repr_mimebundle_ instead of _ipython_display_
         self._widget.from_node(self)
         if hasattr(self._widget, "_repr_mimebundle_"):

--- a/aiida_workgraph/utils/graph.py
+++ b/aiida_workgraph/utils/graph.py
@@ -8,9 +8,13 @@ def task_creation_hook(self, task: Any) -> None:
         task (Task): a task to be created.
     """
     # send message to the widget
-    self.parent._widget.send(
-        {"type": "add_task", "data": {"label": task.name, "inputs": [], "outputs": []}}
-    )
+    if self.parent._widget is not None:
+        self.parent._widget.send(
+            {
+                "type": "add_task",
+                "data": {"label": task.name, "inputs": [], "outputs": []},
+            }
+        )
 
 
 def task_deletion_hook(self, task: Any) -> None:
@@ -25,7 +29,8 @@ def task_deletion_hook(self, task: Any) -> None:
         if link.from_node.name == task.name or link.to_node.name == task.name:
             link_index.append(index)
     del self.parent.links[link_index]
-    self.parent._widget.send({"type": "delete_node", "data": {"name": task.name}})
+    if self._widget is not None:
+        self.parent._widget.send({"type": "delete_node", "data": {"name": task.name}})
 
 
 def link_creation_hook(self, link: Any) -> None:
@@ -34,17 +39,18 @@ def link_creation_hook(self, link: Any) -> None:
     Args:
         link (Link): a link to be created.
     """
-    self.parent._widget.send(
-        {
-            "type": "add_link",
-            "data": {
-                "from_node": link.from_node.name,
-                "from_socket": link.from_socket.name,
-                "to_node": link.to_node.name,
-                "to_socket": link.to_socket.name,
-            },
-        }
-    )
+    if self.parent._widget is not None:
+        self.parent._widget.send(
+            {
+                "type": "add_link",
+                "data": {
+                    "from_node": link.from_node.name,
+                    "from_socket": link.from_socket.name,
+                    "to_node": link.to_node.name,
+                    "to_socket": link.to_socket.name,
+                },
+            }
+        )
 
 
 def link_deletion_hook(self, link: Any) -> None:
@@ -53,14 +59,15 @@ def link_deletion_hook(self, link: Any) -> None:
     Args:
         link (Link): a link to be deleted.
     """
-    self.parent._widget.send(
-        {
-            "type": "delete_link",
-            "data": {
-                "from_node": link.from_node.name,
-                "from_socket": link.from_socket.name,
-                "to_node": link.to_node.name,
-                "to_socket": link.to_socket.name,
-            },
-        }
-    )
+    if self.parent._widget is not None:
+        self.parent._widget.send(
+            {
+                "type": "delete_link",
+                "data": {
+                    "from_node": link.from_node.name,
+                    "from_socket": link.from_socket.name,
+                    "to_node": link.to_node.name,
+                    "to_socket": link.to_socket.name,
+                },
+            }
+        )

--- a/aiida_workgraph/utils/message.py
+++ b/aiida_workgraph/utils/message.py
@@ -1,0 +1,6 @@
+WIDGET_INSTALLATION_MESSAGE = (
+    "Widget dependency not found. To visualize the workgraph, please install the widget dependency. "
+    "Use 'pip install aiida-workgraph[widget]' if installing from PyPI. "
+    "For local source installations, use 'pip install .[widget]' and then build the JavaScript library. "
+    "Refer to the documentation for more details."
+)

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -1,6 +1,7 @@
 import aiida.orm
 import node_graph
 import aiida
+from aiida_workgraph import USE_WIDGET
 from aiida_workgraph.tasks import task_pool
 import time
 from aiida_workgraph.collection import TaskCollection
@@ -10,7 +11,9 @@ from aiida_workgraph.utils.graph import (
     link_creation_hook,
     link_deletion_hook,
 )
-from aiida_workgraph.widget import NodeGraphWidget
+
+if USE_WIDGET:
+    from aiida_workgraph.widget import NodeGraphWidget
 from typing import Any, Dict, List, Optional
 
 
@@ -54,7 +57,7 @@ class WorkGraph(node_graph.NodeGraph):
         self.links.post_creation_hooks = [link_creation_hook]
         self.links.post_deletion_hooks = [link_deletion_hook]
         self.error_handlers = {}
-        self._widget = NodeGraphWidget(parent=self)
+        self._widget = NodeGraphWidget(parent=self) if USE_WIDGET else None
 
     @property
     def tasks(self) -> TaskCollection:
@@ -290,7 +293,8 @@ class WorkGraph(node_graph.NodeGraph):
             #         except Exception:
             #             pass
             #         node.outputs[key].value = value
-        self._widget.states = {task.name: node.state for node in self.tasks}
+        if self._widget is not None:
+            self._widget.states = {task.name: node.state for node in self.tasks}
 
     @property
     def pk(self) -> Optional[int]:

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -467,6 +467,12 @@ class WorkGraph(node_graph.NodeGraph):
         self.error_handlers[name] = {"handler": handler, "tasks": tasks}
 
     def _repr_mimebundle_(self, *args, **kwargs):
+        from aiida_workgraph.utils.message import WIDGET_INSTALLATION_MESSAGE
+
+        if self._widget is None:
+            print(WIDGET_INSTALLATION_MESSAGE)
+            return
+
         # if ipywdigets > 8.0.0, use _repr_mimebundle_ instead of _ipython_display_
         self._widget.from_workgraph(self)
         if hasattr(self._widget, "_repr_mimebundle_"):

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,7 +25,7 @@ The recommended method of installation is to use the Python package manager |pip
 
 .. code-block:: console
 
-    $ pip install aiida-workgraph
+    $ pip install aiida-workgraph aiida-workgraph[widget]
 
 This will install the latest stable version that was released to PyPI.
 
@@ -33,8 +33,18 @@ To install the package from source, first clone the repository and then install 
 
 .. code-block:: console
 
-    $ git clone https://github.com/superstar54/aiida-workgraph
-    $ pip install -e aiida-workgraph
+    $ git clone https://github.com/aiidateam/aiida-workgraph
+    $ cd aiida-workgraph
+    $ pip install -e .
+
+The ``-e`` flag will install the package in editable mode, meaning that changes to the source code will be automatically picked up.
+To install the jupyter widget support you need to in addition build the JavaScript packages:
+
+.. code-block:: console
+
+    $ pip install .[widget]
+    $ cd aiida-workgraph
+    $ pip install -e .
     $ # build widget
     $ cd aiida_workgraph/widget/
     $ npm install
@@ -43,9 +53,6 @@ To install the package from source, first clone the repository and then install 
     $ cd ../../aiida_workgraph/web/frontend/
     $ npm install
     $ npm run build
-
-The ``-e`` flag will install the package in editable mode, meaning that changes to the source code will be automatically picked up.
-
 
 
 .. |pip| replace:: ``pip``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,7 +25,7 @@ The recommended method of installation is to use the Python package manager |pip
 
 .. code-block:: console
 
-    $ pip install aiida-workgraph aiida-workgraph[widget]
+    $ pip install aiida-workgraph[widget]
 
 This will install the latest stable version that was released to PyPI.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "scipy",
     "ase",
     "node-graph>=0.0.11",
-    "anywidget>=0.9.11",
     "aiida-core>=2.3",
     "cloudpickle",
     "aiida-shell",
@@ -42,6 +41,9 @@ Documentation = "https://aiida-workgraph.readthedocs.io"
 Source = "https://github.com/aiidateam/aiida-workgraph"
 
 [project.optional-dependencies]
+widget = [
+    "anywidget>=0.9.11",
+]
 docs = [
     "sphinx_rtd_theme",
     "sphinx~=7.2",


### PR DESCRIPTION
At the moment the widget part of workgraph is compulsory to install which requires to build JavaScript code. This commit makes the use of the widget optional and thus facilitates the installation of a development environment.