### PR TITLE
Add aggregate notebook that explains how to aggregate dynamically sized outputs

### DIFF
--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -1,0 +1,293 @@
+"""
+==============================================
+Aggregate dynamically sized and nested outputs
+==============================================
+"""
+# %%
+# Introduction
+# ============
+# In this tutorial, you will learn how to aggregate dynamically sized outputs by even by linking tasks or by using context.
+# Then we discuss at the end how to deal with nested datatypes.
+#
+# Load the AiiDA profile.
+#
+
+
+from aiida import load_profile
+
+load_profile()
+
+
+# %%
+# Using multi-linking for dynamic outputs
+# =======================================
+#
+
+
+from aiida_workgraph import task, WorkGraph
+from aiida.orm import Int
+
+
+@task.calcfunction()
+def generator(seed: Int):
+    import random
+
+    random.seed(seed.value)
+    return Int(random.randint(0, 1))  # one can also use
+
+
+@task.calcfunction()
+def aggregate(**collected_values):  # We use a keyword argument to obtain a dictionary
+    for key, value in collected_values.items():
+        print("key:", key, "value:", value)
+    return {"result": sum(collected_values.values())}
+
+
+wg = WorkGraph("aggregate_by_multilinking")
+
+aggregate_task = wg.add_task(aggregate, name="aggregate_task")
+
+# we have to increase the link limit because by default workgraph only supports one link per input socket
+# this is still an experimental feature that is why
+aggregate_task.inputs["collected_values"].link_limit = 50
+
+for i in range(2):  # this can be chosen as wanted
+    generator_task = wg.add_task(generator, name=f"generator{i}", seed=Int(i))
+    wg.add_link(
+        generator_task.outputs["result"],
+        aggregate_task.inputs["collected_values"],
+    )
+
+wg.to_html()
+
+
+# %%
+# Run the workgrhap
+
+wg.submit(wait=True)
+print("aggregate_task result", aggregate_task.outputs["result"].value)
+
+
+# %%
+# Plot provenance
+
+from aiida_workgraph.utils import generate_node_graph
+
+generate_node_graph(wg.pk)
+
+
+# %%
+# Mulitple dynamically sized outputs
+# ----------------------------------
+#
+
+from aiida.orm import Float
+
+
+@task.calcfunction()
+def generator_int(seed: Int):
+    import random
+
+    random.seed(seed.value)
+    return Int(random.randint(0, 1))
+
+
+@task.calcfunction()
+def generator_float(seed: Int):
+    import random
+
+    random.seed(seed.value)
+    return Float(random.random())
+
+
+@task.calcfunction(
+    inputs=[{"name": "collected_ints"}, {"name": "collected_floats"}],
+    outputs=[{"name": "int_sum"}, {"name": "float_sum"}],
+)
+def aggregate(**collected_values):
+    print(collected_values)
+    return {
+        "int_sum": sum(collected_values["collected_ints"].values()),
+        "float_sum": sum(collected_values["collected_floats"].values()),
+    }
+
+
+wg = WorkGraph("aggregate")
+
+aggregate_task = wg.add_task(aggregate, name="aggregate_task")
+
+# we have to increase the link limit because by default workgraph only supports one link per input socket
+# this is still an experimental feature that is why
+aggregate_task.inputs["collected_ints"].link_limit = 50
+aggregate_task.inputs["collected_floats"].link_limit = 50
+
+
+for i in range(2):  # this can be chosen as wanted
+    seed = Int(i)
+    generator_int_task = wg.add_task(generator_int, name=f"generator_int{i}", seed=seed)
+    generator_float_task = wg.add_task(
+        generator_float, name=f"generator_float{i}", seed=seed
+    )
+
+    wg.add_link(
+        generator_int_task.outputs["result"],
+        aggregate_task.inputs["collected_ints"],
+    )
+
+    wg.add_link(
+        generator_float_task.outputs["result"],
+        aggregate_task.inputs["collected_floats"],
+    )
+wg.to_html()
+# %%
+# Run the workgraph
+
+wg.run()
+print("aggregate_task int_sum", aggregate_task.outputs["int_sum"].value)
+print("aggregate_task float_sum", aggregate_task.outputs["float_sum"].value)
+
+
+# %%
+# Plot provenance
+
+generate_node_graph(wg.pk)
+
+# %%
+# Using context for dynamic outputs
+# =================================
+
+
+@task.calcfunction()
+def generator(seed: Int):
+    import random
+
+    random.seed(seed.value)
+    return Int(random.randint(0, 1))  # one can also use
+
+
+@task.calcfunction()
+def aggregate(**collected_values):  # We use a keyword argument to obtain a dictionary
+    for key, value in collected_values.items():
+        print("key:", key, "value:", value)
+    return {"result": sum(collected_values.values())}
+
+
+# For this use case it is more convenient to use the graph_builder as we can expose the context under a more convenient name.
+@task.graph_builder(
+    outputs=[{"name": "result", "from": "context.generated"}]
+)  # this port is created by `set_context`
+def generator_loop(nb_iterations: Int):
+    wg = WorkGraph()
+    for i in range(nb_iterations.value):  # this can be chosen as wanted
+        generator_task = wg.add_task(generator, name=f"generator{i}", seed=Int(i))
+        generator_task.set_context({"result": f"generated.seed{i}"})
+    return wg
+
+
+wg = WorkGraph("generate_aggregate_by_context")
+
+
+generator_loop_task = wg.add_task(
+    generator_loop, name="generator_loop", nb_iterations=Int(2)
+)
+
+aggregate_task = wg.add_task(
+    aggregate,
+    name="aggregate_task",
+    collected_values=generator_loop_task.outputs["result"],
+)
+
+wg.to_html()
+
+
+# %%
+# Run the workgrhap
+
+wg.run()
+print("aggregate_task result", aggregate_task.outputs["result"].value)
+
+
+# %%
+# Plot provenance
+
+generate_node_graph(wg.pk)
+
+# %%
+# To support multiple dynamically sized outputs we can add another context and link it.
+
+
+# %%
+# Nested datatypes
+# ================
+# In principle, these methods can be also used for nested data types.
+# However AiiDA does not support a nesting of orm types which happens for lists and dicts.
+# It therefore tries to convert the nested data structures to native types when it becomes part of the provenance.
+# For example an `orm.Dict` of `orm.Int`s is converted to an `orm.Dict` of built-in integers.
+
+
+from aiida.orm import Dict
+
+some_dict = Dict({"key": Int(5)})
+print(some_dict.get_dict())
+some_dict.store()  # store it in the database thereby it becomes part of the provenance
+print(some_dict.get_dict())
+
+
+# %%
+# If it cannot convert the orm.Data type to a built-in type, an error message will be thrown
+
+
+from aiida.orm import StructureData
+import numpy as np
+
+nonserializable_data = StructureData(cell=np.random.rand(3, 3))
+some_dict = Dict({"key": nonserializable_data})
+
+try:
+    some_dict.store()
+except Exception as err:
+    print(err)
+
+# %%
+# One has to therefore remove the nestedness by using built-in types for the collections.
+# In this example we use a dict instead of an orm.Dict
+
+
+@task.calcfunction()
+def compute_cell_volumes(strucs):
+    return {"result": {key: struc.get_cell_volume() for key, struc in strucs.items()}}
+
+
+dict_of_strucs = {
+    f"struc{i}": StructureData(cell=np.random.rand(3, 3)) for i in range(3)
+}
+try:
+    compute_cell_volumes(dict_of_strucs)
+except Exception as err:
+    print(
+        err
+    )  # Oops still the same error, but we now used a dict instead of an orm.Dict?
+
+# %%
+# The problem that AiiDA tries to automatic convert built-in types to orm.Data types.
+# Even though we passed a dict, AiiDA automatically converts it to an orm.Dict.
+# This feature allows us to not wrap everything to orm.Data types, but is here obstructive.
+# To resolve this issue we have to specify the input arguments
+
+
+@task.calcfunction()
+def compute_cell_volumes(**kwargs):
+    strucs = kwargs["strucs"]
+    return {
+        "result": {key: Float(struc.get_cell_volume()) for key, struc in strucs.items()}
+    }
+
+
+dict_of_strucs = {
+    f"struc{i}": StructureData(cell=np.random.rand(3, 3)) for i in range(3)
+}
+cell_volumes = compute_cell_volumes(strucs=dict_of_strucs)
+
+# %%
+# Plotting the provenance graph for one of the cell volumes
+generate_node_graph(cell_volumes["struc0"].pk)

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -58,7 +58,7 @@ some_dict = {f"value{i}": Int(i) for i in range(3)}
 aggregate_sum = aggregate(**some_dict)
 # Note that it is generally not recommended to have nested orm.Data types like in this case orm.Int in an orm.Data
 # This will only work for json serializable types as orm.Int in this case. You will see in the provenance graph later
