### PR TITLE
Remove property class from node-graph

### DIFF
--- a/aiida_workgraph/properties/builtins.py
+++ b/aiida_workgraph/properties/builtins.py
@@ -1,8 +1,17 @@
 from typing import Dict, List, Union, Callable
 from aiida_workgraph.property import TaskProperty
-from node_graph.serializer import SerializeJson
-from node_graph.properties.builtins import PropertyVector, PropertyAny
+from node_graph.serializer import SerializeJson, SerializePickle
 from aiida import orm
+
+
+class PropertyAny(TaskProperty, SerializePickle):
+    """A new class for Any type."""
+
+    identifier: str = "workgraph.any"
+    data_type = "Any"
+
+    def __init__(self, name, description="", default=None, update=None) -> None:
+        super().__init__(name, description, default, update)
 
 
 class PropertyInt(TaskProperty, SerializeJson):
@@ -276,6 +285,25 @@ class PropertyAiiDADict(TaskProperty, SerializeJson):
             self._value = value
         else:
             raise Exception("{} is not a dict.".format(value))
+
+
+# ====================================
+class PropertyVector(TaskProperty, SerializePickle):
+    """Vector property"""
+
+    identifier: str = "workgraph.vector"
+    data_type = "Vector"
+
+    def __init__(self, name, description="", size=3, default=[], update=None) -> None:
+        super().__init__(name, description, default, update)
+        self.size = size
+
+    def copy(self):
+        p = self.__class__(
+            self.name, self.description, self.size, self.value, self.update
+        )
+        p.value = self.value
+        return p
 
 
 class PropertyAiiDAIntVector(PropertyVector):

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,15 +1,14 @@
 import pytest
 from aiida_workgraph import WorkGraph, task
 from aiida import orm
+from typing import Any
 
 
 @pytest.mark.parametrize(
-    "data_type, socket_type",
+    "data_type, identifier",
     (
-        (
-            int,
-            "workgraph.int",
-        ),
+        (Any, "workgraph.any"),
+        (int, "workgraph.int"),
         (float, "workgraph.float"),
         (bool, "workgraph.bool"),
         (str, "workgraph.string"),
@@ -19,14 +18,15 @@ from aiida import orm
         (orm.Bool, "workgraph.aiida_bool"),
     ),
 )
-def test_type_mapping(data_type, socket_type) -> None:
+def test_type_mapping(data_type, identifier) -> None:
     """Test the mapping of data types to socket types."""
 
     @task()
     def add(x: data_type):
         pass
 
-    assert add.task().inputs["x"].identifier == socket_type
+    assert add.task().inputs["x"].identifier == identifier
+    assert add.task().inputs["x"].property.identifier == identifier
 
 
 def test_socket(decorated_multiply) -> None:


### PR DESCRIPTION
Follow https://github.com/aiidateam/aiida-workgraph/pull/294, this PR removes all property types from node-graph.

Note this PR can not guarantee that the property works properly. We need future PR to refactor the property class.

