### PR TITLE
Refactor `AIIDA_CONFIG_FOLDER` -> `AiiDAConfigDir`

### DIFF
--- a/src/aiida_workgraph/config.py
+++ b/src/aiida_workgraph/config.py
@@ -1,5 +1,6 @@
 import json
 from aiida.manage import get_config
+from pathlib import Path
 
 WORKGRAPH_EXTRA_KEY = "_workgraph"
 WORKGRAPH_SHORT_EXTRA_KEY = "_workgraph_short"
@@ -12,7 +13,7 @@ builtin_outputs = [{"name": "_wait"}, {"name": "_outputs"}]
 def load_config() -> dict:
     """Load the configuration from the config file."""
     config = get_config()
-    config_file_path = config.dirpath / "workgraph.json"
+    config_file_path = Path(config.dirpath) / "workgraph.json"
     try:
         with config_file_path.open("r") as f:
             config = json.load(f)

--- a/src/aiida_workgraph/config.py
+++ b/src/aiida_workgraph/config.py
@@ -1,5 +1,5 @@
 import json
-from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
+from aiida.manage.configuration.settings import AiiDAConfigDir
 
 WORKGRAPH_EXTRA_KEY = "_workgraph"
 WORKGRAPH_SHORT_EXTRA_KEY = "_workgraph_short"
@@ -11,7 +11,7 @@ builtin_outputs = [{"name": "_wait"}, {"name": "_outputs"}]
 
 def load_config() -> dict:
     """Load the configuration from the config file."""
-    config_file_path = AIIDA_CONFIG_FOLDER / "workgraph.json"
+    config_file_path = AiiDAConfigDir.get() / "workgraph.json"
     try:
         with config_file_path.open("r") as f:
             config = json.load(f)

--- a/src/aiida_workgraph/config.py
+++ b/src/aiida_workgraph/config.py
@@ -1,5 +1,5 @@
 import json
-from aiida.manage.configuration.settings import AiiDAConfigDir
+from aiida.manage import get_config
 
 WORKGRAPH_EXTRA_KEY = "_workgraph"
 WORKGRAPH_SHORT_EXTRA_KEY = "_workgraph_short"
@@ -11,7 +11,8 @@ builtin_outputs = [{"name": "_wait"}, {"name": "_outputs"}]
 
 def load_config() -> dict:
     """Load the configuration from the config file."""
-    config_file_path = AiiDAConfigDir.get() / "workgraph.json"
+    config = get_config()
+    config_file_path = config.dirpath / "workgraph.json"
     try:
         with config_file_path.open("r") as f:
             config = json.load(f)


### PR DESCRIPTION
After https://github.com/aiidateam/aiida-core/pull/6610 by @unkcpz  `AIIDA_CONFIG_FOLDER` has changed to `AiiDAConfigDir`, 
This PR refactors that accordingly. 
(a similar PR opened on https://github.com/aiidateam/aiida-pythonjob/pull/9)