-# that the information about the orm.Int's is completely lost. 
+# that the information about the orm.Int's is completely lost.
 aggregate_dict_sum = aggregate_dict(Dict(some_dict))
 
 # %%

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -6,7 +6,7 @@ Aggregate data from multiple tasks
 # %%
 # Introduction
 # ============
-# In this tutorial, you will learn how to aggregate dynamically sized outputs by linking tasks or by using context.
+# In this tutorial, you will learn how to aggregate data from the outputs of multiple tasks by linking tasks or by using context.
 # Then we discuss at the end how to deal with nested datatypes.
 #
 # Load the AiiDA profile.

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -15,8 +15,7 @@ Aggregate data from multiple tasks
 # value. However, for scenarios requiring dynamic input port handling, e.g.,
 # functions with variable keyword arguments, the link limit can be safely
 # expanded to accommodate multiple inputs. An input port can be marked as dynamic
-# by using the double asterisk symbol `**` as it is also done to mark an
-# arbitrary number of keyword arguments. This adjustment is particularly
+# by using a positional argument (`*args`) or a keyword argument (`**kwargs`) in the function. This adjustment is particularly
 # useful in tasks designed to aggregate or process collections of data.
 
 
@@ -57,6 +56,9 @@ def aggregate_dict(
 
 some_dict = {f"value{i}": Int(i) for i in range(3)}
 aggregate_sum = aggregate(**some_dict)
+# Note that it is generally not recommended to have nested orm.Data types like in this case orm.Int in an orm.Data
+# This will only work for json serializable types as orm.Int in this case. You will see in the provenance graph later
+# that the information about the orm.Int's is completely lost. 
 aggregate_dict_sum = aggregate_dict(Dict(some_dict))
 
 # %%

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -75,7 +75,10 @@ wg.to_html()
 # %%
 # Run the workgrhap
 
-wg.submit(wait=True)
+wg.run()
+
+# %%
+# Print the output
 print("aggregate_task result", aggregate_task.outputs["sum"].value)
 
 
@@ -163,6 +166,9 @@ wg.to_html()
 # Run the workgraph
 
 wg.run()
+
+# %%
+# Print the output
 print("aggregate_task int_sum", aggregate_task.outputs["int_sum"].value)
 print("aggregate_task float_sum", aggregate_task.outputs["float_sum"].value)
 
@@ -175,7 +181,7 @@ generate_node_graph(wg.pk)
 # %%
 # Using context for dynamic outputs
 # =================================
-# If are not familiar with context please refer to`:doc:`context doc page <../context>`
+# If are not familiar with context please refer to the doc page `Use Context to pass data between tasks`.
 
 
 @task.calcfunction()
@@ -226,6 +232,10 @@ wg.to_html()
 # Run the workgrhap
 
 wg.run()
+
+# %%
+# Print the output
+
 print("aggregate_task result", aggregate_task.outputs["result"].value)
 
 

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -119,9 +119,9 @@ wg.to_html()
 
 
 # %%
-# Run the workgrhap
+# Run the workgraph
 
-wg.run()
+wg.submit(wait=True)
 
 # %%
 # Print the output
@@ -209,7 +209,7 @@ wg.to_html()
 # %%
 # Run the workgraph
 
-wg.run()
+wg.submit(wait=True)
 
 # %%
 # Print the output
@@ -225,7 +225,7 @@ generate_node_graph(wg.pk)
 # %%
 # Using context for dynamic outputs
 # =================================
-    # If your are not familiar with `context` please refer to the `doc page explaining it in detail <../context.html>`_.
+# If your are not familiar with `context` please refer to the `doc page explaining it in detail <../context.html>`_.
 
 
 @task.calcfunction()
@@ -273,9 +273,9 @@ wg.to_html()
 
 
 # %%
-# Run the workgrhap
+# Run the workgraph
 
-wg.run()
+wg.submit(wait=True)
 
 # %%
 # Print the output

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -59,7 +59,6 @@ wg = WorkGraph("aggregate_by_multilinking")
 aggregate_task = wg.add_task(aggregate, name="aggregate_task")
 
 # we have to increase the link limit because by default workgraph only supports one link per input socket
-# this is still an experimental feature that is why
 aggregate_task.inputs["collected_values"].link_limit = 50
 
 for i in range(2):  # this can be chosen as wanted
@@ -140,7 +139,7 @@ wg = WorkGraph("aggregate")
 aggregate_task = wg.add_task(aggregate, name="aggregate_task")
 
 # we have to increase the link limit because by default workgraph only supports
-# one link per input socket this is still an experimental feature that is why
+# one link per input socket.
 aggregate_task.inputs["collected_ints"].link_limit = 50
 aggregate_task.inputs["collected_floats"].link_limit = 50
 

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -6,8 +6,9 @@ Aggregate data from multiple tasks
 # %%
 # Introduction
 # ============
-# In this tutorial, you will learn how to aggregate data from the outputs of multiple tasks by linking tasks or by using context.
-# Then we discuss at the end how to deal with nested datatypes.
+# In this tutorial, you will learn how to aggregate data from the outputs of
+# multiple tasks by linking tasks or by using context. Then we discuss at the
+# end how to deal with nested datatypes.
 #
 # Load the AiiDA profile.
 #
@@ -21,7 +22,9 @@ load_profile()
 # %%
 # Using multi-linking for dynamic inputs
 # ======================================
-# In the following example, we create multiple tasks that return a random integer, and then aggregate all the results and calculate the sum by linking the inputs of the tasks to the input of one final task
+# In the following example, we create multiple tasks that return a random
+# integer, and then aggregate all the results and calculate the sum by linking
+# the inputs of the tasks to the input of one final task
 
 #
 
@@ -71,7 +74,9 @@ print("aggregate_task result", aggregate_task.outputs["sum"].value)
 
 
 # %%
-# The provenance is in this example also tracked. One can see how the generated integers are linked to the aggregate task and one final integer, the sum, is returned.
+# The provenance is in this example also tracked. One can see how the generated
+# integers are linked to the aggregate task and one final integer, the sum, is
+# returned.
 
 from aiida_workgraph.utils import generate_node_graph
 
@@ -81,7 +86,11 @@ generate_node_graph(wg.pk)
 # %%
 # Multiple dynamic inputs
 # -----------------------
-# We now do the same exercise as before but add another dynamic input to it. We generate float numbers and link them to the aggregate task. The aggregate task now returns two sums one for the integers and one for the float numbers. To support this additional dynamic input we have to specify in the `task.calcfunction` decorator in dynamic inputs names.
+# We now do the same exercise as before but add another dynamic input to it. We
+# generate float numbers and link them to the aggregate task. The aggregate
+# task now returns two sums one for the integers and one for the float numbers.
+# To support this additional dynamic input we have to specify in the
+# `task.calcfunction` decorator in dynamic inputs names.
 
 from aiida.orm import Float
 
@@ -118,8 +127,8 @@ wg = WorkGraph("aggregate")
 
 aggregate_task = wg.add_task(aggregate, name="aggregate_task")
 
-# we have to increase the link limit because by default workgraph only supports one link per input socket
-# this is still an experimental feature that is why
+# we have to increase the link limit because by default workgraph only supports
+# one link per input socket this is still an experimental feature that is why
 aggregate_task.inputs["collected_ints"].link_limit = 50
 aggregate_task.inputs["collected_floats"].link_limit = 50
 
@@ -174,7 +183,8 @@ def aggregate(**collected_values):  # We use a keyword argument to obtain a dict
     return {"result": sum(collected_values.values())}
 
 
-# For this use case it is more convenient to use the graph_builder as we can expose the context under a more convenient name.
+# For this use case it is more convenient to use the graph_builder as we can
+# expose the context under a more convenient name.
 @task.graph_builder(
     outputs=[{"name": "result", "from": "context.generated"}]
 )  # this port is created by `set_context`
@@ -221,10 +231,11 @@ generate_node_graph(wg.pk)
 # %%
 # Nested dynamic inputs for a calcfunction
 # ========================================
-# In principle, these methods can be also used for nested data types.
-# However AiiDA does not support a nesting of orm types which happens for lists and dicts.
-# It therefore tries to convert the nested data structures to native types when it becomes part of the provenance.
-# For example an `orm.Dict` of `orm.Int`s is converted to an `orm.Dict` of built-in integers.
+# In principle, these methods can be also used for nested data types. However
+# AiiDA does not support a nesting of orm types which happens for lists and
+# dicts. It therefore tries to convert the nested data structures to native
+# types when it becomes part of the provenance. For example an `orm.Dict` of
+# `orm.Int`s is converted to an `orm.Dict` of built-in integers.
 
 
 from aiida.orm import Dict
@@ -236,7 +247,7 @@ print(some_dict.get_dict())
 
 
 # %%
-# If it cannot convert the orm.Data type to a built-in type, an error message will be thrown
+# If it cannot convert the `orm.Data` type to a built-in type, an error message will be thrown
 
 
 from aiida.orm import StructureData
@@ -251,8 +262,9 @@ except Exception as err:
     print(err)
 
 # %%
-# One has to therefore remove the nestedness by using built-in types for the collections.
-# In this example we use a dict instead of an orm.Dict
+# One has to therefore remove the nestedness of the `orm.Data` type by using built-in
+# types for the collections. In this example we use a dict instead of an
+# `orm.Dict`
 
 
 @task.calcfunction()
@@ -271,9 +283,12 @@ except Exception as err:
     )  # Oops still the same error, but we now used a dict instead of an orm.Dict?
 
 # %%
