### PR TITLE
Pass list of names for task input/output directly

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -6,7 +6,7 @@ from aiida.orm.nodes.process.calculation.calcfunction import CalcFunctionNode
 from aiida.orm.nodes.process.workflow.workfunction import WorkFunctionNode
 from aiida.engine.processes.ports import PortNamespace
 from aiida_workgraph.task import Task
-from aiida_workgraph.utils import build_callable
+from aiida_workgraph.utils import build_callable, validate_task_inout
 import inspect
 
 task_types = {
@@ -122,11 +122,17 @@ def add_output_recursive(
 
 def build_task(
     executor: Union[Callable, str],
-    inputs: Optional[List[str]] = None,
-    outputs: Optional[List[str]] = None,
+    inputs: Optional[List[str | dict]] = None,
+    outputs: Optional[List[str | dict]] = None,
 ) -> Task:
     """Build task from executor."""
     from aiida_workgraph.workgraph import WorkGraph
+
+    if inputs:
+        inputs = validate_task_inout(inputs, "inputs")
+
+    if outputs:
+        outputs = validate_task_inout(outputs, "outputs")
 
     if isinstance(executor, WorkGraph):
         return build_task_from_workgraph(executor)
@@ -142,8 +148,8 @@ def build_task(
 
 def build_task_from_callable(
     executor: Callable,
-    inputs: Optional[List[str]] = None,
-    outputs: Optional[List[str]] = None,
+    inputs: Optional[List[str | dict]] = None,
+    outputs: Optional[List[str | dict]] = None,
 ) -> Task:
     """Build task from a callable object.
     First, check if the executor is already a task.

--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 from aiida_workgraph.utils import get_executor
 from aiida.engine import calcfunction, workfunction, CalcJob, WorkChain

--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Optional, Union, Callable, List
 from aiida.engine.processes import Process
 from aiida import orm
@@ -756,3 +758,26 @@ def workgraph_to_short_json(
             }
         )
     return wgdata_short
+
+
+def validate_task_inout(inout_list: list[str | dict], list_type: str) -> list[dict]:
+    """
+    Checks if all the list elements provided as `inputs` or `outputs` of to a task are of type `str` or `dict`, and,
+    if the former convert them to a list of `dict`s with `name` as the key.
+
+    :param inout_list: The input/output list to be validated.
+    :param list_type: "input" or "output" to indicate what is to be validated.
+    :raises TypeError: If a list of mixed or wrong types is provided to the task
+    :return: Processed `inputs`/`outputs` list.
+    """
+
+    if all(isinstance(item, str) for item in inout_list):
+        return [{"name": item} for item in inout_list]
+    elif all(isinstance(item, dict) for item in inout_list):
+        return inout_list
+    elif not all(isinstance(item, dict) for item in inout_list):
+        raise TypeError(
+            f"Provide either a list of `str` or `dict` as `{list_type}`, not mixed types."
+        )
+    else:
+        raise TypeError(f"Wrong type provided in the `{list_type}` list to the task.")

--- a/tests/test_build_task.py
+++ b/tests/test_build_task.py
@@ -64,6 +64,11 @@ def test_calcfunction():
     assert "result" in add1.outputs.keys()
     assert add1.name == "add1"
 
+    AddTask_outputs_list = build_task(add_minus, outputs=["sum", "difference"])
+    assert issubclass(AddTask_outputs_list, Task)
+    assert "sum" in AddTask_outputs_list().outputs.keys()
+    assert "difference" in AddTask_outputs_list().outputs.keys()
+
 
 def test_function():
     """Generate a task for test."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+import pytest
+
+from aiida_workgraph.utils import validate_task_inout
+
+
+def test_validate_task_inout_str_list():
+    """Test validation with a list of strings."""
+    input_list = ["task1", "task2"]
+    result = validate_task_inout(input_list, "input")
+    assert result == [{"name": "task1"}, {"name": "task2"}]
+
+
+def test_validate_task_inout_dict_list():
+    """Test validation with a list of dictionaries."""
+    input_list = [{"name": "task1"}, {"name": "task2"}]
+    result = validate_task_inout(input_list, "input")
+    assert result == input_list
+
+
+@pytest.mark.parametrize(
+    "input_list, list_type, expected_error",
+    [
+        # Mixed types error cases
+        (
+            ["task1", {"name": "task2"}],
+            "input",
+            "Provide either a list of `str` or `dict` as `input`, not mixed types.",
+        ),
+        (
+            [{"name": "task1"}, "task2"],
+            "output",
+            "Provide either a list of `str` or `dict` as `output`, not mixed types.",
+        ),
+        # Empty list cases
+        ([], "input", None),
+        ([], "output", None),
+    ],
+)
+def test_validate_task_inout_mixed_types(input_list, list_type, expected_error):
+    """Test error handling for mixed type lists."""
+    if expected_error:
+        with pytest.raises(TypeError) as excinfo:
+            validate_task_inout(input_list, list_type)
+        assert str(excinfo.value) == expected_error
+    else:
+        # For empty lists, no error should be raised
+        result = validate_task_inout(input_list, list_type)
+        assert result == []
+
+
+@pytest.mark.parametrize(
+    "input_list, list_type",
+    [
+        # Invalid type cases
+        ([1, 2, 3], "input"),
+        ([None, None], "output"),
+        ([True, False], "input"),
+        (["task", 123], "output"),
+    ],
+)
+def test_validate_task_inout_invalid_types(input_list, list_type):
+    """Test error handling for completely invalid type lists."""
+    with pytest.raises(TypeError) as excinfo:
+        validate_task_inout(input_list, list_type)
+    assert "Provide either a list of" in str(excinfo.value)
+
+
+def test_validate_task_inout_dict_with_extra_keys():
+    """Test validation with dictionaries having extra keys."""
+    input_list = [
+        {"name": "task1", "description": "first task"},
+        {"name": "task2", "priority": "high"},
+    ]
+    result = validate_task_inout(input_list, "input")
+    assert result == input_list


### PR DESCRIPTION
So far, one would always have to pass a list of dictionaries, specifying at least the `"name"` identifier to a `Task`s inputs/outputs, such as:

```python
SeekpathTask = build_task(
    seekpath_structure_analysis,
    outputs=[
        {"name": "primitive_structure"},
        {"name": "explicit_kpoints"},
    ],
)
```

With this PR, it is now possible to just directly specify a list of strings, which will internally be automatically converted to a list of dictionaries, with the `"name"` key assigned to it. With this, it is now possible to write the above function call shorter, as:

```python
SeekpathTask = build_task(
    seekpath_structure_analysis,
    outputs=["primitive_structure", "explicit_kpoints"]
)
```

To avoid confusion, I only allow _either_ a list of `str`, **or** a list of `dict`, but not of mixed types. I added tests for the `validate_task_inout` function, as well as one test for the full call to `build_graph`.