### PR TITLE
Add executed_task to record the tasks that have already been submitted. 

### DIFF
--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -782,18 +782,28 @@ class WorkGraphEngine(Process, metaclass=Protect):
                         )
                     )
                     continue
+            # This calcfuntion/workfunction is already run
+            if (
+                task["metadata"]["node_type"].upper()
+                in [
+                    "CALCFUNCTION",
+                    "WORKFUNCTION",
+                ]
+                and self.get_task_state_info(name, "state").upper() != "PLANNED"
+            ):
+                continue
             self.report(f"Run task: {name}, type: {task['metadata']['node_type']}")
             # print("Run task: ", name)
             # print("executor: ", task["executor"])
             executor, _ = get_executor(task["executor"])
-            print("executor: ", executor)
+            # print("executor: ", executor)
             args, kwargs, var_args, var_kwargs, args_dict = self.get_inputs(task)
             for i, key in enumerate(self.ctx.tasks[name]["metadata"]["args"]):
                 kwargs[key] = args[i]
             # update the port namespace
             kwargs = update_nested_dict_with_special_keys(kwargs)
-            print("args: ", args)
-            print("kwargs: ", kwargs)
+            # print("args: ", args)
+            # print("kwargs: ", kwargs)
             # print("var_kwargs: ", var_kwargs)
             # kwargs["meta.label"] = name
             # output must be a Data type or a mapping of {string: Data}

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -597,12 +597,14 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.report(f"Task {name} action: RESET.")
         self.set_task_state_info(name, "state", "PLANNED")
         self.set_task_state_info(name, "process", None)
+        self.ctx.executed_tasks.remove(name)
         # reset its child tasks
         names = self.ctx.connectivity["child_node"][name]
         for name in names:
             self.set_task_state_info(name, "state", "PLANNED")
             self.ctx.tasks[name]["result"] = None
             self.set_task_state_info(name, "process", None)
+            self.ctx.executed_tasks.remove(name)
 
     def pause_task(self, name: str) -> None:
         """Pause task."""
@@ -1175,6 +1177,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         print("Reset")
         self.ctx._execution_count += 1
         self.set_tasks_state(self.ctx.tasks.keys(), "PLANNED")
+        self.ctx.executed_tasks = []
 
     def set_tasks_state(
         self, tasks: t.Union[t.List[str], t.Sequence[str]], value: str

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -419,8 +419,9 @@ class WorkGraphEngine(Process, metaclass=Protect):
     def setup(self) -> None:
         # track if the awaitable callback is added to the runner
         self.ctx._awaitable_actions = []
-        self.ctx.new_data = dict()
-        self.ctx.input_tasks = dict()
+        self.ctx.new_data = {}
+        self.ctx.input_tasks = {}
+        self.ctx.executed_tasks = []
         # read the latest workgraph data
         wgdata = self.read_wgdata_from_base()
         self.init_ctx(wgdata)
@@ -782,16 +783,11 @@ class WorkGraphEngine(Process, metaclass=Protect):
                         )
                     )
                     continue
-            # This calcfuntion/workfunction is already run
-            if (
-                task["metadata"]["node_type"].upper()
-                in [
-                    "CALCFUNCTION",
-                    "WORKFUNCTION",
-                ]
-                and self.get_task_state_info(name, "state").upper() != "PLANNED"
-            ):
+            # This task is already executed
+            if name in self.ctx.executed_tasks:
                 continue
+            else:
+                self.ctx.executed_tasks.append(name)
             self.report(f"Run task: {name}, type: {task['metadata']['node_type']}")
             # print("Run task: ", name)
             # print("executor: ", task["executor"])


### PR DESCRIPTION
## Issue
@edan-bainglass reported an error in his testing: Some of the tasks were run multiple times. I can confirm that this is a bug.

## Reason
In WorkGraph engine, `calcfunction` is run directly instead of submit. In order to not block the child task of a `calcfunction` task, the engine will continue to run the workgraph (`self.continue_workgraph` method) immediately after the execution of a `calcfunction`, until all its child tasks are finished, or going to a `Waiting` state. This will run recursively.  When continuing the workgraph, we pass a `exclude` list to avoid running the tasks that will be executed in the current run. However, the `exclude` list only considers the current run instead of the recursive run.

More generally, there is a risk that the engine can run a task multiple times because the `self.continue_workgraph` method can be run concurrently, e.g., in the case of `calcfuntion`, and the `callback` from an Awaitable (submitted process).

## Solution
Add `executed_task` to record the tasks that have already been submitted. We check the `executed_task` before running a task, thus avoiding running tasks multiple times. Since a WorkGraph is run (and only) by one daemon, and Python list `append` operation is atomic, as shown in the [documentation](https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe), so the modification on the `executed_tasks` should be thread-safe, within the `asyncio` framework (used by AiiDA Process).