-# For a fixed input port, AiiDA assumes each argument of the calcfunction corresponds to a specific AiiDA data node.
-# Even though we passed a set of AiiDA nodes within a dict, AiiDA automatically converts the whole dict into an orm.Dict.
-# In order to allow passing a set of AiiDA nodes as inputs, one must use a variable keyword argument, e.g., **kwargs, in the calcfunction signature.
+# For a fixed input port, AiiDA assumes each argument of the calcfunction
+# corresponds to a specific AiiDA data node. Even though we passed a set of
+# AiiDA nodes within a dict, AiiDA automatically converts the whole dict into
+# an `orm.Dict`. In order to allow passing a set of AiiDA nodes as inputs, one
+# must use a variable keyword argument, e.g., **kwargs, in the calcfunction
+# signature.
 
 
 @task.calcfunction()

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -12,7 +12,7 @@ Aggregate data from multiple tasks
 #
 # By default, the workgraph only allows one link per input socket, mirroring
 # typical function argument behavior where each argument accepts a single
-# value. However, for scenarios requiring dynamic input handling, e.g.,
+# value. However, for scenarios requiring dynamic input port handling, e.g.,
 # functions with variable keyword arguments, the link limit can be safely
 # expanded to accommodate multiple inputs. An input port can be marked as dynamic
 # by using the double asterisk symbol `**` as it is also done to mark an
