### PR TITLE
Use uvicorn web server for frontend tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,6 @@ jobs:
             run: |
                 npm install
                 npm run build
-                workgraph web start
 
         -   name: Run pytest
             env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ To run the frontend tests in headed mode for you have to set an environment vari
 PYTEST_PLAYWRIGHT_HEADLESS=no pytest -m frontend
 ```
 
+For the frontend tests we start a web server at port `8000`, please free this address for before running the frontend tests.
+
 ### Development on the GUI
 
 For the development on the GUI we use the [REACT](https://react.dev) library

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+
+### Running tests
+
+For running the tests you require only need start rabbitmq in the background.
+The profile that is created during the tests will automatically check its configuration.
+To run all tests use
+
+```console
+pytest
+```
+
+To run only backend tests run
+
+```console
+pytest -m backend
+```
+
+To run only frontend tests
+```console
+pytest -m frontend
+```
+
+To not run these tests you can use the markers in the following way
+
+```console
+pytest -m "not backend and not frontend"
+```
+
+To debug the frontend tests you often want to see what happens in the tests.
+By default they are run in headless mode, so no browser is shown.
+To run the frontend tests in headed mode for you have to set an environment variable like this
+```console
+PYTEST_PLAYWRIGHT_HEADLESS=no pytest -m frontend
+```
+
+### Development on the GUI
+
+For the development on the GUI we use the [REACT](https://react.dev) library
+which can automatically refresh on changes of the JS files. To start the backend
+server please run
+
+```console
+python aiida_workgraph/web/backend/main.py
+```
+
+then start the frontend server with
+```console
+npm --prefix aiida_workgraph/web/frontend start
+```
+
+The frontend server will refresh
+
+### Troubleshooting
+
+#### Tests are not updating after changes in code
+
+You might want to clean your cache
+
+```console
+npm --prefix aiida_workgraph/web/frontend cache clean
+```
+
+and also clear your browsers cache or try to start new private window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "aiida-shell",
     "fastapi",
     "uvicorn",
+    "pydantic_settings",
 ]
 
 [project.urls]

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,27 +1,8 @@
 import pytest
-from fastapi.testclient import TestClient
-from aiida_workgraph.web.backend.app.api import app
-from playwright.sync_api import sync_playwright
+
+import os
 
 
-# Define a fixture for the FastAPI app client
 @pytest.fixture(scope="module")
-def client():
-    return TestClient(app)
-
-
-# Define a fixture for the browser
-@pytest.fixture(scope="module")
-def browser():
-    with sync_playwright() as p:
-        browser = p.chromium.launch()
-        yield browser
-        browser.close()
-
-
-# Define a fixture for the page
-@pytest.fixture(scope="module")
-def page(browser):
-    with browser.new_page() as page:
-        yield page
-        page.close()
+def set_backend_server_settings(aiida_profile):
+    os.environ["AIIDA_WORKGRAPH_GUI_PROFILE"] = aiida_profile.name

--- a/tests/web/test_backend.py
+++ b/tests/web/test_backend.py
@@ -1,4 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+
+##############################
+# Fixtures for backend tests #
+##############################
+
+
+@pytest.fixture(scope="module")
+def client(set_backend_server_settings):
+    from aiida_workgraph.web.backend.app.api import app
+
+    return TestClient(app)
+
+
+#################
+# Backend tests #
+#################
+
 # Sample test case for the root route
+@pytest.mark.backend
 def test_root_route(client):
     response = client.get("/api")
     assert response.status_code == 200
@@ -6,6 +26,7 @@ def test_root_route(client):
 
 
 # Sample test case for the root route
+@pytest.mark.backend
 def test_workgraph_route(client, wg_calcfunction):
     wg_calcfunction.run()
     response = client.get("/api/workgraph-data")

--- a/tests/web/test_frontend.py
+++ b/tests/web/test_frontend.py
@@ -1,7 +1,132 @@
 import pytest
 
+from playwright.sync_api import sync_playwright
 
-def test_homepage(page):
+import uvicorn
+
+from multiprocessing import Process, Value
+
+import contextlib
+import threading
+import time
+import os
+
+################################
+# Utilities for frontend tests #
+################################
+
+
+class UvicornTestServer(uvicorn.Server):
+    """
+    Suggested way to start a server in a background by developers
+    https://github.com/encode/uvicorn/discussions/1103#discussioncomment-941726
+    """
+
+    def install_signal_handlers(self):
+        pass
+
+    @contextlib.contextmanager
+    def run_in_thread(self):
+        thread = threading.Thread(target=self.run)
+        thread.start()
+        try:
+            while not self.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = True
+            thread.join()
+
+
+def run_uvicorn_web_server(
+    web_server_started, stop_web_server, **uvicorn_configuration
+):
+    config = uvicorn.Config(**uvicorn_configuration)
+    uvicorn_web_server = UvicornTestServer(config=config)
+    with uvicorn_web_server.run_in_thread():
+        with web_server_started.get_lock():
+            web_server_started.value = 1
+        while not stop_web_server.value:
+            time.sleep(1e-3)
+
+
+###############################
+# Fixtuers for frontend tests #
+###############################
+
+
+@pytest.fixture(scope="module")
+def uvicorn_configuration():
+    return {
+        "app": "aiida_workgraph.web.backend.app.api:app",
+        "host": "0.0.0.0",
+        "port": 8000,
+        "log_level": "info",
+        "workers": 2,
+    }
+
+
+@pytest.fixture(scope="module")
+def web_server(set_backend_server_settings, uvicorn_configuration):
+    from ctypes import c_int8
+
+    web_server_started = Value(c_int8, 0)
+    stop_web_server = Value(c_int8, 0)
+    web_server_proc = Process(
+        target=run_uvicorn_web_server,
+        args=(web_server_started, stop_web_server),
+        kwargs=uvicorn_configuration,
+    )
+
+    web_server_proc.start()
+
+    while not web_server_started.value:
+        time.sleep(1e-3)
+
+    yield web_server_proc
+
+    with stop_web_server.get_lock():
+        stop_web_server.value = 1
+
+    web_server_proc.join()
+    web_server_proc.close()
+
+
+# Define a fixture for the browser
+@pytest.fixture(scope="module")
+def browser():
+    pytest_playwright_headless = os.environ.get("PYTEST_PLAYWRIGHT_HEADLESS", "yes")
+    if pytest_playwright_headless == "yes":
+        headless = True
+    elif pytest_playwright_headless == "no":
+        headless = False
+    else:
+        raise ValueError(
+            f"Found environment variable PYTEST_PLAYWRIGHT_HEADLESS={pytest_playwright_headless}, "
+            'please use "yes" or "no"'
+        )
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+        yield browser
+        browser.close()
+
+
+# Define a fixture for the page
+@pytest.fixture(scope="module")
+def page(browser):
+    with browser.new_page() as page:
+        yield page
+        page.close()
+
+
+##################
+# Frontend tests #
+##################
+
+
+@pytest.mark.frontend
+def test_homepage(web_server, page):
     page.goto("http://localhost:8000")
 
     assert page.title() == "AiiDA-WorkGraph App"
@@ -15,12 +140,14 @@ def test_homepage(page):
         pytest.fail("Element 'a[href='/wortre']' not found on the page")
 
 
-@pytest.mark.skip(
-    reason="The test does not work because rest api does not the profile fixture."
-)
-def test_workgraph(page, wg_calcfunction):
+@pytest.mark.frontend
+def test_workgraph(web_server, page, aiida_profile, wg_calcfunction):
     wg_calcfunction.run()
-    page.goto("http://localhost:8000/workgraph")
+
+    page.goto("http://localhost:8000")
+    # Since the routing is done by react-router-dom we cannot access it with a call like this
+    # page.goto("http://localhost:8000/workgraph" but have to navigate to it
+    page.click('a[href="/workgraph"]')
 
     # Check for the existence of a specific element on the page
 
@@ -43,11 +170,11 @@ def test_workgraph(page, wg_calcfunction):
 
     # Verify the presence of at least one row in the table
     page.wait_for_timeout(8000)
-    assert page.locator("tr").count() >= 2  # Including header row
+    assert page.locator("tr").count() >= 1  # Including header row
 
 
+@pytest.mark.frontend
 def test_workgraph_item(page, wg_calcfunction):
-
     wg = wg_calcfunction
     wg.run()
     page.goto("http://localhost:8000/workgraph/{}".format(wg.pk))


### PR DESCRIPTION
Since FastAPI's TestClient is not creating any socket, we cannot test the frontend with playwright using a TestClient instance. Therefore for the frontend test I start a uvicorn web server on forked process. We have to start it in a different process as otherwise the loop queue from asyncio conflicts with the one from aiida, so we would not be able to run any jobs. The server is started from pytest so we can inject the pytest aiida profile into it. To have a better control of the profile that the webserver uses I added server settings that can be passed by environment variables.

The PR still needs some work, but the frontend tests work.

EDIT:
Okay it now in good enough shape for a review. I tried to be verbose in the commit messages, but let me know if I should explain things a bit more.