### PR TITLE
create and submit the process using `self.submit`

### DIFF
--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -1065,8 +1065,8 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 wg.name = name
                 wg.group_outputs = self.ctx._tasks[name]["metadata"]["group_outputs"]
                 wg.parent_uuid = self.node.uuid
-                wg.save(metadata={"call_link_label": name})
-                process = self.submit(wg.process_inited)
+                inputs = wg.prepare_inputs(metadata={"call_link_label": name})
+                process = self.submit(WorkGraphEngine, inputs=inputs)
                 self.set_task_state_info(name, "process", process)
                 self.set_task_state_info(name, "state", "RUNNING")
                 self.to_context(**{name: process})

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -189,7 +189,8 @@ def test_decorator_graph_builder(decorated_add_multiply_group: Callable) -> None
     sum_diff1 = wg.add_task("workgraph.test_sum_diff", "sum_diff1")
     wg.add_link(add1.outputs[0], add_multiply1.inputs["x"])
     wg.add_link(add_multiply1.outputs["result"], sum_diff1.inputs["x"])
-    wg.submit(wait=True)
+    # use run to check if graph builder workgraph can be submit inside the engine
+    wg.run()
     assert wg.tasks["add_multiply1"].process.outputs.result.value == 32
     assert wg.tasks["add_multiply1"].outputs["result"].value == 32
     assert wg.tasks["sum_diff1"].outputs["sum"].value == 32


### PR DESCRIPTION
Fix #252 

Instead of creating and submitting the process in two steps, this PR use the `self.submit` only.