### PR TITLE
Pickle the input value if it is a function

### DIFF
--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -8,7 +8,6 @@ def prepare_for_workgraph_task(task: dict, kwargs: dict) -> tuple:
     from aiida_workgraph.utils import merge_properties
     from aiida.orm.utils.serialize import deserialize_unsafe
 
-    print("Task type: workgraph.")
     wgdata = deserialize_unsafe(task["executor"]["wgdata"])
     wgdata["name"] = task["name"]
     wgdata["metadata"]["group_outputs"] = task["metadata"]["group_outputs"]
@@ -30,7 +29,6 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
     from aiida_workgraph.utils import get_or_create_code
     import os
 
-    print("Task  type: Python.")
     # get the names kwargs for the PythonJob, which are the inputs before _wait
     function_kwargs = {}
     for input in task["inputs"]:
@@ -114,7 +112,6 @@ def prepare_for_shell_task(task: dict, kwargs: dict) -> dict:
     from aiida.common import lang
     from aiida.orm import AbstractCode
 
-    print("Task  type: ShellJob.")
     command = kwargs.pop("command", None)
     resolve_command = kwargs.pop("resolve_command", False)
     metadata = kwargs.pop("metadata", {})

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -511,10 +511,14 @@ class WorkGraphEngine(Process, metaclass=Protect):
 
     def read_wgdata_from_base(self) -> t.Dict[str, t.Any]:
         """Read workgraph data from base.extras."""
+        from aiida_workgraph.orm.function_data import PickledLocalFunction
 
         wgdata = self.node.base.extras.get("_workgraph")
         for name, task in wgdata["tasks"].items():
             wgdata["tasks"][name] = deserialize_unsafe(task)
+            for _, prop in wgdata["tasks"][name]["properties"].items():
+                if isinstance(prop["value"], PickledLocalFunction):
+                    prop["value"] = prop["value"].value
         wgdata["error_handlers"] = deserialize_unsafe(wgdata["error_handlers"])
         return wgdata
 

--- a/aiida_workgraph/orm/function_data.py
+++ b/aiida_workgraph/orm/function_data.py
@@ -153,3 +153,7 @@ class PickledFunction(GeneralData):
 def to_pickled_function(value):
     """Convert a Python function to a `PickledFunction` instance."""
     return PickledFunction(value)
+
+
+class PickledLocalFunction(PickledFunction):
+    """PickledFunction subclass for local functions."""

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -199,6 +199,8 @@ class WorkGraphSaver:
         - all tasks
         """
         from aiida_workgraph.utils import workgraph_to_short_json
+        import inspect
+        from aiida_workgraph.orm.function_data import PickledLocalFunction
 
         # pprint(self.wgdata)
         # self.wgdata["created"] = datetime.datetime.utcnow()
@@ -207,6 +209,9 @@ class WorkGraphSaver:
         self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():
+            for _, prop in task["properties"].items():
+                if inspect.isfunction(prop["value"]):
+                    prop["value"] = PickledLocalFunction(prop["value"]).store()
             self.wgdata["tasks"][name] = serialize(task)
         # nodes is a copy of tasks, so we need to pop it out
         self.wgdata.pop("nodes")

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -71,12 +71,12 @@ class WorkGraph(node_graph.NodeGraph):
     def prepare_inputs(self, metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         from aiida_workgraph.utils import (
             merge_properties,
-            serialize_pythonjob_properties,
+            serialize_properties,
         )
 
         wgdata = self.to_dict()
         merge_properties(wgdata)
-        serialize_pythonjob_properties(wgdata)
+        serialize_properties(wgdata)
         metadata = metadata or {}
         inputs = {"wg": wgdata, "metadata": metadata}
         return inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 [project.entry-points."aiida.data"]
 "workgraph.general" = "aiida_workgraph.orm.general_data:GeneralData"
 "workgraph.pickled_function" = "aiida_workgraph.orm.function_data:PickledFunction"
+"workgraph.pickled_local_function" = "aiida_workgraph.orm.function_data:PickledLocalFunction"
 "workgraph.ase.atoms.Atoms" = "aiida_workgraph.orm.atoms:AtomsData"
 "workgraph.builtins.int" = "aiida.orm.nodes.data.int:Int"
 "workgraph.builtins.float" = "aiida.orm.nodes.data.float:Float"


### PR DESCRIPTION
In workgraph, we use `aiida.orm.utils.serialize.serialize` (yaml serialize) to serialize the input data of a workgraph and save it to the `node.base.extras`. However, the `yaml` seralizer can not handle the local function properly, as shown in #261 . 

This PR provide a solution. If a Python function is used as a task input, we first serialize it using pickle, then use yaml.

We created a `PickledLocalFunction` class to serialize the function, and this class is the same as the `PickledFunction`. We use a different name just to label it, so that later we know we need to deserialize it and get the Python function back, before we pass it as a task input.



## Test
I change the `test_shell_workflow` to `test_shell_graph_builder` and defined the parser inside the `graph_bulder.`