### PR TITLE
Set the node' label as the workgraph/task's name.

### DIFF
--- a/aiida_workgraph/calculations/python.py
+++ b/aiida_workgraph/calculations/python.py
@@ -145,6 +145,12 @@ class PythonJob(CalcJob):
         else:
             return f"PythonJob<{self.inputs.function_name.value}>"
 
+    def on_create(self) -> None:
+        """Called when a Process is created."""
+
+        super().on_create()
+        self.node.label = self.inputs.process_label.value
+
     def prepare_for_submission(self, folder: Folder) -> CalcInfo:
         """Prepare the calculation for submission.
 

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -95,7 +95,7 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
     function_kwargs = serialize_to_aiida_nodes(function_kwargs)
     # transfer the args to kwargs
     inputs = {
-        "process_label": f"PythonJob<{task['name']}",
+        "process_label": f"PythonJob<{task['name']}>",
         "function_source_code": orm.Str(function_source_code),
         "function_name": orm.Str(function_name),
         "code": code,

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -416,6 +416,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         )
         saver = WorkGraphSaver(self.node, wgdata, restart_process=restart_process)
         saver.save()
+        self.node.label = wgdata["name"]
 
     def setup(self) -> None:
         # track if the awaitable callback is added to the runner

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -24,23 +24,26 @@ def test_decorator(fixture_localhost):
     wg = WorkGraph("test_PythonJob_outputs")
     wg.add_task(
         add,
-        name="add",
+        name="add1",
         x=1,
         y=2,
         computer="localhost",
     )
     wg.add_task(
         decorted_multiply,
-        name="multiply",
-        x=wg.tasks["add"].outputs["sum"],
+        name="multiply1",
+        x=wg.tasks["add1"].outputs["sum"],
         y=3,
         computer="localhost",
     )
     # wg.submit(wait=True)
     wg.run()
-    assert wg.tasks["add"].outputs["sum"].value.value == 3
-    assert wg.tasks["add"].outputs["diff"].value.value == -1
-    assert wg.tasks["multiply"].outputs["result"].value.value == 9
+    assert wg.tasks["add1"].outputs["sum"].value.value == 3
+    assert wg.tasks["add1"].outputs["diff"].value.value == -1
+    assert wg.tasks["multiply1"].outputs["result"].value.value == 9
+    # process_label and label
+    assert wg.tasks["add1"].node.process_label == "PythonJob<add1>"
+    assert wg.tasks["add1"].node.label == "add1"
 
 
 @pytest.mark.usefixtures("started_daemon_client")

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -39,6 +39,7 @@ def test_save_load(wg_calcfunction):
     wg.save()
     assert wg.process.process_state.value.upper() == "CREATED"
     assert wg.process.process_label == "WorkGraph<test_save_load>"
+    assert wg.process.label == "test_save_load"
     wg2 = WorkGraph.load(wg.process.pk)
     assert len(wg.tasks) == len(wg2.tasks)
 


### PR DESCRIPTION
Suggested by @edan-bainglass .
Set the node' label as the workgraph/task's name when the process node is created. This is very useful for querying. For example, for `WorkGraph<abc_name>` and `PythonJob<abc_name>`, the `node.label` will be `abc_name`.

Note: `node.label` is mutable, thus user can modify it after.
