### PR TITLE
Update any remaining instances of `Worktree` to `WorkGraph`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Start the web app, open a terminal and run:
 workgraph web start
 ```
 
-Then visit the page http://127.0.0.1:8000/workgraph, you should find a `first_workflow` Worktree, click the pk and view the WorkGraph.
+Then visit the page http://127.0.0.1:8000/workgraph, you should find a `first_workflow` WorkGraph, click the pk and view the WorkGraph.
 
 <img src="docs/source/_static/images/first-workflow.png" />
 

--- a/aiida_workgraph/orm/workgraph.py
+++ b/aiida_workgraph/orm/workgraph.py
@@ -11,12 +11,12 @@ __all__ = ("WorkGraphNode",)
 class WorkGraphNode(WorkChainNode):
     """ORM class for all nodes representing the execution of a WorkGraph."""
 
-    WORKTREE_STATE_INFO_KEY = "workgraph_state_info"
+    WORKGRAPH_STATE_INFO_KEY = "workgraph_state_info"
 
     @classproperty
     def _updatable_attributes(cls) -> Tuple[str, ...]:  # type: ignore
         # pylint: disable=no-self-argument
-        return super()._updatable_attributes + (cls.WORKTREE_STATE_INFO_KEY,)
+        return super()._updatable_attributes + (cls.WORKGRAPH_STATE_INFO_KEY,)
 
     @property
     def workgraph_state_info(self) -> Optional[str]:
@@ -25,7 +25,7 @@ class WorkGraphNode(WorkChainNode):
 
         :returns: string representation of the workgraph state info
         """
-        return self.base.attributes.get(self.WORKTREE_STATE_INFO_KEY, None)
+        return self.base.attributes.get(self.WORKGRAPH_STATE_INFO_KEY, None)
 
     def set_workgraph_state_info(self, workgraph_state_info: str) -> None:
         """
@@ -34,5 +34,5 @@ class WorkGraphNode(WorkChainNode):
         :param state: string representation of the workgraph state info
         """
         return self.base.attributes.set(
-            self.WORKTREE_STATE_INFO_KEY, workgraph_state_info
+            self.WORKGRAPH_STATE_INFO_KEY, workgraph_state_info
         )

--- a/aiida_workgraph/web/frontend/src/components/NodeDetails.js
+++ b/aiida_workgraph/web/frontend/src/components/NodeDetails.js
@@ -4,7 +4,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dark } from 'react-syntax-highlighter/dist/esm/styles/prism'; // Correct import for 'dark' style
 import { useNavigate } from 'react-router-dom'; // Use the useNavigate hook
 
-const WorktreeButton = styled.button`
+const WorkGraphButton = styled.button`
   padding: 10px;
   background-color: #007bff;
   color: #fff;
@@ -121,8 +121,8 @@ function NodeDetails({ selectedNode, onClose, setShowNodeDetails }) {
     onClose();
   };
 
-  const handleWorktreeClick = () => {
-    if (selectedNode.node_type === 'graph_builder' && selectedNode.process.pk) {
+  const handleWorkGraphClick = () => {
+    if ((selectedNode.node_type.toUpperCase() === 'GRAPH_BUILDER' || selectedNode.node_type.toUpperCase() === 'WORKGRAPH') && selectedNode.process.pk) {
       navigate(`/workgraph/${selectedNode.process.pk}`);
     }
   };
@@ -163,10 +163,10 @@ function NodeDetails({ selectedNode, onClose, setShowNodeDetails }) {
     <NodeDetailsPanel>
       <CloseButton onClick={handleClose}>Close</CloseButton>
       <NodeDetailsTitle>Node Details</NodeDetailsTitle>
-      {selectedNode.node_type === 'graph_builder' && (
-      <WorktreeButton onClick={handleWorktreeClick} disabled={isButtonDisabled}>
-        Go to Worktree
-      </WorktreeButton>
+      {(selectedNode.node_type.toUpperCase() === 'GRAPH_BUILDER' || selectedNode.node_type.toUpperCase() === 'WORKGRAPH') && (
+      <WorkGraphButton onClick={handleWorkGraphClick} disabled={isButtonDisabled}>
+        Go to WorkGraph
+      </WorkGraphButton>
       )}
       {selectedNode && (
         <NodeDetailsTable>

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphDetail.js
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphDetail.js
@@ -3,12 +3,12 @@ import { useParams } from 'react-router-dom';
 
 function WorkGraphDetail() {
     let { pk } = useParams();
-    const [workgraphData, setWorktreeData] = useState(null);
+    const [workgraphData, setWorkGraphData] = useState(null);
 
     useEffect(() => {
         fetch(`http://localhost:8000/workgraph/${pk}`)
             .then(response => response.json())
