### PR TITLE
Visualize `nodes` inputs for ShellJob tasks

### DIFF
--- a/aiida_workgraph/utils/__init__.py
+++ b/aiida_workgraph/utils/__init__.py
@@ -732,7 +732,9 @@ def workgraph_to_short_json(
             {"name": name, "identifier": input["identifier"]}
             for name, input in task["inputs"].items()
             if name in task["args"]
+            or (task["identifier"].upper() == "SHELLJOB" and name.startswith("nodes."))
         ]
+
         properties = process_properties(task)
         wgdata_short["nodes"][name] = {
             "label": task["name"],


### PR DESCRIPTION
Fixes #117.

Possibly visualize more inputs or other data?