### PR TITLE
Error handler can use the label of the ExitCode

### DIFF
--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -28,7 +28,15 @@ def test_error_handlers(add_code):
     wg.add_error_handler(
         handle_negative_sum,
         name="handle_negative_sum",
-        tasks={"add1": {"exit_codes": [410], "max_retries": 5, "kwargs": {}}},
+        tasks={
+            "add1": {
+                "exit_codes": [
+                    ArithmeticAddCalculation.exit_codes.ERROR_NEGATIVE_NUMBER
+                ],
+                "max_retries": 5,
+                "kwargs": {},
+            }
+        },
     )
     wg.submit(
         inputs={


### PR DESCRIPTION
Before saving the error handlers, we convert the ExitCode's label (str) to the ExitCode's status (int).