@@ -26,9 +26,9 @@ from aiida import load_profile
 load_profile()
 
 # %%
-# Dynamic inputs vs orm.Dict
+# Dynamic input ports vs orm.Dict
 # --------------------------
-# We want to first focus shortly on the difference between a dynamic input and a orm.Dict as input
+# We want to first focus shortly on the difference between a dynamic input ports and a orm.Dict as input
 # as this is essential for understanding the aggregation mechanism. For that we firstly
 # imitate the `aggregate` function using a Dict as input.
 
@@ -40,7 +40,7 @@ from aiida_workgraph import task, WorkGraph
 @task.calcfunction()
 def aggregate(
     **collected_values,
-):  # We use the double asterisk to allow dynamic input handling
+):  # We use the double asterisk to mark it as an dynamic input port
     for key, value in collected_values.items():
         print("key:", key, "value:", value)
     return Int(sum(collected_values.values()))
@@ -49,7 +49,7 @@ def aggregate(
 @task.calcfunction
 def aggregate_dict(
     collected_values,
-):  # We use the double asterisk to allow dynamic input handling
+):  # We use the double asterisk to mark it as an dynamic input port
     for key, value in collected_values.items():
         print("key:", key, "value:", value)
     return Int(sum(collected_values.get_dict().values()))
