### PR TITLE
Add rudimentary frontend tests for all functionalities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,10 @@ jobs:
             env:
                 AIIDA_WARN_v3: 1
             run: |
-                pytest -v tests --cov --durations=0
+                # Have to split tests into see issue #225
+                pytest -m "not frontend and not backend" -v --cov --durations=0
+                pytest -m backend -v --cov-append --durations=0
+                pytest -m frontend -v --cov-append --durations=0
 
         -   name: Upload coverage reports to Codecov
             uses: codecov/codecov-action@v4.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,19 @@ npm --prefix aiida_workgraph/web/frontend start
 
 The frontend server will refresh
 
-### Troubleshooting
+#### Tools for writing frontend tests
 
-#### Tests are not updating after changes in code
+To determine the right commands for invoking DOM elements playwright offers a
+tool that outputs commands while navigating through the GUI. It requires a
+webserver to be running so it can be started with
+```console
+workgraph web start
+playwright codegen
+```
+
+#### Troubleshooting
+
+##### Tests are not updating after changes in code
 
 You might want to clean your cache
 

--- a/tests/web/backend/conftest.py
+++ b/tests/web/backend/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi.testclient import TestClient
+import os
+
+
+@pytest.fixture(scope="module", autouse=True)
+def aiida_profile(aiida_config, aiida_profile_factory):
+    """Create and load a profile with RabbitMQ as broker for backend tests."""
+    with aiida_profile_factory(aiida_config, broker_backend="core.rabbitmq") as profile:
+        yield profile
+
+
+@pytest.fixture(scope="module")
+def set_backend_server_settings(aiida_profile):
+    os.environ["AIIDA_WORKGRAPH_GUI_PROFILE"] = aiida_profile.name
+
+
+@pytest.fixture(scope="module")
+def client(set_backend_server_settings):
+    from aiida_workgraph.web.backend.app.api import app
+
+    return TestClient(app)

--- a/tests/web/backend/test_backend.py
+++ b/tests/web/backend/test_backend.py
@@ -1,33 +1,17 @@
 import pytest
-from fastapi.testclient import TestClient
-
-##############################
-# Fixtures for backend tests #
-##############################
 
 
-@pytest.fixture(scope="module")
-def client(set_backend_server_settings):
-    from aiida_workgraph.web.backend.app.api import app
-
-    return TestClient(app)
-
-
-#################
-# Backend tests #
-#################
-
-# Sample test case for the root route
 @pytest.mark.backend
 def test_root_route(client):
+    """Sample test case for the root route"""
     response = client.get("/api")
     assert response.status_code == 200
     assert response.json() == {"message": "Welcome to AiiDA-WorkGraph."}
 
 
-# Sample test case for the root route
 @pytest.mark.backend
 def test_workgraph_route(client, wg_calcfunction):
+    """Sample test case for the root route"""
     wg_calcfunction.run()
     response = client.get("/api/workgraph-data")
     assert response.status_code == 200

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,8 +1,0 @@
-import pytest
-
-import os
-
-
-@pytest.fixture(scope="module")
-def set_backend_server_settings(aiida_profile):
-    os.environ["AIIDA_WORKGRAPH_GUI_PROFILE"] = aiida_profile.name

