### PR TITLE
Create a short version of the workgraph data for the connectivity analysis

### DIFF
--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -291,15 +291,18 @@ class WorkGraphSaver:
         from node_graph.analysis import DifferenceAnalysis
 
         wg1 = self.get_wgdata_from_db(restart_process)
-        # also make a alias for nodes
-        wg1["nodes"] = wg1["tasks"]
-        self.wgdata["nodes"] = self.wgdata["tasks"]
+        # change tasks to nodes for DifferenceAnalysis
+        wg1["nodes"] = wg1.pop("tasks")
+        self.wgdata["nodes"] = self.wgdata.pop("tasks")
         dc = DifferenceAnalysis(nt1=wg1, nt2=self.wgdata)
         (
             new_tasks,
             modified_tasks,
             update_metadata,
         ) = dc.build_difference()
+        # change nodes back to tasks
+        wg1["tasks"] = wg1.pop("nodes")
+        self.wgdata["tasks"] = self.wgdata.pop("nodes")
         return new_tasks, modified_tasks, update_metadata
 
     def exist_in_db(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.0.14",
+    "node-graph>=0.0.16",
     "aiida-core>=2.3",
     "cloudpickle",
     "aiida-shell",

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,11 +1,11 @@
 import pytest
 from aiida_workgraph import WorkGraph, task
 from aiida_shell.launch import prepare_code
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, load_computer
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_shell_command():
+def test_shell_command(fixture_localhost):
     """Test the ShellJob with command as a string."""
     wg = WorkGraph(name="test_shell_command")
     job1 = wg.add_task(
@@ -18,6 +18,8 @@ def test_shell_command():
             "file_b": SinglefileData.from_string("string b"),
         },
     )
+    # also check if we can set the computer explicitly
+    job1.set({"metadata.computer": load_computer("localhost")})
     wg.submit(wait=True)
     assert job1.node.outputs.stdout.get_content() == "string astring b"
 


### PR DESCRIPTION
When analyzing the connectivity of the graph, The actual input data of the tasks is not needed. Therefore, the `ConnectivityAnalysis` class from `node_graph` tries to deepcopy to create a short version. However, it raised an error when deepcoping of the orm.computer, as reported in #290 .

~~In principle, we can fix this in `ConnectivityAnalysis` in `node_graph`, but we can also fix it in workgraph. This PR tries to create the short version data before passing to `ConnectivityAnalysis`, and avoids deepcopy the data of the tasks but only picks the info that is needed.~~
This is fixed in the `node-graph` package, and this PR bumped `node-graph` to the latest version.