@@ -70,12 +70,12 @@ generate_node_graph(aggregate_dict_sum.pk)
 
 # %%
 # We can see while the Dict version only considers the whole dictionary as one
-# entity, the dynamic input allows to consider the different orm.Data instances.
+# entity in the provenance graph, while the dynamic input port allows us to consider the different orm.Data instances.
 
 
 # %%
-# Using multi-linking to create dynamic inputs
-# ============================================
+# Using multi-linking to create dynamic input ports
+# =================================================
 # In the following example, we create multiple tasks that return a random
 # integer, and then aggregate all the results and calculate the sum by linking
 # the outputs of the tasks to the input of one final task
@@ -95,7 +95,7 @@ def generator(seed: Int):
 @task.calcfunction(outputs=[{"name": "sum"}])
 def aggregate(
     **collected_values,
-):  # We use the double asterisk to allow dynamic input handling
+):  # We use the double asterisk to mark it as an dynamic input port
     for key, value in collected_values.items():
         print("key:", key, "value:", value)
     return {"sum": Int(sum(collected_values.values()))}
@@ -137,12 +137,12 @@ generate_node_graph(wg.pk)
 
 
 # %%
-# Multiple dynamic inputs
-# -----------------------
-# We now do the same exercise as before but add another dynamic input to it. We
+# Multiple dynamic input ports
+# ----------------------------
+# We now do the same exercise as before but add another dynamic input port to it. We
 # generate float numbers and link them to the aggregate task. The aggregate
 # task now returns two sums one for the integers and one for the float numbers.