--- a/tests/web/frontend/test_frontend.py
+++ b/tests/web/frontend/test_frontend.py
@@ -1,0 +1,208 @@
+import pytest
+import re
+
+from playwright.sync_api import expect
+
+
+@pytest.mark.frontend
+def test_homepage(web_server, page):
+    page.goto("http://localhost:8000")
+
+    assert page.title() == "AiiDA-WorkGraph App"
+
+    # Check for the existence of a specific element on the page
+    # Attempt to locate the element
+    element = page.locator("a[href='/workgraph']")
+
+    # Check if the element is found
+    if not element.is_visible():
+        pytest.fail("Element 'a[href='/wortre']' not found on the page")
+
+
+@pytest.mark.frontend
+def test_workgraph(web_server, page, ran_wg_calcfunction):
+    page.goto("http://localhost:8000")
+    # Since the routing is done by react-router-dom we cannot access it with a call like this
+    # page.goto("http://localhost:8000/workgraph" but have to navigate to it
+    page.click('a[href="/workgraph"]')
+
+    # Check for the existence of a specific element on the page
+
+    # Verify the presence of the WorkGraphTable heading
+    assert page.locator("h2").inner_text() == "WorkGraph"
+
+    # Verify the presence of the search input
+    assert page.locator(".search-input").is_visible()
+
+    # Verify the presence of the table header columns
+    # Verify the presence of the table header columns
+    assert page.locator("th:has-text('PK')").is_visible()
+    assert page.locator("th:has-text('Created')").is_visible()
+    assert page.locator("th:has-text('Process Label')").is_visible()
+    assert page.locator("th:has-text('State')").is_visible()
+    assert page.locator("th:has-text('Actions')").is_visible()
+
+    # Verify the presence of pagination controls
+    assert page.locator(".pagination").is_visible()
+
+    # Verify the presence of at least one row in the table
+
+    # Ensures that the first row has appeared
+    page.get_by_role("cell", name="WorkGraph<test_debug_math>").hover()
+
+    header_and_rows = page.get_by_role("row").all()
+    # we wait for the cell to appear
+    assert len(header_and_rows) == 2
+
+
+@pytest.mark.frontend
+def test_workgraph_item(web_server, page, ran_wg_calcfunction):
+    page.goto("http://localhost:8000/workgraph/")
+    page.get_by_role("link", name=str(ran_wg_calcfunction.pk), exact=True).click()
+    # page.goto("http://localhost:8000/workgraph/{}".format(ran_wg_calcfunction.pk))
+    # page.get_by_text()
+    # page.get_by_role("button", name="Arrange").click()
+    # ran_wg_calcfunction.pk))
+
+    page.get_by_text("sumdiff3").is_visible()
+
+    # Simulate user interaction (e.g., clicking a button)
+    # Replace the selector with the actual selector of the button you want to click
+    # You should identify the button that triggers an action in your component
+    page.get_by_role("button", name="Arrange").click()
+
+    gui_node = page.get_by_text("sumdiff2")
+
+    # Verify that clicking on the "Real-time state" changes the color to green
+    gui_node_color = gui_node.evaluate(
+        "element => window.getComputedStyle(element).backgroundColor"
+    )
+    assert gui_node_color == "rgba(0, 0, 0, 0)"
+    page.get_by_role("switch").click()  # Switch "Real-time state"
+
+    # this waits until a green background appears
+    page.wait_for_function(
+        "selector => !!document.querySelector(selector)",
+        arg="div.title[style='background: green;']",
+        timeout=5000,
+    )
+    gui_node_color = gui_node.evaluate(
+        "element => window.getComputedStyle(element).backgroundColor"
+    )
+    assert gui_node_color == "rgb(0, 128, 0)"
+
+    # Verify that clicking on the gui node will pop up a sidebar
+    gui_node.click()
+    node_details_sidebar = page.get_by_text("CloseNode")
+    node_details_sidebar.wait_for(state="visible")
+    assert node_details_sidebar.is_visible()
+    node_details_sidebar.get_by_role("button", name="Close").click()
+    node_details_sidebar.wait_for(state="hidden")
+    assert node_details_sidebar.is_hidden()
+
+    # verify Summary works
+    page.get_by_role("button", name="Summary").click()
+    assert page.get_by_text("typeWorkGraph<test_debug_math>").is_visible()
+
+    # Verify that Log  works
+    page.get_by_role("button", name="Log").click()
+    log_line = (
+        page.locator(".log-content")
+        .locator("div")
+        .filter(has_text=re.compile(r".*Task: sumdiff2 finished.*"))
+    )
+    log_line.wait_for(state="visible")
+    assert log_line.is_visible()
+
+    # Verify that Time  works
+    page.get_by_role("button", name="Time").click()
+    row = page.locator(".rct-sidebar-row ").get_by_text("sumdiff2")
+    row.wait_for(state="visible")
+    assert row.is_visible()
+
+
+@pytest.mark.frontend
+def test_datanode_item(web_server, page, ran_wg_calcfunction):
+    page.goto("http://localhost:8000/datanode/")
+    data_node_pk = ran_wg_calcfunction.nodes["sumdiff1"].inputs["x"].value.pk
+    page.get_by_role("link", name=str(data_node_pk), exact=True).click()
+
+    # check if three rows (header plus 2) are present
+    expect(page.locator(":nth-match(tr, 3)")).to_be_visible()
+    rows = page.get_by_role("row").all()
+    assert "value" in rows[1].text_content()
+    assert "node_type" in rows[2].text_content()
+
+
+@pytest.mark.frontend
+def test_settings(web_server, page, ran_wg_calcfunction):
+    page.goto("http://localhost:8000/settings/")
+    # Verify that only one row is visible
+    expect(page.locator(":nth-match(tr, 1)")).to_be_visible()
+    expect(page.locator(":nth-match(tr, 2)")).to_be_hidden()
+
+    # Verify that after starting the daemon one additional row appeared
+    page.get_by_role("button", name="Start Daemon").click()
+    expect(page.locator(":nth-match(tr, 2)")).to_be_visible()
+    expect(page.locator(":nth-match(tr, 3)")).to_be_hidden()
+
+    # Verify that after adding workers one additional row appeared
+    page.get_by_role("button", name="Increase Workers").click()
+    expect(page.locator(":nth-match(tr, 3)")).to_be_visible()
+    expect(page.locator(":nth-match(tr, 4)")).to_be_hidden()
+
+    # Verify that after decreasing workers one row disappears
+    page.get_by_role("button", name="Decrease Workers").click()
+    expect(page.locator(":nth-match(tr, 2)")).to_be_visible()
+    expect(page.locator(":nth-match(tr, 3)")).to_be_hidden()
+
+    # Verify that stopping the daemon only the header row exists
+    page.get_by_role("button", name="Stop Daemon").click()
+    expect(page.locator(":nth-match(tr, 1)")).to_be_visible()
+    expect(page.locator(":nth-match(tr, 2)")).to_be_hidden()
+
+
+############################
+# Tests mutating the state #
+############################
+# The tests below change the state of the aiida database and cannot necessary be executed in arbitrary order.
+
+
+@pytest.mark.frontend
+def test_workgraph_delete(web_server, page, ran_wg_calcfunction):
+    """Tests that the first workgraph node in the table can be deleted successfully."""
+    page.goto("http://localhost:8000")
+    # Since the routing is done by react-router-dom we cannot access it with a call like this
+    # page.goto("http://localhost:8000/workgraph" but have to navigate to it
+    page.click('a[href="/workgraph"]')
+
+    # Ensures that the first data row has appeared, the first row is header
+    expect(page.locator(":nth-match(tr, 2)")).to_be_visible()
+
+    header_and_rows = page.get_by_role("row").all()
+
+    first_row = header_and_rows[1]
+    delete_button = first_row.locator(".delete-button")
+    delete_button.click()
+    first_row.wait_for(state="hidden")
+    assert first_row.is_hidden()
+
+
+@pytest.mark.frontend
+def test_datanode_delete(web_server, page, ran_wg_calcfunction):
+    """Tests that the first data node in the table can be deleted successfully."""
+    page.goto("http://localhost:8000")
+    # Since the routing is done by react-router-dom we cannot access it with a call like this
+    # page.goto("http://localhost:8000/workgraph" but have to navigate to it
+    page.click('a[href="/datanode"]')
+
+    # Ensures that the first data row has appeared, the first row is header
+    expect(page.locator(":nth-match(tr, 2)")).to_be_visible()
+
+    header_and_rows = page.get_by_role("row").all()
+
+    first_row = header_and_rows[1]
+    delete_button = first_row.locator(".delete-button")
+    delete_button.click()
+    first_row.wait_for(state="hidden")
+    assert first_row.is_hidden()


### PR DESCRIPTION
For the frontend and backend tests new profiles are created to separate the effects of workgraph tests from the GUI.

Also only one workgraph is run for the frontend tests to save time.

Implements request in issue #159

TODO:
- [x] Move settings tests to mutable section (because the settings stop the daemon at the end, they only change the state if unsuccessful so I keep them where they are)