### PR TITLE
Fix: avoid empty module set when inspecting the type annotations

### DIFF
--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -554,9 +554,9 @@ def get_required_imports(func):
         else:
             return  # If no module or origin, we can't import it, e.g., for literals
 
-        if module_name not in imports:
-            imports[module_name] = set()
         if type_name is not None:
+            if module_name not in imports:
+                imports[module_name] = set()
             imports[module_name].add(type_name)
 
     for _, type_hint in type_hints.items():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -86,6 +86,13 @@ def test_PythonJob_typing():
     ) -> list[Atoms]:
         pass
 
+    def generate_structures_2(
+        structure1: Atoms,
+        strain_lst1: list = None,
+        data1: str = "",
+    ) -> list[Atoms]:
+        pass
+
     modules = get_required_imports(generate_structures)
     assert modules == {
         "ase.atoms": {"Atoms"},
@@ -93,6 +100,8 @@ def test_PythonJob_typing():
         "builtins": {"list"},
         "numpy": {"array"},
     }
+    modules = get_required_imports(generate_structures_2)
+    assert modules == {"ase.atoms": {"Atoms"}, "builtins": {"list", "str"}}
 
 
 def test_PythonJob_outputs(fixture_localhost):


### PR DESCRIPTION
This PR makes sure all the modules set to be imported are not empty.