### PR TITLE
PythonJob spports exit code output

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -310,6 +310,7 @@ def build_pythonjob_task(func: Callable) -> Task:
     for output in tdata_py["outputs"]:
         if output not in outputs:
             outputs.append(output)
+    outputs.append({"identifier": "workgraph.any", "name": "exit_code"})
     # change "copy_files" link_limit to 1e6
     for input in inputs:
         if input["name"] == "copy_files":

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -280,6 +280,7 @@ def build_task_from_AiiDA(
 def build_pythonjob_task(func: Callable) -> Task:
     """Build PythonJob task from function."""
     from aiida_workgraph.calculations.python import PythonJob
+    from aiida_workgraph.tasks.pythonjob import PythonJob as PythonJobTask
     from copy import deepcopy
 
     # if the function is not a task, build a task from the function
@@ -323,6 +324,8 @@ def build_pythonjob_task(func: Callable) -> Task:
     tdata["outputs"] = outputs
     tdata["kwargs"] = kwargs
     tdata["task_type"] = "PYTHONJOB"
+    tdata["identifier"] = "workgraph.pythonjob"
+    tdata["node_class"] = PythonJobTask
     task = create_task(tdata)
     task.is_aiida_component = True
     return task, tdata

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -531,7 +531,12 @@ class WorkGraphEngine(Process, metaclass=Protect):
 
     def get_task(self, name: str):
         """Get task from the context."""
-        task = Task.from_dict(self.ctx._tasks[name])
+        from aiida_workgraph.tasks.builtins import PythonJob
+
+        if self.ctx._tasks[name]["metadata"]["node_type"].upper() == "PYTHONJOB":
+            task = PythonJob.from_dict(self.ctx._tasks[name])
+        else:
+            task = Task.from_dict(self.ctx._tasks[name])
         return task
 
     def update_task(self, task: Task):

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -531,12 +531,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
 
     def get_task(self, name: str):
         """Get task from the context."""
-        from aiida_workgraph.tasks.builtins import PythonJob
-
-        if self.ctx._tasks[name]["metadata"]["node_type"].upper() == "PYTHONJOB":
-            task = PythonJob.from_dict(self.ctx._tasks[name])
-        else:
-            task = Task.from_dict(self.ctx._tasks[name])
+        task = Task.from_dict(self.ctx._tasks[name])
         # update task results
         for output in task.outputs:
             output.value = get_nested_dict(
@@ -549,11 +544,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
     def update_task(self, task: Task):
         """Update task in the context.
         This is used in error handlers to update the task parameters."""
-        from aiida_workgraph.utils import serialize_pythonjob_properties
-
         tdata = task.to_dict()
-        if task.identifier.upper() == "PYTHONJOB":
-            serialize_pythonjob_properties(tdata)
         self.ctx._tasks[task.name]["properties"] = tdata["properties"]
         self.reset_task(task.name)
 

--- a/aiida_workgraph/task.py
+++ b/aiida_workgraph/task.py
@@ -112,11 +112,15 @@ class Task(GraphNode):
         Returns:
             Node: An instance of Node initialized with the provided data."""
         from aiida_workgraph.tasks import task_pool
+        from aiida.orm.utils.serialize import deserialize_unsafe
 
         task = super().from_dict(data, node_pool=task_pool)
         task.context_mapping = data.get("context_mapping", {})
         task.waiting_on.add(data.get("wait", []))
-        task.process = data.get("process", None)
+        process = data.get("process", None)
+        if process and isinstance(process, str):
+            process = deserialize_unsafe(process)
+        task.process = process
 
         return task
 

--- a/aiida_workgraph/task.py
+++ b/aiida_workgraph/task.py
@@ -114,7 +114,7 @@ class Task(GraphNode):
         from aiida_workgraph.tasks import task_pool
         from aiida.orm.utils.serialize import deserialize_unsafe
 
-        task = super().from_dict(data, node_pool=task_pool)
+        task = GraphNode.from_dict(data, node_pool=task_pool)
         task.context_mapping = data.get("context_mapping", {})
         task.waiting_on.add(data.get("wait", []))
         process = data.get("process", None)

--- a/aiida_workgraph/tasks/builtins.py
+++ b/aiida_workgraph/tasks/builtins.py
@@ -306,27 +306,3 @@ class Select(Task):
             "path": "aiida_workgraph.executors.builtins",
             "name": "select",
         }
-
-
-class PythonJob(Task):
-    """PythonJob Task.
-    Note: this task is only used for loading the task from a dictionary."""
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any], **kwargs) -> "Task":
-        # deserialize the properties
-        input_kwargs = []
-        for input in data["inputs"]:
-            if input["name"] == "_wait":
-                break
-            input_kwargs.append(input["name"])
-        for name in input_kwargs:
-            prop = data["properties"][name]
-            if not (
-                prop["value"] is None
-                or isinstance(prop["value"], dict)
-                and prop["value"] == {}
-            ):
-                prop["value"] = prop["value"].value
-
-        return super().from_dict(data, **kwargs)

--- a/aiida_workgraph/tasks/builtins.py
+++ b/aiida_workgraph/tasks/builtins.py
@@ -306,3 +306,27 @@ class Select(Task):
             "path": "aiida_workgraph.executors.builtins",
             "name": "select",
         }
+
+
+class PythonJob(Task):
+    """PythonJob Task.
+    Note: this task is only used for loading the task from a dictionary."""
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any], **kwargs) -> "Task":
+        # deserialize the properties
+        input_kwargs = []
+        for input in data["inputs"]:
+            if input["name"] == "_wait":
+                break
+            input_kwargs.append(input["name"])
+        for name in input_kwargs:
+            prop = data["properties"][name]
+            if not (
+                prop["value"] is None
+                or isinstance(prop["value"], dict)
+                and prop["value"] == {}
+            ):
+                prop["value"] = prop["value"].value
+
+        return super().from_dict(data, **kwargs)

--- a/aiida_workgraph/tasks/pythonjob.py
+++ b/aiida_workgraph/tasks/pythonjob.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict
+from aiida import orm
+from aiida_workgraph.orm.serializer import general_serializer
+from aiida_workgraph.task import Task
+
+
+class PythonJob(Task):
+    """PythonJob Task."""
+
+    identifier = "workgraph.pythonjob"
+
+    @classmethod
+    def get_function_kwargs(cls, data) -> Dict[str, Any]:
+        input_kwargs = set()
+        for name in data["metadata"]["kwargs"]:
+            # all the kwargs are after computer is the input for the PythonJob, should be AiiDA Data node
+            if name == "computer":
+                break
+            input_kwargs.add(name)
+        return input_kwargs
+
+    def update_from_dict(cls, data: Dict[str, Any], **kwargs) -> "PythonJob":
+        """Overwrite the update_from_dict method to handle the PythonJob data."""
+        cls.deserialize_pythonjob_data(data)
+        return super().update_from_dict(data)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = super().to_dict()
+        self.serialize_pythonjob_data(data)
+        return data
+
+    @classmethod
+    def serialize_pythonjob_data(cls, tdata: Dict[str, Any]):
+        """Serialize the properties for PythonJob."""
+
+        input_kwargs = cls.get_function_kwargs(tdata)
+        for name in input_kwargs:
+            prop = tdata["properties"][name]
+            # if value is not None, not {}
+            if not (
+                prop["value"] is None
+                or isinstance(prop["value"], dict)
+                and prop["value"] == {}
+            ):
+                prop["value"] = general_serializer(prop["value"])
+
+    @classmethod
+    def deserialize_pythonjob_data(cls, tdata: Dict[str, Any]) -> None:
+        """
+        Process the task data dictionary for a PythonJob.
+        It load the orignal Python data from the AiiDA Data node for the
+        args and kwargs of the function.
+
+        Args:
+            tdata (Dict[str, Any]): The input data dictionary.
+
+        Returns:
+            Dict[str, Any]: The processed data dictionary.
+        """
+        input_kwargs = cls.get_function_kwargs(tdata)
+
+        for name in input_kwargs:
+            if name in tdata["properties"]:
+                value = tdata["properties"][name]["value"]
+                if isinstance(value, orm.Data):
+                    value = value.value
+                elif value is not None and value != {}:
+                    raise ValueError(f"There something wrong with the input {name}")
+                tdata["properties"][name]["value"] = value

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -218,41 +218,6 @@ def get_dict_from_builder(builder: Any) -> Dict:
         return builder
 
 
-def get_pythonjob_data(tdata: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Process the task data dictionary for a PythonJob.
-    It load the orignal Python data from the AiiDA Data node for the
-    args and kwargs of the function.
-
-    Args:
-        tdata (Dict[str, Any]): The input data dictionary.
-
-    Returns:
-        Dict[str, Any]: The processed data dictionary.
-    """
-    for name in tdata["metadata"]["args"]:
-        if tdata["properties"][name]["value"] is None:
-            continue
-        if name in tdata["properties"]:
-            tdata["properties"][name]["value"] = tdata["properties"][name][
-                "value"
-            ].value
-    for name in tdata["metadata"]["kwargs"]:
-        # all the kwargs are after computer is the input for the PythonJob, should be AiiDA Data node
-        if tdata["properties"][name]["value"] is None:
-            continue
-        if name == "computer":
-            break
-        if name in tdata["properties"]:
-            value = tdata["properties"][name]["value"]
-            if isinstance(value, orm.Data):
-                value = value.value
-            elif value != {}:
-                raise ValueError(f"There something wrong with the input {name}")
-            tdata["properties"][name]["value"] = value
-    return tdata
-
-
 def serialize_workgraph_data(wgdata: Dict[str, Any]) -> Dict[str, Any]:
     from aiida.orm.utils.serialize import serialize
 
@@ -273,8 +238,6 @@ def get_workgraph_data(process: Union[int, orm.Node]) -> Optional[Dict[str, Any]
         return
     for name, task in wgdata["tasks"].items():
         wgdata["tasks"][name] = deserialize_unsafe(task)
-        if wgdata["tasks"][name]["metadata"]["node_type"].upper() == "PYTHONJOB":
-            get_pythonjob_data(wgdata["tasks"][name])
     wgdata["error_handlers"] = deserialize_unsafe(wgdata["error_handlers"])
     return wgdata
 
@@ -385,46 +348,20 @@ def get_or_create_code(
         return code
 
 
-def serialize_pythonjob_properties(task):
-    """Serialize the properties for PythonJob."""
-
-    from aiida_workgraph.orm.serializer import general_serializer
-
-    input_kwargs = []
-    for input in task["inputs"]:
-        if input["name"] == "_wait":
-            break
-        input_kwargs.append(input["name"])
-    for name in input_kwargs:
-        prop = task["properties"][name]
-        # if value is not None, not {}
-        if not (
-            prop["value"] is None
-            or isinstance(prop["value"], dict)
-            and prop["value"] == {}
-        ):
-            prop["value"] = general_serializer(prop["value"])
-
-
 def serialize_properties(wgdata):
     """Serialize the properties.
     Because we use yaml (aiida's serialize) to serialize the data and
     save it to the node.base.extras. yaml can not handle the function
     defined in a scope, e.g., local function in another function.
     So, if a function is used as input, we needt to serialize the function.
-
-    For PythonJob, serialize the function inputs."""
+    """
     from aiida_workgraph.orm.function_data import PickledLocalFunction
     import inspect
 
     for _, task in wgdata["tasks"].items():
-        if task["metadata"]["node_type"].upper() == "PYTHONJOB":
-            # get the names kwargs for the PythonJob, which are the inputs before _wait
-            serialize_pythonjob_properties(task)
-        else:
-            for _, prop in task["properties"].items():
-                if inspect.isfunction(prop["value"]):
-                    prop["value"] = PickledLocalFunction(prop["value"]).store()
+        for _, prop in task["properties"].items():
+            if inspect.isfunction(prop["value"]):
+                prop["value"] = PickledLocalFunction(prop["value"]).store()
 
 
 def generate_bash_to_create_python_env(

--- a/docs/source/built-in/pythonjob.ipynb
+++ b/docs/source/built-in/pythonjob.ipynb
@@ -23,7 +23,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 1,
       "id": "c6b83fb5",
       "metadata": {},
       "outputs": [
@@ -33,7 +33,7 @@
               "Profile<uuid='57ccbf7d9e2b41b39edb2bfdaf725feb' name='default'>"
             ]
           },
-          "execution_count": 3,
+          "execution_count": 1,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -2368,7 +2368,61 @@
       "id": "fe376995",
       "metadata": {},
       "source": [
-        "We can see that the `result.txt` file is retrieved from the remote computer and stored in the local repository."
+        "We can see that the `result.txt` file is retrieved from the remote computer and stored in the local repository.\n",
+        "\n",
+        "## Exit Code\n",
+        "\n",
+        "The `PythonJob` task includes a built-in output socket, `exit_code`, which serves as a mechanism for error handling and status reporting during task execution. This `exit_code` is an integer value where `0` indicates a successful completion, and any non-zero value signals that an error occurred.\n",
+        "\n",
+        "### How it Works:\n",
+        "When the function returns a dictionary with an `exit_code` key, the system automatically parses and uses this code to indicate the task's status. In the case of an error, the non-zero `exit_code` value helps identify the specific problem.\n",
+        "\n",
+        "\n",
+        "### Benefits of `exit_code`:\n",
+        "\n",
+        "1. **Error Reporting:**  \n",
+        "   If the task encounters an error, the `exit_code` can communicate the reason. This is helpful during process inspection to determine why a task failed.\n",
+        "\n",
+        "2. **Error Handling and Recovery:**  \n",
+        "   You can utilize `exit_code` to add specific error handlers for particular exit codes. This allows you to modify the task's parameters and restart it.\n",
+        "\n",
+        "\n",
+        "Below is an example Python function that uses `exit_code` to handle potential errors:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "a96cbbcb",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "WorkGraph process created, PK: 146751\n",
+            "exit status:  1\n",
+            "exit message:  Sum is negative\n"
+          ]
+        }
+      ],
+      "source": [
+        "from aiida_workgraph import WorkGraph, task\n",
+        "\n",
+        "@task.pythonjob(outputs=[{\"name\": \"sum\"}])\n",
+        "def add(x: int, y: int) -> int:\n",
+        "    sum = x + y\n",
+        "    if sum < 0:\n",
+        "        exit_code = {\"status\": 1, \"message\": \"Sum is negative\"}\n",
+        "        return {\"sum\": sum, \"exit_code\": exit_code}\n",
+        "    return {\"sum\": sum}\n",
+        "\n",
+        "wg = WorkGraph(\"test_PythonJob\")\n",
+        "wg.add_task(add, name=\"add\", x=1, y=-2)\n",
+        "wg.submit(wait=True)\n",
+        "\n",
+        "print(\"exit status: \",  wg.tasks[\"add\"].node.exit_status)\n",
+        "print(\"exit message: \",  wg.tasks[\"add\"].node.exit_message)"
       ]
     },
     {
@@ -2376,6 +2430,8 @@
       "id": "8d4d935b",
       "metadata": {},
       "source": [
+        "In this example, the task failed with `exit_code = 1` due to the condition `Sum is negative`, which is also reflected in the state message.\n",
+        "\n",
         "## Define your data serializer\n",
         "Workgraph search data serializer from the `aiida.data` entry point by the module name and class name (e.g., `ase.atoms.Atoms`). \n",
         "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 "workgraph.test_greater" = "aiida_workgraph.tasks.test:TestGreater"
 "workgraph.test_sum_diff" = "aiida_workgraph.tasks.test:TestSumDiff"
 "workgraph.test_arithmetic_multiply_add" = "aiida_workgraph.tasks.test:TestArithmeticMultiplyAdd"
+"workgraph.pythonjob" = "aiida_workgraph.tasks.pythonjob:PythonJob"
 
 [project.entry-points."aiida_workgraph.property"]
 "workgraph.any" = "aiida_workgraph.properties.builtins:PropertyAny"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -509,5 +509,5 @@ def test_exit_code(fixture_localhost, python_executable_path):
         code_label=python_executable_path,
     )
     wg.run()
-    assert wg.tasks["add"].node.exit_status == 2
+    assert wg.tasks["add"].node.exit_status == 1
     assert wg.tasks["add"].node.exit_message == "Sum is negative"


### PR DESCRIPTION
This PR allows custom `exit_code` for PythonJob. Add a built-in output socket, `exit_code`, which serves as a mechanism for error handling and status reporting during task execution. This `exit_code` is dict with `status` and `message`. For the `status`, an integer value where `0` indicates a successful completion, and any non-zero value signals that an error occurred.

### How it Works:
When the function returns a dictionary with an `exit_code` key, the system automatically parses and uses this code to indicate the task's status. In the case of an error, the non-zero `exit_code` value helps identify the specific problem.


### Benefits of `exit_code`:

1. **Error Reporting:**  
   If the task encounters an error, the `exit_code` can communicate the reason. This is helpful during process inspection to determine why a task failed.

2. **Error Handling and Recovery:**  
   You can utilize `exit_code` to add specific error handlers for particular exit codes. This allows you to modify the task's parameters and restart it.


Below is an example Python function that uses `exit_code`:

```python
from aiida_workgraph import WorkGraph, task

@task.pythonjob(outputs=[{"name": "sum"}])
def add(x: int, y: int) -> int:
    sum = x + y
    if sum < 0:
        exit_code = {"status": 1, "message": "Sum is negative"}
        return {"sum": sum, "exit_code": exit_code}
    return {"sum": sum}

wg = WorkGraph("test_PythonJob")
wg.add_task(add, name="add", x=1, y=-2)
wg.submit(wait=True)

print("exit status: ",  wg.tasks["add"].node.exit_status)
print("exit message: ",  wg.tasks["add"].node.exit_message)
```
```python
>>> WorkGraph process created, PK: 146751
>>> exit status:  1
>>> exit message:  Sum is negative
```

In this example, the task failed with `exit_code = 1` due to the condition `Sum is negative`, which is also reflected in the state message.

```console
> verdi process show 146718                                                               (aiida) 
Property     Value
-----------  ------------------------------------
type         PythonJob<add>
state        Finished [1] Sum is negative
pk           146718
uuid         2ffe92ed-0634-4a02-95fe-c14ecb778f92
label        add
description
ctime        2024-09-09 13:21:14.818233+02:00
mtime        2024-09-09 13:21:18.138330+02:00
computer     [1] localhost
```

Here is another example form PW calculation
```console
> verdi process show 146793                                                             (aiida) 
Property     Value
-----------  --------------------------------------------------------------------------------
type         PythonJob<scf>
state        Finished [410] The electronic minimization cycle did not reach self-consistency.
pk           146793
uuid         5ed2228d-42ca-46f2-8e7f-d862c6991fba
label        scf
```