### PR TITLE
Refactor task's data, bumps `node-graph` to 0.0.19

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -293,7 +293,6 @@ def build_pythonjob_task(func: Callable) -> Task:
     tdata = {
         "metadata": {"task_type": "PYTHONJOB"},
         "executor": PythonJob,
-        "task_type": "CALCJOB",
     }
     _, tdata_py = build_task_from_AiiDA(tdata)
     tdata = deepcopy(func.tdata)
@@ -347,7 +346,6 @@ def build_shelljob_task(
     tdata = {
         "metadata": {"task_type": "SHELLJOB"},
         "executor": ShellJob,
-        "task_type": "SHELLJOB",
     }
     _, tdata = build_task_from_AiiDA(tdata)
     # create input sockets for the nodes, if it is linked other sockets

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -132,10 +132,10 @@ def build_task(
         return build_task_from_workgraph(executor)
     elif isinstance(executor, str):
         (
-            path,
+            module,
             executor_name,
         ) = executor.rsplit(".", 1)
-        executor, _ = get_executor({"path": path, "name": executor_name})
+        executor, _ = get_executor({"module": module, "name": executor_name})
     if callable(executor):
         return build_task_from_callable(executor, inputs=inputs, outputs=outputs)
 
@@ -268,7 +268,7 @@ def build_task_from_AiiDA(
     outputs.append({"identifier": "workgraph.any", "name": "_outputs"})
     outputs.append({"identifier": "workgraph.any", "name": "_wait"})
     inputs.append({"identifier": "workgraph.any", "name": "_wait", "link_limit": 1e6})
-    tdata["metadata"]["node_class"] = {"path": "aiida_workgraph.task", "name": "Task"}
+    tdata["metadata"]["node_class"] = {"module": "aiida_workgraph.task", "name": "Task"}
     tdata["args"] = args
     tdata["kwargs"] = kwargs
     tdata["inputs"] = inputs
@@ -328,7 +328,7 @@ def build_pythonjob_task(func: Callable) -> Task:
     tdata["metadata"]["task_type"] = "PYTHONJOB"
     tdata["identifier"] = "workgraph.pythonjob"
     tdata["metadata"]["node_class"] = {
-        "path": "aiida_workgraph.tasks.pythonjob",
+        "module": "aiida_workgraph.tasks.pythonjob",
         "name": "PythonJob",
     }
     task = create_task(tdata)
@@ -438,13 +438,13 @@ def build_task_from_workgraph(wg: any) -> Task:
     outputs.append({"identifier": "workgraph.any", "name": "_outputs"})
     outputs.append({"identifier": "workgraph.any", "name": "_wait"})
     inputs.append({"identifier": "workgraph.any", "name": "_wait", "link_limit": 1e6})
-    tdata["metadata"]["node_class"] = {"path": "aiida_workgraph.task", "name": "Task"}
+    tdata["metadata"]["node_class"] = {"module": "aiida_workgraph.task", "name": "Task"}
     tdata["kwargs"] = kwargs
     tdata["inputs"] = inputs
     tdata["outputs"] = outputs
     tdata["identifier"] = wg.name
     executor = {
-        "path": "aiida_workgraph.engine.workgraph",
+        "module": "aiida_workgraph.engine.workgraph",
         "name": "WorkGraphEngine",
         "wgdata": serialize(wg.to_dict(store_nodes=True)),
         "type": tdata["metadata"]["task_type"],
@@ -518,7 +518,7 @@ def generate_tdata(
         "metadata": {
             "task_type": task_type,
             "catalog": catalog,
-            "node_class": {"path": "aiida_workgraph.task", "name": "Task"},
+            "node_class": {"module": "aiida_workgraph.task", "name": "Task"},
         },
         "properties": properties,
         "inputs": _inputs,

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -5,7 +5,7 @@ from aiida.common.extendeddicts import AttributeDict
 
 def prepare_for_workgraph_task(task: dict, kwargs: dict) -> tuple:
     """Prepare the inputs for WorkGraph task"""
-    from aiida_workgraph.utils import merge_properties
+    from aiida_workgraph.utils import merge_properties, serialize_properties
     from aiida.orm.utils.serialize import deserialize_unsafe
 
     wgdata = deserialize_unsafe(task["executor"]["wgdata"])
@@ -21,6 +21,7 @@ def prepare_for_workgraph_task(task: dict, kwargs: dict) -> tuple:
             ] = value
     # merge the properties
     merge_properties(wgdata)
+    serialize_properties(wgdata)
     metadata = {"call_link_label": task["name"]}
     inputs = {"wg": wgdata, "metadata": metadata}
     return inputs, wgdata

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -37,8 +37,8 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
         function_kwargs[input["name"]] = kwargs.pop(input["name"], None)
     # if the var_kwargs is not None, we need to pop the var_kwargs from the kwargs
     # then update the function_kwargs if var_kwargs is not None
-    if task["metadata"]["var_kwargs"] is not None:
-        function_kwargs.pop(task["metadata"]["var_kwargs"], None)
+    if task["var_kwargs"] is not None:
+        function_kwargs.pop(task["var_kwargs"], None)
         if var_kwargs:
             # var_kwargs can be AttributeDict if it get data from the previous task output
             if isinstance(var_kwargs, (dict, AttributeDict)):

--- a/aiida_workgraph/engine/workgraph.py
+++ b/aiida_workgraph/engine/workgraph.py
@@ -31,7 +31,7 @@ from aiida.engine.processes.workchains.awaitable import (
 )
 from aiida.engine.processes.workchains.workchain import Protect, WorkChainSpec
 from aiida.engine import run_get_node
-from aiida_workgraph.utils import create_and_pause_process, get_item_by_name
+from aiida_workgraph.utils import create_and_pause_process
 from aiida_workgraph.task import Task
 from aiida_workgraph.utils import get_nested_dict, update_nested_dict
 from aiida_workgraph.executors.monitors import monitor
@@ -459,7 +459,6 @@ class WorkGraphEngine(Process, metaclass=Protect):
 
         super().on_create()
         wgdata = self.inputs.wg._dict
-        print("wgdata: ", wgdata["tasks"]["multiply"])
         restart_process = (
             orm.load_node(wgdata["restart_process"].value)
             if wgdata.get("restart_process")
@@ -515,7 +514,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         wgdata = self.node.base.extras.get("_workgraph")
         for name, task in wgdata["tasks"].items():
             wgdata["tasks"][name] = deserialize_unsafe(task)
-            for prop in wgdata["tasks"][name]["properties"]:
+            for _, prop in wgdata["tasks"][name]["properties"].items():
                 if isinstance(prop["value"], PickledLocalFunction):
                     prop["value"] = prop["value"].value
         wgdata["error_handlers"] = deserialize_unsafe(wgdata["error_handlers"])
@@ -546,6 +545,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         This is used in error handlers to update the task parameters."""
         tdata = task.to_dict()
         self.ctx._tasks[task.name]["properties"] = tdata["properties"]
+        self.ctx._tasks[task.name]["inputs"] = tdata["inputs"]
         self.reset_task(task.name)
 
     def get_task_state_info(self, name: str, key: str) -> str:
@@ -736,7 +736,13 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 self.report(f"Task: {name} failed.")
                 self.run_error_handlers(name)
         elif isinstance(node, orm.Data):
-            task["results"] = {task["outputs"][0]["name"]: node}
+            #
+            output_name = [
+                output_name
+                for output_name in list(task["outputs"].keys())
+                if output_name not in ["_wait", "_outputs"]
+            ][0]
+            task["results"] = {output_name: node}
             self.set_task_state_info(task["name"], "state", "FINISHED")
             self.task_set_context(name)
             self.report(f"Task: {name} finished.")
@@ -749,16 +755,24 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Set the results of a normal task.
         A normal task is created by decorating a function with @task().
         """
+        from aiida_workgraph.utils import get_sorted_names
+
         task = self.ctx._tasks[name]
         if isinstance(results, tuple):
             if len(task["outputs"]) != len(results):
                 return self.exit_codes.OUTPUS_NOT_MATCH_RESULTS
-            for i in range(len(task["outputs"])):
-                task["results"][task["outputs"][i]["name"]] = results[i]
+            output_names = get_sorted_names(task["outputs"])
+            for i, output_name in enumerate(output_names):
+                task["results"][output_name] = results[i]
         elif isinstance(results, dict):
             task["results"] = results
         else:
-            task["results"][task["outputs"][0]["name"]] = results
+            output_name = [
+                output_name
+                for output_name in list(task["outputs"].keys())
+                if output_name not in ["_wait", "_outputs"]
+            ][0]
+            task["results"][output_name] = results
         self.task_set_context(name)
         self.set_task_state_info(name, "state", "FINISHED")
         self.report(f"Task: {name} finished.")
@@ -981,8 +995,6 @@ class WorkGraphEngine(Process, metaclass=Protect):
             executor, _ = get_executor(task["executor"])
             # print("executor: ", executor)
             args, kwargs, var_args, var_kwargs, args_dict = self.get_inputs(name)
-            print("args: ", args)
-            print("kwargs: ", kwargs)
             for i, key in enumerate(self.ctx._tasks[name]["args"]):
                 kwargs[key] = args[i]
             # update the port namespace
@@ -1190,7 +1202,12 @@ class WorkGraphEngine(Process, metaclass=Protect):
                 for key in self.ctx._tasks[name]["args"]:
                     kwargs.pop(key, None)
                 # add function and interval to the args
-                args = [executor, kwargs.pop("interval"), kwargs.pop("timeout"), *args]
+                args = [
+                    executor,
+                    kwargs.pop("interval", 1),
+                    kwargs.pop("timeout", 3600),
+                    *args,
+                ]
                 awaitable_target = asyncio.ensure_future(
                     self.run_executor(monitor, args, kwargs, var_args, var_kwargs),
                     loop=self.loop,
@@ -1262,28 +1279,24 @@ class WorkGraphEngine(Process, metaclass=Protect):
         var_args = None
         var_kwargs = None
         task = self.ctx._tasks[name]
-        properties = task.get("properties", [])
+        properties = task.get("properties", {})
         inputs = {}
-        for input in task["inputs"]:
+        for name, input in task["inputs"].items():
             # print(f"input: {input['name']}")
             if len(input["links"]) == 0:
-                inputs[input["name"]] = self.update_context_variable(
-                    input["property"]["value"]
-                )
+                inputs[name] = self.update_context_variable(input["property"]["value"])
             elif len(input["links"]) == 1:
                 link = input["links"][0]
                 if self.ctx._tasks[link["from_node"]]["results"] is None:
-                    inputs[input["name"]] = None
+                    inputs[name] = None
                 else:
                     # handle the special socket _wait, _outputs
                     if link["from_socket"] == "_wait":
                         continue
                     elif link["from_socket"] == "_outputs":
-                        inputs[input["name"]] = self.ctx._tasks[link["from_node"]][
-                            "results"
-                        ]
+                        inputs[name] = self.ctx._tasks[link["from_node"]]["results"]
                     else:
-                        inputs[input["name"]] = get_nested_dict(
+                        inputs[name] = get_nested_dict(
                             self.ctx._tasks[link["from_node"]]["results"],
                             link["from_socket"],
                         )
@@ -1291,53 +1304,44 @@ class WorkGraphEngine(Process, metaclass=Protect):
             elif len(input["links"]) > 1:
                 value = {}
                 for link in input["links"]:
-                    name = f'{link["from_node"]}_{link["from_socket"]}'
+                    item_name = f'{link["from_node"]}_{link["from_socket"]}'
                     # handle the special socket _wait, _outputs
                     if link["from_socket"] == "_wait":
                         continue
                     if self.ctx._tasks[link["from_node"]]["results"] is None:
-                        value[name] = None
+                        value[item_name] = None
                     else:
-                        value[name] = self.ctx._tasks[link["from_node"]]["results"][
-                            link["from_socket"]
-                        ]
-                inputs[input["name"]] = value
-        print("inputs: ", inputs)
+                        value[item_name] = self.ctx._tasks[link["from_node"]][
+                            "results"
+                        ][link["from_socket"]]
+                inputs[name] = value
         for name in task.get("args", []):
             if name in inputs:
                 args.append(inputs[name])
                 args_dict[name] = inputs[name]
             else:
-                value = self.update_context_variable(
-                    get_item_by_name(properties, name)["value"]
-                )
+                value = self.update_context_variable(properties[name]["value"])
                 args.append(value)
                 args_dict[name] = value
         for name in task.get("kwargs", []):
             if name in inputs:
                 kwargs[name] = inputs[name]
             else:
-                value = self.update_context_variable(
-                    get_item_by_name(properties, name)["value"]
-                )
+                value = self.update_context_variable(properties[name]["value"])
                 kwargs[name] = value
         if task["var_args"] is not None:
             name = task["var_args"]
             if name in inputs:
                 var_args = inputs[name]
             else:
-                value = self.update_context_variable(
-                    get_item_by_name(properties, name)["value"]
-                )
+                value = self.update_context_variable(properties[name]["value"])
                 var_args = value
         if task["var_kwargs"] is not None:
             name = task["var_kwargs"]
             if name in inputs:
                 var_kwargs = inputs[name]
             else:
-                value = self.update_context_variable(
-                    get_item_by_name(properties, name)["value"]
-                )
+                value = self.update_context_variable(properties[name]["value"])
                 var_kwargs = value
         return args, kwargs, var_args, var_kwargs, args_dict
 

--- a/aiida_workgraph/executors/monitors.py
+++ b/aiida_workgraph/executors/monitors.py
@@ -13,16 +13,19 @@ async def monitor(function, interval, timeout, *args, **kwargs):
         await asyncio.sleep(interval)
 
 
-def file_monitor(filename):
+def file_monitor(filename: str):
     """Check if the file exists."""
     import os
 
     return os.path.exists(filename)
 
 
-def time_monitor(time):
+def time_monitor(time: str):
     """Return True if the current time is greater than the given time."""
     import datetime
+
+    # load the time string
+    time = datetime.datetime.strptime(time, "%Y-%m-%d %H:%M:%S.%f")
 
     return datetime.datetime.now() > time
 

--- a/aiida_workgraph/property.py
+++ b/aiida_workgraph/property.py
@@ -56,12 +56,12 @@ def build_property_from_AiiDA(DataClass: Type[Any]) -> Type[TaskProperty]:
                 raise Exception("{} is not an {}.".format(value, DataClass.__name__))
 
         def get_serialize(self) -> Dict[str, str]:
-            serialize = {"path": "aiida.orm.utils.serialize", "name": "serialize"}
+            serialize = {"module": "aiida.orm.utils.serialize", "name": "serialize"}
             return serialize
 
         def get_deserialize(self) -> Dict[str, str]:
             deserialize = {
-                "path": "aiida.orm.utils.serialize",
+                "module": "aiida.orm.utils.serialize",
                 "name": "deserialize_unsafe",
             }
             return deserialize

--- a/aiida_workgraph/socket.py
+++ b/aiida_workgraph/socket.py
@@ -32,12 +32,12 @@ def build_socket_from_AiiDA(DataClass: Type[Any]) -> Type[TaskSocket]:
             self.add_property(DataClass, name, **kwargs)
 
         def get_serialize(self) -> dict:
-            serialize = {"path": "aiida.orm.utils.serialize", "name": "serialize"}
+            serialize = {"module": "aiida.orm.utils.serialize", "name": "serialize"}
             return serialize
 
         def get_deserialize(self) -> dict:
             deserialize = {
-                "path": "aiida.orm.utils.serialize",
+                "module": "aiida.orm.utils.serialize",
                 "name": "deserialize_unsafe",
             }
             return deserialize

--- a/aiida_workgraph/task.py
+++ b/aiida_workgraph/task.py
@@ -111,9 +111,11 @@ class Task(GraphNode):
 
         Returns:
             Node: An instance of Node initialized with the provided data."""
-        from aiida_workgraph.tasks import task_pool
+        from aiida_workgraph.tasks import task_pool as workgraph_task_pool
         from aiida.orm.utils.serialize import deserialize_unsafe
 
+        if task_pool is None:
+            task_pool = workgraph_task_pool
         task = GraphNode.from_dict(data, node_pool=task_pool)
         task.context_mapping = data.get("context_mapping", {})
         task.waiting_on.add(data.get("wait", []))

--- a/aiida_workgraph/tasks/builtins.py
+++ b/aiida_workgraph/tasks/builtins.py
@@ -91,7 +91,7 @@ class Gather(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.builtins",
+            "module": "aiida_workgraph.executors.builtins",
             "name": "GatherWorkChain",
         }
 
@@ -143,7 +143,7 @@ class AiiDAInt(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "Int",
         }
 
@@ -162,7 +162,7 @@ class AiiDAFloat(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "Float",
         }
 
@@ -181,7 +181,7 @@ class AiiDAString(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "Str",
         }
 
@@ -202,7 +202,7 @@ class AiiDAList(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "List",
         }
 
@@ -223,7 +223,7 @@ class AiiDADict(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "Dict",
         }
 
@@ -251,7 +251,7 @@ class AiiDANode(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "load_node",
         }
 
@@ -276,7 +276,7 @@ class AiiDACode(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida.orm",
+            "module": "aiida.orm",
             "name": "load_code",
         }
 
@@ -303,6 +303,6 @@ class Select(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.builtins",
+            "module": "aiida_workgraph.executors.builtins",
             "name": "select",
         }

--- a/aiida_workgraph/tasks/monitors.py
+++ b/aiida_workgraph/tasks/monitors.py
@@ -27,7 +27,7 @@ class TimeMonitor(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.monitors",
+            "module": "aiida_workgraph.executors.monitors",
             "name": "time_monitor",
         }
 
@@ -57,7 +57,7 @@ class FileMonitor(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.monitors",
+            "module": "aiida_workgraph.executors.monitors",
             "name": "file_monitor",
         }
 
@@ -89,6 +89,6 @@ class TaskMonitor(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.monitors",
+            "module": "aiida_workgraph.executors.monitors",
             "name": "task_monitor",
         }

--- a/aiida_workgraph/tasks/monitors.py
+++ b/aiida_workgraph/tasks/monitors.py
@@ -22,6 +22,7 @@ class TimeMonitor(Task):
         inp.add_property("workgraph.any", default=86400.0)
         inp = self.inputs.new("workgraph.any", "_wait")
         inp.link_limit = 100000
+        self.outputs.new("workgraph.any", "result")
         self.outputs.new("workgraph.any", "_wait")
 
     def get_executor(self) -> Dict[str, str]:
@@ -51,6 +52,7 @@ class FileMonitor(Task):
         inp.add_property("workgraph.any", default=86400.0)
         inp = self.inputs.new("workgraph.any", "_wait")
         inp.link_limit = 100000
+        self.outputs.new("workgraph.any", "result")
         self.outputs.new("workgraph.any", "_wait")
 
     def get_executor(self) -> Dict[str, str]:
@@ -82,6 +84,7 @@ class TaskMonitor(Task):
         inp.add_property("workgraph.any", default=86400.0)
         inp = self.inputs.new("workgraph.any", "_wait")
         inp.link_limit = 100000
+        self.outputs.new("workgraph.any", "result")
         self.outputs.new("workgraph.any", "_wait")
 
     def get_executor(self) -> Dict[str, str]:

--- a/aiida_workgraph/tasks/pythonjob.py
+++ b/aiida_workgraph/tasks/pythonjob.py
@@ -12,7 +12,7 @@ class PythonJob(Task):
     @classmethod
     def get_function_kwargs(cls, data) -> Dict[str, Any]:
         input_kwargs = set()
-        for name in data["metadata"]["kwargs"]:
+        for name in data["kwargs"]:
             # all the kwargs are after computer is the input for the PythonJob, should be AiiDA Data node
             if name == "computer":
                 break

--- a/aiida_workgraph/tasks/test.py
+++ b/aiida_workgraph/tasks/test.py
@@ -26,7 +26,7 @@ class TestAdd(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.test",
+            "module": "aiida_workgraph.executors.test",
             "name": "add",
         }
 
@@ -51,7 +51,7 @@ class TestGreater(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.test",
+            "module": "aiida_workgraph.executors.test",
             "name": "greater",
         }
 
@@ -81,7 +81,7 @@ class TestSumDiff(Task):
 
     def get_executor(self) -> Dict[str, str]:
         return {
-            "path": "aiida_workgraph.executors.test",
+            "module": "aiida_workgraph.executors.test",
             "name": "sum_diff",
         }
 

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -632,9 +632,7 @@ def workgraph_to_short_json(
     #
     for name, task in wgdata["tasks"].items():
         # Add required inputs to nodes
-        inputs = [
-            input for name, input in task["inputs"].items() if name in task["args"]
-        ]
+        inputs = [{"name": name} for name in task["inputs"] if name in task["args"]]
         properties = process_properties(task)
         wgdata_short["nodes"][name] = {
             "label": task["name"],

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -57,10 +57,10 @@ def get_executor(data: Dict[str, Any]) -> Union[Process, Any]:
             executor = CalculationFactory(data["name"])
         elif type == "DataFactory":
             executor = DataFactory(data["name"])
-        elif data["name"] == "" and data["path"] == "":
+        elif data["name"] == "" and data["module"] == "":
             executor = None
         else:
-            module = importlib.import_module("{}".format(data.get("path", "")))
+            module = importlib.import_module("{}".format(data.get("module", "")))
             executor = getattr(module, data["name"])
 
     return executor, type
@@ -397,7 +397,10 @@ def serialize_properties(wgdata):
     import inspect
 
     for _, task in wgdata["tasks"].items():
-        for _, prop in task["properties"].items():
+        for _, input in task["inputs"].items():
+            if input["property"] is None:
+                continue
+            prop = input["property"]
             if inspect.isfunction(prop["value"]):
                 prop["value"] = PickledLocalFunction(prop["value"]).store()
 

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -209,7 +209,7 @@ class WorkGraphSaver:
         self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():
-            for _, prop in task["properties"].items():
+            for prop in task["properties"]:
                 if inspect.isfunction(prop["value"]):
                     prop["value"] = PickledLocalFunction(prop["value"]).store()
             self.wgdata["tasks"][name] = serialize(task)

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -213,7 +213,10 @@ class WorkGraphSaver:
         self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():
-            for _, prop in task["properties"].items():
+            for _, input in task["inputs"].items():
+                if input["property"] is None:
+                    continue
+                prop = input["property"]
                 if inspect.isfunction(prop["value"]):
                     prop["value"] = PickledLocalFunction(prop["value"]).store()
             self.wgdata["tasks"][name] = serialize(task)

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -83,20 +83,24 @@ class WorkGraphSaver:
         """
         # reset task input links
         for name, task in self.wgdata["tasks"].items():
-            for input in task["inputs"]:
+            for _, input in task["inputs"].items():
                 input["links"] = []
-            for output in task["outputs"]:
+            for _, output in task["outputs"].items():
                 output["links"] = []
         for link in self.wgdata["links"]:
             to_socket = [
                 socket
-                for socket in self.wgdata["tasks"][link["to_node"]]["inputs"]
-                if socket["name"] == link["to_socket"]
+                for name, socket in self.wgdata["tasks"][link["to_node"]][
+                    "inputs"
+                ].items()
+                if name == link["to_socket"]
             ][0]
             from_socket = [
                 socket
-                for socket in self.wgdata["tasks"][link["from_node"]]["outputs"]
-                if socket["name"] == link["from_socket"]
+                for name, socket in self.wgdata["tasks"][link["from_node"]][
+                    "outputs"
+                ].items()
+                if name == link["from_socket"]
             ][0]
             to_socket["links"].append(link)
             from_socket["links"].append(link)
@@ -134,7 +138,7 @@ class WorkGraphSaver:
         """Find the input and outputs tasks for the zone."""
         task = self.wgdata["tasks"][name]
         input_tasks = []
-        for input in self.wgdata["tasks"][name]["inputs"]:
+        for _, input in self.wgdata["tasks"][name]["inputs"].items():
             for link in input["links"]:
                 input_tasks.append(link["from_node"])
         # find all the input tasks
@@ -152,7 +156,7 @@ class WorkGraphSaver:
             else:
                 # if the child task is not a zone, get the input tasks of the child task
                 # find all the input tasks which outside the while zone
-                for input in self.wgdata["tasks"][child_task]["inputs"]:
+                for _, input in self.wgdata["tasks"][child_task]["inputs"].items():
                     for link in input["links"]:
                         input_tasks.append(link["from_node"])
         # find the input tasks which are not in the zone
@@ -206,10 +210,12 @@ class WorkGraphSaver:
         # self.wgdata["created"] = datetime.datetime.utcnow()
         # self.wgdata["lastUpdate"] = datetime.datetime.utcnow()
         short_wgdata = workgraph_to_short_json(self.wgdata)
+        for name, task in short_wgdata.items():
+            short_wgdata["nodes"][name] = serialize(task)
         self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():
-            for prop in task["properties"]:
+            for _, prop in task["properties"].items():
                 if inspect.isfunction(prop["value"]):
                     prop["value"] = PickledLocalFunction(prop["value"]).store()
             self.wgdata["tasks"][name] = serialize(task)

--- a/aiida_workgraph/utils/analysis.py
+++ b/aiida_workgraph/utils/analysis.py
@@ -210,8 +210,6 @@ class WorkGraphSaver:
         # self.wgdata["created"] = datetime.datetime.utcnow()
         # self.wgdata["lastUpdate"] = datetime.datetime.utcnow()
         short_wgdata = workgraph_to_short_json(self.wgdata)
-        for name, task in short_wgdata.items():
-            short_wgdata["nodes"][name] = serialize(task)
         self.process.base.extras.set("_workgraph_short", short_wgdata)
         self.save_task_states()
         for name, task in self.wgdata["tasks"].items():

--- a/aiida_workgraph/web/backend/app/utils.py
+++ b/aiida_workgraph/web/backend/app/utils.py
@@ -83,7 +83,7 @@ def node_to_short_json(workgraph_pk: int, tdata: Dict[str, Any]) -> Dict[str, An
         "metadata": [
             ["name", tdata["name"]],
             ["node_type", tdata["metadata"]["node_type"]],
-            ["identifier", tdata["metadata"]["identifier"]],
+            ["identifier", tdata["identifier"]],
         ],
         "executor": executor,
     }

--- a/aiida_workgraph/widget/src/widget/__init__.py
+++ b/aiida_workgraph/widget/src/widget/__init__.py
@@ -43,7 +43,7 @@ class NodeGraphWidget(anywidget.AnyWidget):
         tdata.pop("executor", None)
         tdata.pop("node_class", None)
         tdata.pop("process", None)
-        tdata["label"] = tdata["metadata"]["identifier"]
+        tdata["label"] = tdata["identifier"]
         wgdata = {"name": node.name, "nodes": {node.name: tdata}, "links": []}
         self.value = wgdata
 

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -201,9 +201,12 @@ class WorkGraph(node_graph.NodeGraph):
         wgdata["tasks"] = wgdata.pop("nodes")
         if store_nodes:
             for task in wgdata["tasks"].values():
-                for prop in task["properties"].values():
+                for prop in task["properties"]:
                     if isinstance(prop["value"], aiida.orm.Node):
                         prop["value"].store()
+                for input in task["inputs"]:
+                    if isinstance(input["property"]["value"], aiida.orm.Node):
+                        input["property"]["value"].store()
 
         return wgdata
 

--- a/aiida_workgraph/workgraph.py
+++ b/aiida_workgraph/workgraph.py
@@ -177,6 +177,7 @@ class WorkGraph(node_graph.NodeGraph):
 
     def to_dict(self, store_nodes=False) -> Dict[str, Any]:
         import cloudpickle as pickle
+        from aiida_workgraph.utils import store_nodes_recursely
 
         wgdata = super().to_dict()
         # save the sequence and context
@@ -200,14 +201,7 @@ class WorkGraph(node_graph.NodeGraph):
         wgdata["error_handlers"] = pickle.dumps(self.error_handlers)
         wgdata["tasks"] = wgdata.pop("nodes")
         if store_nodes:
-            for task in wgdata["tasks"].values():
-                for prop in task["properties"]:
-                    if isinstance(prop["value"], aiida.orm.Node):
-                        prop["value"].store()
-                for input in task["inputs"]:
-                    if isinstance(input["property"]["value"], aiida.orm.Node):
-                        input["property"]["value"].store()
-
+            store_nodes_recursely(wgdata)
         return wgdata
 
     def wait(self, timeout: int = 50, tasks: dict = None) -> None:

--- a/docs/gallery/concept/autogen/task.py
+++ b/docs/gallery/concept/autogen/task.py
@@ -169,7 +169,7 @@ class MyAdd(Task):
 
     def get_executor(self):
         return {
-            "path": "aiida_workgraph.executors.test",
+            "module": "aiida_workgraph.executors.test",
             "name": "add",
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.0.18",
+    "node-graph>=0.0.19",
     "aiida-core>=2.3",
     "cloudpickle",
     "aiida-shell",

--- a/tests/datas/test_calcfunction.yaml
+++ b/tests/datas/test_calcfunction.yaml
@@ -7,21 +7,28 @@ metadata:
 tasks:
   - identifier: workgraph.aiida_float
     name: float1
-    properties:
-      value: 3.0
+    inputs:
+      - name: value
+        property:
+          value: 3.0
   - identifier: workgraph.test_sum_diff
     name: sumdiff1
-    properties:
-      x: 2.0
     inputs:
-    - to_socket: y
-      from_node: float1
-      from_socket: 0
+      - name: x
+        property:
+          value: 2.0
   - identifier: workgraph.test_sum_diff
     name: sumdiff2
-    properties:
-      x: 4.0
     inputs:
-    - to_socket: y
-      from_node: sumdiff1
-      from_socket: 0
+      - name: x
+        property:
+          value: 4.0
+links:
+  - to_node: sumdiff1
+    from_node: float1
+    to_socket: y
+    from_socket: result
+  - to_node: sumdiff2
+    from_node: sumdiff1
+    to_socket: y
+    from_socket: sum

--- a/tests/test_awaitable_task.py
+++ b/tests/test_awaitable_task.py
@@ -30,7 +30,7 @@ def test_time_monitor(decorated_add):
     monitor1 = wg.add_task(
         "workgraph.time_monitor",
         "monitor1",
-        datetime=datetime.datetime.now() + datetime.timedelta(seconds=10),
+        datetime=str(datetime.datetime.now() + datetime.timedelta(seconds=10)),
     )
     add1 = wg.add_task(decorated_add, "add1", x=1, y=2)
     add1.waiting_on.add(monitor1)
@@ -49,7 +49,7 @@ def test_file_monitor(decorated_add, tmp_path):
         with open(filepath, "w") as f:
             f.write("test")
 
-    monitor_file_path = tmp_path / "test_file_monitor.txt"
+    monitor_file_path = str(tmp_path / "test_file_monitor.txt")
 
     wg = WorkGraph(name="test_file_monitor")
     monitor1 = wg.add_task(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -70,9 +70,7 @@ def test_decorators_task_args(task_function):
     assert tdata["kwargs"] == ["b"]
     assert tdata["var_args"] is None
     assert tdata["var_kwargs"] == "c"
-    assert set([output["name"] for output in tdata["outputs"]]) == set(
-        ["result", "_outputs", "_wait"]
-    )
+    assert set(tdata["outputs"].keys()) == set(["result", "_outputs", "_wait"])
 
 
 @pytest.fixture(params=["decorator_factory", "decorator"])

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -486,6 +486,8 @@ def test_load_pythonjob(fixture_localhost, python_executable_path):
     )
     assert wg.tasks["add"].outputs["result"].value.value == "Hello, World!"
     wg = WorkGraph.load(wg.pk)
+    wg.tasks["add"].inputs["x"].value = "Hello, "
+    wg.tasks["add"].inputs["y"].value = "World!"
 
 
 def test_exit_code(fixture_localhost, python_executable_path):

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -5,17 +5,13 @@ import time
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 
 
-def test_to_dict(wg_calcfunction):
+def test_from_dict(decorated_add):
     """Export NodeGraph to dict."""
-    wg = wg_calcfunction
-    wgdata = wg.to_dict()
-    assert len(wgdata["tasks"]) == len(wg.tasks)
-    assert len(wgdata["links"]) == len(wg.links)
-
-
-def test_from_dict(wg_calcfunction):
-    """Export NodeGraph to dict."""
-    wg = wg_calcfunction
+    wg = WorkGraph("test_from_dict")
+    task1 = wg.add_task(decorated_add, x=2, y=3)
+    wg.add_task(
+        "workgraph.test_sum_diff", name="sumdiff2", x=4, y=task1.outputs["result"]
+    )
     wgdata = wg.to_dict()
     wg1 = WorkGraph.from_dict(wgdata)
     assert len(wg.tasks) == len(wg1.tasks)


### PR DESCRIPTION
This PR bumps `node-graph` to 0.0.19, so that we don't need to pickle the `node-class`:
1) inputs and outputs to dict
2) keep property inside input
3) use the `module` and `name` for the node_class and executor