-# To support this additional dynamic input, we can define multiple input
+# To support this additional dynamic input ports, we can define multiple input
 # sockets in the decorator, as shown in the code example below:
 
 
@@ -225,7 +225,7 @@ generate_node_graph(wg.pk)
 # %%
 # Using context for dynamic outputs
 # =================================
-# If your are not familiar with `context` please refer to the doc page `Concepts <../../concept/index.html>`_.
+    # If your are not familiar with `context` please refer to the `doc page explaining it in detail <../context.html>`_.
 
 
 @task.calcfunction()

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -175,6 +175,7 @@ generate_node_graph(wg.pk)
 # %%
 # Using context for dynamic outputs
 # =================================
+# If are not familiar with context please refer to`:doc:`context doc page <../context>`
 
 
 @task.calcfunction()

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -56,8 +56,9 @@ def aggregate_dict(
 
 some_dict = {f"value{i}": Int(i) for i in range(3)}
 aggregate_sum = aggregate(**some_dict)
-# Note that it is generally not recommended to have nested orm.Data types like in this case orm.Int in an orm.Data
-# This will only work for json serializable types as orm.Int in this case. You will see in the provenance graph later
+# Note that it is generally not recommended to have nested orm.Data types like
+# in this case orm.Int in an orm.Data This will only work for json serializable
+# types as orm.Int in this case. You will see in the provenance graph later
 # that the information about the orm.Int's is completely lost.
 aggregate_dict_sum = aggregate_dict(Dict(some_dict))
 

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -225,7 +225,7 @@ generate_node_graph(wg.pk)
 # %%
 # Using context for dynamic outputs
 # =================================
-# If are not familiar with context please refer to the doc page `Use Context to pass data between tasks`.
+# If your are not familiar with `context` please refer to the doc page `Concepts <../../concept/index.html>`_.
 
 
 @task.calcfunction()

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -1,7 +1,7 @@
 """
-==============================================
+==================================
 Aggregate data from multiple tasks
-==============================================
+==================================
 """
 # %%
 # Introduction
@@ -20,7 +20,7 @@ load_profile()
 
 # %%
 # Using multi-linking for dynamic inputs
-# =======================================
+# ======================================
 # In the following example, we create multiple tasks that return a random integer, and then aggregate all the results and calculate the sum by linking the inputs of the tasks to the input of one final task
 
 #
@@ -80,7 +80,7 @@ generate_node_graph(wg.pk)
 
 # %%
 # Multiple dynamic inputs
-# ----------------------------------
+# -----------------------
 # We now do the same exercise as before but add another dynamic input to it. We generate float numbers and link them to the aggregate task. The aggregate task now returns two sums one for the integers and one for the float numbers. To support this additional dynamic input we have to specify in the `task.calcfunction` decorator in dynamic inputs names.
 
 from aiida.orm import Float
@@ -219,8 +219,8 @@ generate_node_graph(wg.pk)
 
 
 # %%
-# Nested dynamic inputs for a calcfunction 
-# ================
+# Nested dynamic inputs for a calcfunction
+# ========================================
 # In principle, these methods can be also used for nested data types.
 # However AiiDA does not support a nesting of orm types which happens for lists and dicts.
 # It therefore tries to convert the nested data structures to native types when it becomes part of the provenance.

--- a/docs/gallery/howto/autogen/aggregate.py
+++ b/docs/gallery/howto/autogen/aggregate.py
@@ -26,9 +26,9 @@ load_profile()
 # integer, and then aggregate all the results and calculate the sum by linking
 # the outputs of the tasks to the input of one final task
 #
-# By default, the workgraph only allows one link per input socket, 
+# By default, the workgraph only allows one link per input socket,
 # mirroring typical function argument behavior where each argument accepts a single value.
-# However, for scenarios requiring dynamic input handling, e.g., functions with variable 
+# However, for scenarios requiring dynamic input handling, e.g., functions with variable
 # keyword arguments, the link limit can be safely expanded to accommodate multiple inputs.
 # This adjustment is particularly useful in tasks designed to aggregate or process collections of data.
 
@@ -102,7 +102,6 @@ generate_node_graph(wg.pk)
 # as shown in the code example below:
 
 
-
 from aiida.orm import Float
 
 
@@ -120,6 +119,7 @@ def generator_float(seed: Int):
 
     random.seed(seed.value)
     return Float(random.random())
+
 
 # The variable keyword arguments (**collected_values) declare the input as dynamic.
 # Thus, we can safely and flexibly add numerous input sockets.

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -10,6 +10,7 @@ This section contains a collection of HowTos for various topics.
 
    autogen/graph_builder
    autogen/parallel
+   autogen/aggregate
    if
    while
    context

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -10,10 +10,10 @@ This section contains a collection of HowTos for various topics.
 
    autogen/graph_builder
    autogen/parallel
-   autogen/aggregate
    if
    while
    context
+   autogen/aggregate
    waiting_on
    combine_workgraph
    restart

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -10,10 +10,10 @@ This section contains a collection of HowTos for various topics.
 
    autogen/graph_builder
    autogen/parallel
+   autogen/aggregate
    if
    while
    context
-   autogen/aggregate
    waiting_on
    combine_workgraph
    restart


### PR DESCRIPTION
Implements suggestions in issue https://github.com/aiidateam/aiida-workgraph/issues/284

~@superstar54 I have an issue with `submit(wait=True)` the output is None (see first example where I kept submit).~ EDIT: I see that this is something related to my local setup and not a general bug.

While I think the section about nested data types at the end is important, it does not really fit into the aggregate notebook. It is also more dealing with aiida-core issues than workgraph. I have no good idea at the moment. I would keep it there and see if we can move it somewhere more meaningful in the future.