### PR TITLE
Avoid passing `None` to arguments of `prepare_shell_job_inputs`

### DIFF
--- a/aiida_workgraph/decorator.py
+++ b/aiida_workgraph/decorator.py
@@ -379,6 +379,8 @@ def build_shelljob_task(
         tdata["outputs"][output["name"]] = output
     outputs = [] if outputs is None else outputs
     parser_outputs = [] if parser_outputs is None else parser_outputs
+    parser_outputs = validate_task_inout(parser_outputs, "parser_outputs")
+
     outputs = [
         {"identifier": "workgraph.any", "name": ShellParser.format_link_label(output)}
         for output in outputs

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -4,6 +4,16 @@ from aiida_shell.launch import prepare_code
 from aiida.orm import SinglefileData, load_computer
 
 
+def test_prepare_for_shell_task_nonexistent():
+    """Check that the `ValueError` raised by `aiida-shell` for a non-extistent executable is captured by WorkGraph."""
+    from aiida_workgraph.engine.utils import prepare_for_shell_task
+
+    task = {"name": "test"}
+    inputs = {"command": "abc42"}
+    with pytest.raises(ValueError, match="failed to determine the absolute path"):
+        prepare_for_shell_task(task=task, inputs=inputs)
+
+
 @pytest.mark.usefixtures("started_daemon_client")
 def test_shell_command(fixture_localhost):
     """Test the ShellJob with command as a string."""


### PR DESCRIPTION
Originally noted in #348, and fixes #348.

The reason for the bug was that in this line:
https://github.com/aiidateam/aiida-workgraph/blob/8f6260b44595f79471f6ea70e8efe0f0e158cdab/aiida_workgraph/engine/utils.py#L139
iteration was done over all input arguments of the `prepare_shell_job_inputs` function, using `None` as the default for the ones that weren't contained in the `inputs` dictionary passed to the `prepare_for_shell_task` function of WorkGraph. This would lead to `None` values being passed explicitly to the arguments of `prepare_shell_job_inputs`, in particular `resolve_command`, effectively overriding its default `True` value.

Inside `aiida-shell` the check for the absolute path of the executable inside the `prepare_code` function (see [here](https://github.com/sphuber/aiida-shell/blob/14866d1450aa252ec414373e86e98611e2eae9db/src/aiida_shell/launch.py#L176-L184)) would thus be skipped, and the WorkGraph would just fail silently at a later stage. With this PR, only the input arguments that are also contained in the `inputs` of the `prepare_for_shell_task` are being explicitly passed, while the rest is left unset.