### PR TITLE
PythonJob use task name as process label

### DIFF
--- a/aiida_workgraph/calculations/python.py
+++ b/aiida_workgraph/calculations/python.py
@@ -50,6 +50,9 @@ class PythonJob(CalcJob):
         spec.input(
             "function_name", valid_type=Str, serializer=to_aiida_type, required=False
         )
+        spec.input(
+            "process_label", valid_type=Str, serializer=to_aiida_type, required=False
+        )
         spec.input_namespace(
             "function_kwargs", valid_type=Data, required=False
         )  # , serializer=serialize_to_aiida_nodes)
@@ -137,7 +140,10 @@ class PythonJob(CalcJob):
 
         :returns: The process label to use for ``ProcessNode`` instances.
         """
-        return f"PythonJob<{self.inputs.function_name.value}>"
+        if self.inputs.process_label:
+            return self.inputs.process_label.value
+        else:
+            return f"PythonJob<{self.inputs.function_name.value}>"
 
     def prepare_for_submission(self, folder: Folder) -> CalcInfo:
         """Prepare the calculation for submission.

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -95,6 +95,7 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
     function_kwargs = serialize_to_aiida_nodes(function_kwargs)
     # transfer the args to kwargs
     inputs = {
+        "process_label": f"PythonJob<{task['name']}",
         "function_source_code": orm.Str(function_source_code),
         "function_name": orm.Str(function_name),
         "code": code,


### PR DESCRIPTION
Provide an input `process_label` so that the user can set the process label manually. In case of WorkGraph, the process label will be set as: `PythonJob<{task['name']}`