### PR TITLE
Add _wait Socket for Context Transitions and Fix Allowed Types for AiiDA Property

### DIFF
--- a/aiida_workgraph/properties/builtins.py
+++ b/aiida_workgraph/properties/builtins.py
@@ -165,7 +165,7 @@ class PropertyAiiDAIntVector(PropertyVector):
 
     identifier: str = "workgraph.aiida_int_vector"
     allowed_types = (list, orm.List, type(None))
-    allowed_item_types = (int, type(None))
+    allowed_item_types = (int, str, type(None))
 
 
 class PropertyAiiDAFloatVector(PropertyVector):
@@ -173,14 +173,14 @@ class PropertyAiiDAFloatVector(PropertyVector):
 
     identifier: str = "workgraph.aiida_float_vector"
     allowed_types = (list, orm.List, type(None))
-    allowed_item_types = (int, float, type(None))
+    allowed_item_types = (int, float, str, type(None))
 
 
 class PropertyStructureData(TaskProperty, SerializePickle):
     """A new class for Any type."""
 
     identifier: str = "workgraph.aiida_structuredata"
-    allowed_types = (orm.StructureData, type(None))
+    allowed_types = (orm.StructureData, str, type(None))
 
 
 __all__ = [

--- a/aiida_workgraph/tasks/builtins.py
+++ b/aiida_workgraph/tasks/builtins.py
@@ -108,7 +108,10 @@ class ToContext(Task):
         self.inputs.clear()
         self.outputs.clear()
         self.inputs.new("workgraph.any", "key")
+        inp = self.inputs.new("workgraph.any", "_wait")
+        inp.link_limit = 100000
         self.inputs.new("workgraph.any", "value")
+        self.outputs.new("workgraph.any", "_wait")
 
 
 class FromContext(Task):
@@ -124,7 +127,10 @@ class FromContext(Task):
         self.inputs.clear()
         self.outputs.clear()
         self.inputs.new("workgraph.any", "key")
+        inp = self.inputs.new("workgraph.any", "_wait")
+        inp.link_limit = 100000
         self.outputs.new("workgraph.any", "result")
+        self.outputs.new("workgraph.any", "_wait")
 
 
 class AiiDAInt(Task):

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -18,6 +18,8 @@ def test_workgraph_ctx(decorated_add: Callable) -> None:
         "workgraph.to_context", name="to_ctx1", key="x", value=add1.outputs["result"]
     )
     from_ctx1 = wg.add_task("workgraph.from_context", name="from_ctx1", key="x")
+    # test the task can wait for another task
+    from_ctx1.waiting_on.add(add1)
     add2 = wg.add_task(decorated_add, "add2", x=from_ctx1.outputs["result"], y=1)
     wg.run()
     assert add2.outputs["result"].value == 6

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -19,7 +19,6 @@ from typing import Any
         (orm.Str, "abc", "workgraph.aiida_string"),
         (orm.Bool, True, "workgraph.aiida_bool"),
         (orm.Bool, "{{variable}}", "workgraph.aiida_bool"),
-        # (orm.StructureData, orm.StructureData(), "workgraph.aiida_structuredata"),
     ),
 )
 def test_type_mapping(data_type, data, identifier) -> None:
@@ -33,6 +32,29 @@ def test_type_mapping(data_type, data, identifier) -> None:
     assert add.task().inputs["x"].property.identifier == identifier
     add_task = add.task()
     add_task.set({"x": data})
+    # test set data from context
+    add_task.set({"x": "{{variable}}"})
+
+
+def test_aiida_data_socket() -> None:
+    """Test the mapping of data types to socket types."""
+    from aiida import orm, load_profile
+
+    load_profile()
+
+    datas = [(orm.StructureData, orm.StructureData(), "workgraph.aiida_structuredata")]
+    for data_type, data, identifier in datas:
+
+        @task()
+        def add(x: data_type):
+            pass
+
+        assert add.task().inputs["x"].identifier == identifier
+        assert add.task().inputs["x"].property.identifier == identifier
+        add_task = add.task()
+        add_task.set({"x": data})
+        # test set data from context
+        add_task.set({"x": "{{variable}}"})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR includes two fixes:
1. Add `_wait` socket for both `from_context` and `to_context`.
2. Resolves an issue with the `allowed_types` specification in AiiDA properties to allow setting value from `context`.