### PR TITLE
support python 3.12 for the entry points

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
 
@@ -36,8 +36,8 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.11']
-                aiida-core-version: ['2.4', '2.5']
+                python-version: ['3.9', '3.11', '3.12']
+                aiida-core-version: ['2.5', '2.6']
 
         services:
             postgres:

--- a/aiida_workgraph/orm/serializer.py
+++ b/aiida_workgraph/orm/serializer.py
@@ -3,6 +3,7 @@ from aiida import orm, common
 from importlib.metadata import entry_points
 from typing import Any
 from aiida_workgraph.config import load_config
+import sys
 
 
 def get_serializer_from_entry_points() -> dict:
@@ -14,8 +15,13 @@ def get_serializer_from_entry_points() -> dict:
     serializers = configs.get("serializers", {})
     excludes = serializers.get("excludes", [])
     # Retrieve the entry points for 'aiida.data' and store them in a dictionary
+    eps = entry_points()
+    if sys.version_info >= (3, 10):
+        group = eps.select(group="aiida.data")
+    else:
+        group = eps.get("aiida.data", [])
     eps = {}
-    for ep in entry_points().get("aiida.data", []):
+    for ep in group:
         # split the entry point name by first ".", and check the last part
         key = ep.name.split(".", 1)[-1]
         # skip key without "." because it is not a module name for a data type


### PR DESCRIPTION
In Python 3.10 or later, the method to select entry points has changed to select(), while for earlier versions, get() is used.