### PR TITLE
Recursively process nested dictionaries when setting a dynamic port socket

### DIFF
--- a/tests/utils/test_workchain.py
+++ b/tests/utils/test_workchain.py
@@ -12,6 +12,8 @@ class WorkChainWithNestNamespace(WorkChain):
     def define(cls, spec):
         """Specify inputs and outputs."""
         super().define(spec)
+        spec.input_namespace("non_dynamic_port")
+        spec.input("non_dynamic_port.a")
         spec.expose_inputs(
             ArithmeticAddCalculation,
             namespace="add",


### PR DESCRIPTION
Recursively process nested dictionaries, to create input sockets and links for items inside a dynamic socket, 