### PR TITLE
Show timeline of called_process

### DIFF
--- a/aiida_workgraph/web/backend/app/workgraph.py
+++ b/aiida_workgraph/web/backend/app/workgraph.py
@@ -100,7 +100,7 @@ async def read_workgraph(id: int):
 
 
 @router.get("/api/workgraph-state/{id}")
-async def read_workgraph_tasks_state(id: int, item_type: str = "tasks"):
+async def read_workgraph_tasks_state(id: int, item_type: str = "task"):
     from aiida_workgraph.utils import get_processes_latest
 
     try:

--- a/aiida_workgraph/web/backend/app/workgraph.py
+++ b/aiida_workgraph/web/backend/app/workgraph.py
@@ -100,11 +100,11 @@ async def read_workgraph(id: int):
 
 
 @router.get("/api/workgraph-state/{id}")
-async def read_workgraph_tasks_state(id: int):
+async def read_workgraph_tasks_state(id: int, item_type: str = "tasks"):
     from aiida_workgraph.utils import get_processes_latest
 
     try:
-        processes_info = get_processes_latest(id)
+        processes_info = get_processes_latest(id, item_type=item_type)
         return processes_info
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Workgraph {id} not found")

--- a/aiida_workgraph/web/frontend/src/components/WorkGraphDuration.js
+++ b/aiida_workgraph/web/frontend/src/components/WorkGraphDuration.js
@@ -89,7 +89,7 @@ const NodeDurationGraph = ({ id }) => {
             </div>
             <div style={{ margin: '10px' }}>
     <label>
-        Tasks:
+        Task:
         <input
             type="radio"
             value="task"


### PR DESCRIPTION

In the while zone, tasks repeat several times, however, in the timeline it only shows the time for the last iteration of the task. As show below, there is some missing info between `add1` and `add2`.

![Screenshot from 2024-08-18 14-12-06](https://github.com/user-attachments/assets/356b421d-600f-4b30-8485-9bcd39e93040)

This PR adds the `called_process` option. Switching to this option, it will show the timeline for all the processes that called by the WorkGraph:
![Screenshot from 2024-08-18 14-12-18](https://github.com/user-attachments/assets/92a660bd-3cd4-410e-ad51-64141bef1797)
