### PR TITLE
Only check `process_class` for calcfunction and workfunction

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -8,6 +8,7 @@ from aiida.engine.processes.ports import PortNamespace
 import cloudpickle as pickle
 from aiida_workgraph.task import Task
 from aiida_workgraph.orm.function_data import PickledFunction
+import inspect
 
 task_types = {
     CalcFunctionNode: "CALCFUNCTION",
@@ -19,7 +20,7 @@ task_types = {
 aiida_socket_mapping = {
     orm.Int: "workgraph.aiida_int",
     orm.Float: "workgraph.aiida_float",
-    orm.Str: "workgraph.aiida_str",
+    orm.Str: "workgraph.aiida_string",
     orm.Bool: "workgraph.aiida_bool",
 }
 
@@ -145,7 +146,6 @@ def build_task_from_callable(
     If it is a function, build task from function.
     If it is a class, it only supports CalcJob and WorkChain.
     """
-    import inspect
     from aiida_workgraph.task import Task
 
     # if it is already a task, return it
@@ -211,7 +211,8 @@ def build_task_from_AiiDA(
         add_input_recursive(inputs, port, args, kwargs, required=port.required)
     for _key, port in spec.outputs.ports.items():
         add_output_recursive(outputs, port, required=port.required)
-    if spec.inputs.dynamic:
+    # Only check this for calcfunction and workfunction
+    if inspect.isfunction(executor) and spec.inputs.dynamic:
         if hasattr(executor.process_class, "_varargs"):
             name = executor.process_class._varargs
         else:


### PR DESCRIPTION
Note: WorkChain and CalcJob do not have `process_class`