### PR TITLE
Set the default value to an empty dictionary for namespace socket

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -411,7 +411,6 @@ def build_task_from_workgraph(wg: any) -> Task:
             {
                 "identifier": "workgraph.namespace",
                 "name": f"{task.name}",
-                "property": {"identifier": "workgraph.any", "default": {}},
             }
         )
         for socket in task.inputs:
@@ -425,7 +424,6 @@ def build_task_from_workgraph(wg: any) -> Task:
             {
                 "identifier": "workgraph.namespace",
                 "name": f"{task.name}",
-                "property": {"identifier": "workgraph.any", "default": {}},
             }
         )
         for socket in task.outputs:

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -407,7 +407,13 @@ def build_task_from_workgraph(wg: any) -> Task:
     # add all the inputs/outputs from the tasks in the workgraph
     for task in wg.tasks:
         # inputs
-        inputs.append({"identifier": "workgraph.any", "name": f"{task.name}"})
+        inputs.append(
+            {
+                "identifier": "workgraph.namespace",
+                "name": f"{task.name}",
+                "property": {"identifier": "workgraph.any", "default": {}},
+            }
+        )
         for socket in task.inputs:
             if socket.name == "_wait":
                 continue
@@ -415,7 +421,13 @@ def build_task_from_workgraph(wg: any) -> Task:
                 {"identifier": socket.identifier, "name": f"{task.name}.{socket.name}"}
             )
         # outputs
-        outputs.append({"identifier": "workgraph.any", "name": f"{task.name}"})
+        outputs.append(
+            {
+                "identifier": "workgraph.namespace",
+                "name": f"{task.name}",
+                "property": {"identifier": "workgraph.any", "default": {}},
+            }
+        )
         for socket in task.outputs:
             if socket.name in ["_wait", "_outputs"]:
                 continue

--- a/aiida_workgraph/sockets/builtins.py
+++ b/aiida_workgraph/sockets/builtins.py
@@ -30,6 +30,8 @@ class SocketNamespace(TaskSocket, SerializePickle):
         **kwargs: Any
     ) -> None:
         super().__init__(name, node, type, index, uuid=uuid)
+        # Set the default value to an empty dictionary
+        kwargs.setdefault("default", {})
         self.add_property("workgraph.any", name, **kwargs)
 
 

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -149,7 +149,7 @@ def get_nested_dict(d: Dict, name: str, **kwargs) -> Any:
     return current
 
 
-def update_nested_dict(d: Dict[str, Any] | None, key: str, value: Any) -> None:
+def update_nested_dict(d: Optional[Dict[str, Any]], key: str, value: Any) -> None:
     """
     Update or create a nested dictionary structure based on a dotted key path.
 
@@ -227,9 +227,7 @@ def merge_properties(wgdata: Dict[str, Any]) -> None:
             if "." in key and prop["value"] not in [None, {}]:
                 root, key = key.split(".", 1)
                 root_prop = task["properties"][root]
-                root_prop["value"] = update_nested_dict(
-                    root_prop["value"], key, prop["value"]
-                )
+                update_nested_dict(root_prop["value"], key, prop["value"])
                 prop["value"] = None
         for key, input in task["inputs"].items():
             if input["property"] is None:
@@ -238,9 +236,7 @@ def merge_properties(wgdata: Dict[str, Any]) -> None:
             if "." in key and prop["value"] not in [None, {}]:
                 root, key = key.split(".", 1)
                 root_prop = task["inputs"][root]["property"]
-                root_prop["value"] = update_nested_dict(
-                    root_prop["value"], key, prop["value"]
-                )
+                update_nested_dict(root_prop["value"], key, prop["value"])
                 prop["value"] = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "node-graph>=0.1.0",
     "aiida-core>=2.3",
     "cloudpickle",
-    "aiida-shell",
+    "aiida-shell==0.7.3",
     "fastapi",
     "uvicorn",
     "pydantic_settings",

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -87,6 +87,7 @@ def test_kwargs() -> None:
     test1 = test.node()
     assert test1.inputs["kwargs"].link_limit == 1e6
     assert test1.inputs["kwargs"].identifier == "workgraph.namespace"
+    assert test1.inputs["kwargs"].property.value == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -34,6 +34,7 @@ def test_build_task_from_workgraph(
     wg = WorkGraph("build_task_from_workgraph")
     add1_task = wg.add_task(decorated_add, name="add1", x=1, y=3)
     wg_task = wg.add_task(wg_calcfunction, name="wg_calcfunction")
+    assert wg_task.inputs["sumdiff1"].value == {}
     wg.add_task(decorated_add, name="add2", y=3)
     wg.add_link(add1_task.outputs["result"], wg_task.inputs["sumdiff1.x"])
     wg.add_link(wg_task.outputs["sumdiff2.sum"], wg.tasks["add2"].inputs["x"])


### PR DESCRIPTION
When creating a task from a workgraph, the top-level input of a task should be a namespace