-            .then(data => setWorktreeData(data))
+            .then(data => setWorkGraphData(data))
             .catch(error => console.error('Error fetching data:', error));
     }, [pk]); // useEffect will re-run if pk changes
 

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphIndicator.js
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphIndicator.js
@@ -28,7 +28,7 @@ const Separator = styled.span`
   color: #ccc;
 `;
 
-function Breadcrumbs({ parentWorktrees }) {
+function Breadcrumbs({ parentWorkGraphs }) {
   // const separatorIcon = <FontAwesomeIcon icon={faChevronRight} />; // Change this icon as needed
   // const separatorIcon = <FontAwesomeIcon icon={faCircle} />; // Alternative smaller icon
   // const separatorIcon = '>'; // Text-based alternative
@@ -36,12 +36,12 @@ function Breadcrumbs({ parentWorktrees }) {
 
   return (
     <BreadcrumbContainer aria-label="breadcrumb">
-      {parentWorktrees.map(([workgraphName, workgraphId], index) => (
+      {parentWorkGraphs.map(([workgraphName, workgraphId], index) => (
         <React.Fragment key={workgraphId}>
           <BreadcrumbLink href={`/workgraph/${workgraphId}`}>
             {workgraphName}
           </BreadcrumbLink>
-          {index < parentWorktrees.length - 1 && <Separator>{separatorIcon}</Separator>}
+          {index < parentWorkGraphs.length - 1 && <Separator>{separatorIcon}</Separator>}
         </React.Fragment>
       ))}
     </BreadcrumbContainer>

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphItem.tsx
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphItem.tsx
@@ -5,7 +5,7 @@ import '../rete.css';
 import { createEditor } from '../rete/default';
 import { Button, Switch } from "antd";
 import WorkGraphIndicator from './WorkGraphIndicator'; // Import the WorkGraphIndicator component
-import WorktreeSummary from './WorkGraphSummary';
+import WorkGraphSummary from './WorkGraphSummary';
 import WorkGraphLog from './WorkGraphLog';
 import NodeDetails from './NodeDetails';
 import NodeDurationGraph from './WorkGraphDuration'
@@ -15,7 +15,7 @@ import {
   LayoutAction,
   TopMenu,
   EditorWrapper,
-} from './WorkGraphItemStyles'; // Import your styles
+} from './WorkGraphItemStyles';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -72,13 +72,13 @@ export function useRete<T extends { destroy(): void }>(
 
 
 
-function WorkGraphGraph() {
+function WorkGraph() {
   const { pk } = useParams();
-  const [workgraphData, setWorktreeData] = useState({ summary: {}, nodes: {}, links: [], pk: [] });
+  const [workgraphData, setWorkGraphData] = useState({ summary: {}, nodes: {}, links: [], pk: [] });
   const [ref, editor] = useRete(createEditor, workgraphData);
   const [selectedNode, setSelectedNode] = useState({ metadata: [], executor: '' });
   const [showNodeDetails, setShowNodeDetails] = useState(false);
-  const [workgraphHierarchy, setWorktreeHierarchy] = useState([]);
+  const [workgraphHierarchy, setWorkGraphHierarchy] = useState([]);
   const [selectedView, setSelectedView] = useState('Editor');
   const [realtimeSwitch, setRealtimeSwitch] = useState(false); // State to manage the realtime switch
 
@@ -157,9 +157,9 @@ function WorkGraphGraph() {
     fetch(`http://localhost:8000/api/workgraph/${pk}`)
       .then((response) => response.json())
       .then((data) => {
-        setWorktreeData(data);
+        setWorkGraphData(data);
         // Set the workgraph hierarchy here based on your data
-        setWorktreeHierarchy(data.parent_workgraphs);
+        setWorkGraphHierarchy(data.parent_workgraphs);
       })
       .catch((error) => console.error('Error fetching data:', error));
   }, [pk]); // Only re-run when `pk` changes
@@ -256,11 +256,11 @@ function WorkGraphGraph() {
           <Button onClick={() => setSelectedView('Log')}>Log</Button>
           <Button onClick={() => setSelectedView('Time')}>Time</Button>
         </TopMenu>
-          {selectedView === 'Summary' && <WorktreeSummary summary={workgraphData.summary} />}
+          {selectedView === 'Summary' && <WorkGraphSummary summary={workgraphData.summary} />}
           {selectedView === 'Log' && <WorkGraphLog id={pk} />}
           {selectedView === 'Time' && <NodeDurationGraph id={pk}/>}
           <EditorWrapper visible={selectedView === 'Editor'}>
-          <WorkGraphIndicator parentWorktrees={workgraphHierarchy} />
+          <WorkGraphIndicator parentWorkGraphs={workgraphHierarchy} />
             <EditorContainer>
               <LayoutAction>
               <div>
@@ -289,4 +289,4 @@ function WorkGraphGraph() {
   );
 }
 
-export default WorkGraphGraph;
+export default WorkGraph;

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphLog.js
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphLog.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useEffect, useState } from "react";
 
 
-export const WorktreeLogStyle = styled.div`
+export const WorkGraphLogStyle = styled.div`
   .log-section {
   border: 1px solid #ddd;
   padding: 1em;
@@ -51,7 +51,7 @@ function WorkGraphLog({ id }) {
   };
 
   return (
-    <WorktreeLogStyle>
+    <WorkGraphLogStyle>
       <div className="log-section">
         <h3>Log Information</h3>
         <div className="log-content">
@@ -60,7 +60,7 @@ function WorkGraphLog({ id }) {
           ))}
         </div>
       </div>
-    </WorktreeLogStyle>
+    </WorkGraphLogStyle>
   );
 }
 

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphSummary.js
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphSummary.js
@@ -1,9 +1,9 @@
-// WorktreeSummary.js
+// WorkGraphSummary.js
 import styled from "styled-components";
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dark } from 'react-syntax-highlighter/dist/esm/styles/prism'; // Correct import for 'dark' style
 
-export const WorktreeInfoStyle = styled.div`
+export const WorkGraphInfoStyle = styled.div`
   width: 50%;
   padding: 1em;
   overflow-y: auto;
@@ -62,7 +62,7 @@ export const WorktreeInfoStyle = styled.div`
   background-color: #f7f7f7; /* Light gray background for better readability */
 `;
 
-function WorktreeSummary({ summary }) {
+function WorkGraphSummary({ summary }) {
 
   const renderInputs = (inputs, depth = 0) => {
     return Object.entries(inputs).map(([key, value]) => {
@@ -93,7 +93,7 @@ function WorktreeSummary({ summary }) {
   };
 
   return (
-    <WorktreeInfoStyle>
+    <WorkGraphInfoStyle>
     <div>
       <h2>Summary</h2>
       <div className="info-table">
@@ -121,8 +121,8 @@ function WorktreeSummary({ summary }) {
         </ul>
       </NodeDetailsTable>
     </div>
-    </WorktreeInfoStyle>
+    </WorkGraphInfoStyle>
   );
 }
 
-export default WorktreeSummary;
+export default WorkGraphSummary;

--- a/docs/source/quick_start.ipynb
+++ b/docs/source/quick_start.ipynb
@@ -1296,7 +1296,7 @@
         "# link the output of a task to the input of another task\n",
         "wg.add_link(add_multiply1.outputs[\"multiply\"], add_multiply2.inputs[\"z\"])\n",
         "wg.submit(wait=True)\n",
-        "print(\"Worktree state: \", wg.state)"
+        "print(\"WorkGraph state: \", wg.state)"
       ]
     },
     {
@@ -1698,11 +1698,11 @@
       "metadata": {},
       "source": [
         "### Start the web server\n",
-        "Worktree also provides a web GUI, where you can view and manage the workgraph. Open a terminal, and run:\n",
+        "WorkGraph also provides a web GUI, where you can view and manage the workgraph. Open a terminal, and run:\n",
         "```\n",
         "workgraph web start\n",
         "```\n",
-        "Then visit the page http://127.0.0.1:8000/workgraph, you can view the workgraph later from here. You should find all the submited workgraph, e.g., the `first_workflow` Worktree. Please click the pk and view the workgraph."
+        "Then visit the page http://127.0.0.1:8000/workgraph, you can view the workgraph later from here. You should find all the submited workgraph, e.g., the `first_workflow` WorkGraph. Please click the pk and view the workgraph."
       ]
     },
     {


### PR DESCRIPTION
1. Update any remaining instances of `Worktree` to `WorkGraph` from the previous renaming commit.

2. Activate the "Go to WorkGraph" button for tasks originating from a `WorkGraph` in the node detail page.
