### PR TITLE
Fix serialization and desrialization the pythonjob data

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -18,6 +18,7 @@ task_types = {
 
 type_mapping = {
     "default": "workgraph.any",
+    "namespace": "workgraph.namespace",
     int: "workgraph.int",
     float: "workgraph.float",
     str: "workgraph.string",
@@ -288,6 +289,9 @@ def build_pythonjob_task(func: Callable) -> Task:
     }
     _, tdata_py = build_task_from_AiiDA(tdata)
     tdata = deepcopy(func.tdata)
+    function_kwargs = [
+        name for name in tdata["inputs"] if name not in ["_wait", "_outputs"]
+    ]
     # merge the inputs and outputs from the PythonJob task to the function task
     # skip the already existed inputs and outputs
     for input in [
@@ -324,6 +328,7 @@ def build_pythonjob_task(func: Callable) -> Task:
     }
     task = create_task(tdata)
     task.is_aiida_component = True
+    task.function_kwargs = function_kwargs
     return task, tdata
 
 

--- a/aiida_workgraph/engine/utils.py
+++ b/aiida_workgraph/engine/utils.py
@@ -93,11 +93,17 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
     metadata.update({"call_link_label": task["name"]})
     # get the source code of the function
     function_name = task["executor"]["name"]
-    function_source_code = (
-        task["executor"]["import_statements"]
-        + "\n"
-        + task["executor"]["source_code_without_decorator"]
-    )
+    if task["executor"].get("is_pickle", False):
+        function_source_code = (
+            task["executor"]["import_statements"]
+            + "\n"
+            + task["executor"]["source_code_without_decorator"]
+        )
+    else:
+        function_source_code = (
+            f"from {task['executor']['module']} import {function_name}"
+        )
+
     # outputs
     function_outputs = [
         output

--- a/aiida_workgraph/executors/test.py
+++ b/aiida_workgraph/executors/test.py
@@ -2,6 +2,7 @@ from typing import Union, Dict
 import time
 from aiida.engine import calcfunction
 from aiida.orm import Int, Float
+from aiida_workgraph import task
 
 
 @calcfunction
@@ -29,3 +30,8 @@ def sum_diff(
     """Add node."""
     time.sleep(t.value)
     return {"sum": x + y, "diff": x - y}
+
+
+@task.pythonjob()
+def add_pythonjob(x: int, y: int) -> int:
+    return x + y

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -617,10 +617,6 @@ def get_raw_value(identifier, value: Any) -> Any:
         "workgraph.float",
         "workgraph.string",
         "workgraph.bool",
-    ]:
-        if value is not None:
-            return value
-    elif identifier in [
         "workgraph.aiida_int",
         "workgraph.aiida_float",
         "workgraph.aiida_string",
@@ -635,6 +631,10 @@ def get_raw_value(identifier, value: Any) -> Any:
         and value is not None
         and isinstance(value, orm.StructureData)
     ):
+        content = value.backend_entity.attributes
+        content["node_type"] = value.node_type
+        return content
+    elif isinstance(value, orm.Data):
         content = value.backend_entity.attributes
         content["node_type"] = value.node_type
         return content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.0.20",
+    "node-graph>=0.1.0",
     "aiida-core>=2.3",
     "cloudpickle",
     "aiida-shell",

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -48,6 +48,23 @@ def test_decorator(fixture_localhost, python_executable_path):
     assert wg.tasks["add1"].node.label == "add1"
 
 
+def test_importable_function(fixture_localhost, python_executable_path):
+    """Test importable function."""
+    from aiida_workgraph.executors.test import add_pythonjob
+
+    wg = WorkGraph("test_importable_function")
+    wg.add_task(
+        add_pythonjob,
+        name="add",
+        x=1,
+        y=2,
+        computer="localhost",
+        code_label=python_executable_path,
+    )
+    wg.run()
+    assert wg.tasks["add"].outputs["result"].value.value == 3
+
+
 def test_PythonJob_kwargs(fixture_localhost, python_executable_path):
     """Test function with kwargs."""
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -75,3 +75,15 @@ def test_numpy_array(decorated_normal_add):
     # wg.run()
     assert wg.state.upper() == "FINISHED"
     # assert (wg.tasks["add1"].outputs["result"].value == np.array([5, 7, 9])).all()
+
+
+def test_kwargs() -> None:
+    """Test the kwargs of a task."""
+
+    @task()
+    def test(a, b=1, **kwargs):
+        return {"sum": a + b, "product": a * b}
+
+    test1 = test.node()
+    assert test1.inputs["kwargs"].link_limit == 1e6
+    assert test1.inputs["kwargs"].identifier == "workgraph.namespace"


### PR DESCRIPTION
This PR improve the PythonJob:
- handle 'namespace' socket when derializatoin
- for importable functions, import them directly; for locally defined functions, use their source code.
- bump node-graph to 0.1.0, so that the link_limit is 1e6 and identifier is `workgraph.namespace` for `var_args` and `var_kwargs`