### PR TITLE
Add AiiDAProcessTask

### DIFF
--- a/docs/gallery/concept/autogen/task.py
+++ b/docs/gallery/concept/autogen/task.py
@@ -183,8 +183,8 @@ class MyAdd(Task):
     catalog = "Test"
 
     _executor = {
-        "module": "aiida_workgraph.executors.test",
-        "name": "add",
+        "module_path": "aiida_workgraph.executors.test",
+        "callable_name": "add",
     }
 
     def create_sockets(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.1.11",
+    "node-graph==0.1.12",
     "node-graph-widget",
     "aiida-core>=2.3",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.1.10",
+    "node-graph==0.1.11",
     "node-graph-widget",
     "aiida-core>=2.3",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.1.9",
+    "node-graph==0.1.10",
     "node-graph-widget",
     "aiida-core>=2.3",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 "workgraph.test_sum_diff" = "aiida_workgraph.tasks.test:TestSumDiff"
 "workgraph.test_arithmetic_multiply_add" = "aiida_workgraph.tasks.test:TestArithmeticMultiplyAdd"
 "workgraph.pythonjob" = "aiida_workgraph.tasks.pythonjob:PythonJob"
+"workgraph.aiida_process" = "aiida_workgraph.tasks.aiida:AiiDAProcessTask"
 
 [project.entry-points."aiida_workgraph.property"]
 "workgraph.any" = "aiida_workgraph.properties.builtins:PropertyAny"

--- a/src/aiida_workgraph/collection.py
+++ b/src/aiida_workgraph/collection.py
@@ -3,8 +3,6 @@ from node_graph.collection import (
     PropertyCollection,
 )
 from typing import Any, Callable, Optional, Union
-from aiida.engine import CalcJob, WorkChain
-from aiida_workgraph.utils import build_callable
 
 
 class TaskCollection(NodeCollection):
@@ -25,17 +23,6 @@ class TaskCollection(NodeCollection):
 
         # build the task on the fly if the identifier is a callable
         if callable(identifier):
-            if isinstance(identifier, type):
-                if issubclass(identifier, (CalcJob, WorkChain)):
-                    executor = build_callable(identifier)
-                    task = super()._new(
-                        "workgraph.aiida_process",
-                        name,
-                        uuid,
-                        _executor=executor,
-                        **kwargs
-                    )
-                    return task
             identifier = build_task_from_callable(identifier)
         if isinstance(identifier, str) and identifier.upper() == "PYTHONJOB":
             identifier, _ = build_pythonjob_task(kwargs.pop("function"))

--- a/src/aiida_workgraph/config.py
+++ b/src/aiida_workgraph/config.py
@@ -1,10 +1,19 @@
 import json
 from aiida.manage import get_config
 from pathlib import Path
+from aiida.orm.nodes.process.calculation.calcfunction import CalcFunctionNode
+from aiida.orm.nodes.process.workflow.workfunction import WorkFunctionNode
+from aiida.engine import CalcJob, WorkChain
 
 WORKGRAPH_EXTRA_KEY = "_workgraph"
 WORKGRAPH_SHORT_EXTRA_KEY = "_workgraph_short"
 
+task_types = {
+    CalcFunctionNode: "CALCFUNCTION",
+    WorkFunctionNode: "WORKFUNCTION",
+    CalcJob: "CALCJOB",
+    WorkChain: "WORKCHAIN",
+}
 
 builtin_inputs = [
     {"name": "_wait", "link_limit": 1e6, "metadata": {"arg_type": "none"}}

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -288,9 +288,9 @@ def build_task_from_workgraph(wg: any) -> Task:
     # get wgdata from the workgraph
     wgdata = wg.prepare_inputs()["wg"]
     executor = {
-        "module": "aiida_workgraph.engine.workgraph",
-        "name": "WorkGraphEngine",
-        "wgdata": wgdata,
+        "module_path": "aiida_workgraph.engine.workgraph",
+        "callable_name": "WorkGraphEngine",
+        "graph_data": wgdata,
         "type": tdata["metadata"]["task_type"],
     }
     tdata["metadata"]["group_outputs"] = group_outputs

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -3,22 +3,11 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 from aiida_workgraph.utils import get_executor
 from aiida.engine import calcfunction, workfunction, CalcJob, WorkChain
-from aiida.orm.nodes.process.calculation.calcfunction import CalcFunctionNode
-from aiida.orm.nodes.process.workflow.workfunction import WorkFunctionNode
-from aiida.engine.processes.ports import PortNamespace
 from aiida_workgraph.task import Task
 from aiida_workgraph.utils import build_callable, validate_task_inout
 import inspect
-from aiida_workgraph.config import builtin_inputs, builtin_outputs
+from aiida_workgraph.config import builtin_inputs, builtin_outputs, task_types
 from aiida_workgraph.orm.mapping import type_mapping
-
-
-task_types = {
-    CalcFunctionNode: "CALCFUNCTION",
-    WorkFunctionNode: "WORKFUNCTION",
-    CalcJob: "CALCJOB",
-    WorkChain: "WORKCHAIN",
-}
 
 
 def create_task(tdata):
@@ -33,96 +22,6 @@ def create_task(tdata):
     tdata["outputs"] = list_to_dict(tdata.get("outputs", {}))
 
     return create_node(tdata)
-
-
-def add_input_recursive(
-    inputs: List[List[Union[str, Dict[str, Any]]]],
-    port: PortNamespace,
-    prefix: Optional[str] = None,
-    required: bool = True,
-) -> List[List[Union[str, Dict[str, Any]]]]:
-    """Add input recursively."""
-    if prefix is None:
-        port_name = port.name
-    else:
-        port_name = f"{prefix}.{port.name}"
-    required = port.required and required
-    input_names = [input["name"] for input in inputs]
-    if isinstance(port, PortNamespace):
-        # TODO the default value is {} could cause problem, because the address of the dict is the same,
-        # so if you change the value of one port, the value of all the ports of other tasks will be changed
-        # consider to use None as default value
-        if port_name not in input_names:
-            inputs.append(
-                {
-                    "identifier": "workgraph.namespace",
-                    "name": port_name,
-                    "metadata": {
-                        "arg_type": "kwargs",
-                        "required": required,
-                        "dynamic": port.dynamic,
-                    },
-                }
-            )
-        for value in port.values():
-            add_input_recursive(inputs, value, prefix=port_name, required=required)
-    else:
-        if port_name not in input_names:
-            # port.valid_type can be a single type or a tuple of types,
-            # we only support single type for now
-            if isinstance(port.valid_type, tuple) and len(port.valid_type) > 1:
-                socket_type = "workgraph.any"
-            if isinstance(port.valid_type, tuple) and len(port.valid_type) == 1:
-                socket_type = type_mapping.get(port.valid_type[0], "workgraph.any")
-            else:
-                socket_type = type_mapping.get(port.valid_type, "workgraph.any")
-            inputs.append(
-                {
-                    "identifier": socket_type,
-                    "name": port_name,
-                    "metadata": {"arg_type": "kwargs", "required": required},
-                }
-            )
-    return inputs
-
-
-def add_output_recursive(
-    outputs: List[List[Union[str, Dict[str, Any]]]],
-    port: PortNamespace,
-    prefix: Optional[str] = None,
-    required: bool = True,
-) -> List[List[Union[str, Dict[str, Any]]]]:
-    """Add output recursively."""
-    if prefix is None:
-        port_name = port.name
-    else:
-        port_name = f"{prefix}.{port.name}"
-    required = port.required and required
-    output_names = [output["name"] for output in outputs]
-    if isinstance(port, PortNamespace):
-        # TODO the default value is {} could cause problem, because the address of the dict is the same,
-        # so if you change the value of one port, the value of all the ports of other tasks will be changed
-        # consider to use None as default value
-        if port_name not in output_names:
-            outputs.append(
-                {
-                    "identifier": "workgraph.namespace",
-                    "name": port_name,
-                    "metadata": {"required": required},
-                }
-            )
-        for value in port.values():
-            add_output_recursive(outputs, value, prefix=port_name, required=required)
-    else:
-        if port_name not in output_names:
-            outputs.append(
-                {
-                    "identifier": "workgraph.any",
-                    "name": port_name,
-                    "metadata": {"required": required},
-                }
-            )
-    return outputs
 
 
 def build_task(
@@ -146,7 +45,9 @@ def build_task(
             module,
             executor_name,
         ) = executor.rsplit(".", 1)
-        executor, _ = get_executor({"module": module, "name": executor_name})
+        executor, _ = get_executor(
+            {"module_path": module, "callable_name": executor_name}
+        )
     if callable(executor):
         return build_task_from_callable(executor, inputs=inputs, outputs=outputs)
 
@@ -180,7 +81,7 @@ def build_task_from_callable(
             tdata["metadata"]["task_type"] = task_types.get(
                 executor.node_class, "NORMAL"
             )
-            tdata["executor"] = executor
+            tdata["callable"] = executor
             return build_task_from_AiiDA(tdata, inputs=inputs, outputs=outputs)[0]
         else:
             tdata["metadata"]["task_type"] = "NORMAL"
@@ -189,13 +90,13 @@ def build_task_from_callable(
     else:
         if issubclass(executor, CalcJob):
             tdata["metadata"]["task_type"] = "CALCJOB"
-            tdata["executor"] = executor
+            tdata["callable"] = executor
             return build_task_from_AiiDA(tdata, inputs=inputs, outputs=outputs)[0]
         elif issubclass(executor, WorkChain):
             tdata["metadata"]["task_type"] = "WORKCHAIN"
-            tdata["executor"] = executor
+            tdata["callable"] = executor
             return build_task_from_AiiDA(tdata, inputs=inputs, outputs=outputs)[0]
-    raise ValueError("The executor is not supported.")
+    raise ValueError(f"The executor {executor} is not supported.")
 
 
 def build_task_from_function(
@@ -216,52 +117,13 @@ def build_task_from_AiiDA(
 ) -> Tuple[Task, Dict[str, Any]]:
     """Register a task from a AiiDA component.
     For example: CalcJob, WorkChain, CalcFunction, WorkFunction."""
+    from aiida_workgraph.utils.inspect_aiida_components import (
+        get_task_data_from_aiida_component,
+    )
 
-    tdata.setdefault("metadata", {})
-    inputs = [] if inputs is None else inputs
-    outputs = [] if outputs is None else outputs
-    executor = tdata["executor"]
-    spec = executor.spec()
-    for _, port in spec.inputs.ports.items():
-        add_input_recursive(inputs, port, required=port.required)
-    for _, port in spec.outputs.ports.items():
-        add_output_recursive(outputs, port, required=port.required)
-    # Only check this for calcfunction and workfunction
-    if inspect.isfunction(executor) and spec.inputs.dynamic:
-        if hasattr(executor.process_class, "_varargs"):
-            name = executor.process_class._varargs
-        else:
-            name = (
-                executor.process_class._var_keyword
-                or executor.process_class._var_positional
-            )
-        # if user already defined the var_args in the inputs, skip it
-        if name not in [input["name"] for input in inputs]:
-            inputs.append(
-                {
-                    "identifier": "workgraph.namespace",
-                    "name": name,
-                    "metadata": {"arg_type": "var_kwargs", "dynamic": True},
-                }
-            )
-
-    tdata["identifier"] = tdata.pop("identifier", tdata["executor"].__name__)
-    tdata["executor"] = build_callable(executor)
-    tdata["executor"]["type"] = tdata["metadata"]["task_type"]
-    if tdata["metadata"]["task_type"].upper() in ["CALCFUNCTION", "WORKFUNCTION"]:
-        outputs = (
-            [{"identifier": "workgraph.any", "name": "result"}]
-            if not outputs
-            else outputs
-        )
-    # add built-in sockets
-    for output in builtin_outputs:
-        outputs.append(output.copy())
-    for input in builtin_inputs:
-        inputs.append(input.copy())
-    tdata["metadata"]["node_class"] = {"module": "aiida_workgraph.task", "name": "Task"}
-    tdata["inputs"] = inputs
-    tdata["outputs"] = outputs
+    tdata = get_task_data_from_aiida_component(
+        tdata=tdata, inputs=inputs, outputs=outputs
+    )
     task = create_task(tdata)
     task.is_aiida_component = True
     return task, tdata
@@ -281,7 +143,7 @@ def build_pythonjob_task(func: Callable) -> Task:
         )
     tdata = {
         "metadata": {"task_type": "PYTHONJOB"},
-        "executor": PythonJob,
+        "callable": PythonJob,
     }
     _, tdata_py = build_task_from_AiiDA(tdata)
     tdata = deepcopy(func.tdata)
@@ -309,8 +171,8 @@ def build_pythonjob_task(func: Callable) -> Task:
     tdata["metadata"]["task_type"] = "PYTHONJOB"
     tdata["identifier"] = "workgraph.pythonjob"
     tdata["metadata"]["node_class"] = {
-        "module": "aiida_workgraph.tasks.pythonjob",
-        "name": "PythonJob",
+        "module_path": "aiida_workgraph.tasks.pythonjob",
+        "callable_name": "PythonJob",
     }
     task = create_task(tdata)
     task.is_aiida_component = True
@@ -324,7 +186,7 @@ def build_shelljob_task(outputs: list = None, parser_outputs: list = None) -> Ta
 
     tdata = {
         "metadata": {"task_type": "SHELLJOB"},
-        "executor": ShellJob,
+        "callable": ShellJob,
     }
     _, tdata = build_task_from_AiiDA(tdata)
     # Extend the outputs
@@ -416,7 +278,10 @@ def build_task_from_workgraph(wg: any) -> Task:
         outputs.append(output.copy())
     for input in builtin_inputs:
         inputs.append(input.copy())
-    tdata["metadata"]["node_class"] = {"module": "aiida_workgraph.task", "name": "Task"}
+    tdata["metadata"]["node_class"] = {
+        "module_path": "aiida_workgraph.task",
+        "callable_name": "Task",
+    }
     tdata["inputs"] = inputs
     tdata["outputs"] = outputs
     tdata["identifier"] = wg.name
@@ -498,7 +363,10 @@ def generate_tdata(
         "metadata": {
             "task_type": task_type,
             "catalog": catalog,
-            "node_class": {"module": "aiida_workgraph.task", "name": "Task"},
+            "node_class": {
+                "module_path": "aiida_workgraph.task",
+                "callable_name": "Task",
+            },
             "group_inputs": group_inputs or [],
             "group_outputs": group_outputs or [],
         },

--- a/src/aiida_workgraph/engine/utils.py
+++ b/src/aiida_workgraph/engine/utils.py
@@ -5,7 +5,7 @@ from aiida.common.extendeddicts import AttributeDict
 def prepare_for_workgraph_task(task: dict, kwargs: dict) -> tuple:
     """Prepare the inputs for WorkGraph task"""
 
-    wgdata = task["executor"]["wgdata"]
+    wgdata = task["executor"]["graph_data"]
     wgdata["name"] = task["name"]
     wgdata["metadata"]["group_outputs"] = task["metadata"]["group_outputs"]
     # update the workgraph data by kwargs

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -1,0 +1,62 @@
+from aiida_workgraph.task import Task
+from aiida_workgraph.utils.inspect_aiida_components import (
+    get_task_data_from_aiida_component,
+)
+from aiida_workgraph.orm.mapping import type_mapping
+from copy import deepcopy
+from node_graph.utils import list_to_dict
+from node_graph.executor import NodeExecutor
+
+
+class AiiDAProcessTask(Task):
+    """Task with AiiDA process as executor."""
+
+    identifier = "workgraph.aiida_process"
+    name = "aiida_process"
+    node_type = "Process"
+    catalog = "AIIDA"
+
+    def __init__(self, executor: NodeExecutor, **kwargs):
+
+        task_data = self.inspect_executor(executor)
+        self.task_data = task_data
+        super().__init__(executor=executor, **kwargs)
+        self.node_type = self.task_data["metadata"]["task_type"]
+
+    def inspect_executor(self, executor) -> dict:
+        metadata = executor.get("metadata", {})
+        inputs = metadata.pop("inputs", [])
+        outputs = metadata.pop("outputs", [])
+        task_data = get_task_data_from_aiida_component(
+            tdata=deepcopy(executor),
+            inputs=deepcopy(inputs),
+            outputs=deepcopy(outputs),
+        )
+        return task_data
+
+    def create_sockets(self) -> None:
+        self.inputs._clear()
+        self.outputs._clear()
+
+        inputs = list_to_dict(self.task_data.get("inputs", {}))
+        for input in inputs.values():
+            if isinstance(input, str):
+                input = {"identifier": type_mapping["default"], "name": input}
+            kwargs = {}
+            if "property_data" in input:
+                kwargs["property_data"] = input.pop("property_data")
+            self.add_input(
+                input.get("identifier", type_mapping["default"]),
+                name=input["name"],
+                metadata=input.get("metadata", {}),
+                link_limit=input.get("link_limit", 1),
+                **kwargs,
+            )
+        outputs = list_to_dict(self.task_data.get("outputs", {}))
+        for output in outputs.values():
+            if isinstance(output, str):
+                output = {"identifier": type_mapping["default"], "name": output}
+            identifier = output.get("identifier", type_mapping["default"])
+            self.add_output(
+                identifier, name=output["name"], metadata=output.get("metadata", {})
+            )

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -120,11 +120,6 @@ class AiiDAInt(Task):
     node_type = "data"
     catalog = "Test"
 
-    _executor = {
-        "module": "aiida.orm",
-        "name": "Int",
-    }
-
     def create_sockets(self) -> None:
         self.add_input("workgraph.any", "value", property_data={"default": 0.0})
         self.add_input(
@@ -133,17 +128,19 @@ class AiiDAInt(Task):
         self.add_output("workgraph.aiida_int", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "Int",
+        }
+        return executor
+
 
 class AiiDAFloat(Task):
     identifier = "workgraph.aiida_float"
     name = "AiiDAFloat"
     node_type = "data"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "Float",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -155,17 +152,19 @@ class AiiDAFloat(Task):
         self.add_output("workgraph.aiida_float", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "Float",
+        }
+        return executor
+
 
 class AiiDAString(Task):
     identifier = "workgraph.aiida_string"
     name = "AiiDAString"
     node_type = "data"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "Str",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -177,17 +176,19 @@ class AiiDAString(Task):
         self.add_output("workgraph.aiida_string", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "Str",
+        }
+        return executor
+
 
 class AiiDAList(Task):
     identifier = "workgraph.aiida_list"
     name = "AiiDAList"
     node_type = "data"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "List",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -199,17 +200,19 @@ class AiiDAList(Task):
         self.add_output("workgraph.aiida_list", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "List",
+        }
+        return executor
+
 
 class AiiDADict(Task):
     identifier = "workgraph.aiida_dict"
     name = "AiiDADict"
     node_type = "data"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "Dict",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -221,6 +224,13 @@ class AiiDADict(Task):
         self.add_output("workgraph.aiida_dict", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "Dict",
+        }
+        return executor
+
 
 class AiiDANode(Task):
     """AiiDANode"""
@@ -229,11 +239,6 @@ class AiiDANode(Task):
     name = "AiiDANode"
     node_type = "node"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "load_node",
-    }
 
     def create_properties(self) -> None:
         pass
@@ -251,6 +256,13 @@ class AiiDANode(Task):
         self.add_output("workgraph.any", "node")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "load_node",
+        }
+        return executor
+
 
 class AiiDACode(Task):
     """AiiDACode"""
@@ -259,11 +271,6 @@ class AiiDACode(Task):
     name = "AiiDACode"
     node_type = "node"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida.orm",
-        "name": "load_code",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -278,6 +285,13 @@ class AiiDACode(Task):
         self.add_output("workgraph.any", "Code")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida.orm",
+            "callable_name": "load_code",
+        }
+        return executor
+
 
 class Select(Task):
     """Select"""
@@ -286,11 +300,6 @@ class Select(Task):
     name = "Select"
     node_type = "Normal"
     catalog = "Control"
-
-    _executor = {
-        "module": "aiida_workgraph.executors.builtins",
-        "name": "select",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -303,3 +312,10 @@ class Select(Task):
         )
         self.add_output("workgraph.any", "result")
         self.add_output("workgraph.any", "_wait")
+
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.builtins",
+            "callable_name": "select",
+        }
+        return executor

--- a/src/aiida_workgraph/tasks/monitors.py
+++ b/src/aiida_workgraph/tasks/monitors.py
@@ -9,11 +9,6 @@ class TimeMonitor(Task):
     node_type = "MONITOR"
     catalog = "Monitor"
 
-    _executor = {
-        "module": "aiida_workgraph.executors.monitors",
-        "name": "time_monitor",
-    }
-
     def create_sockets(self) -> None:
         self.inputs._clear()
         self.outputs._clear()
@@ -29,6 +24,13 @@ class TimeMonitor(Task):
         self.add_output("workgraph.any", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.monitors",
+            "callable_name": "time_monitor",
+        }
+        return executor
+
 
 class FileMonitor(Task):
     """Monitor the file"""
@@ -37,11 +39,6 @@ class FileMonitor(Task):
     name = "FileMonitor"
     node_type = "MONITOR"
     catalog = "Monitor"
-
-    _executor = {
-        "module": "aiida_workgraph.executors.monitors",
-        "name": "file_monitor",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -58,6 +55,13 @@ class FileMonitor(Task):
         self.add_output("workgraph.any", "result")
         self.add_output("workgraph.any", "_wait")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.monitors",
+            "callable_name": "file_monitor",
+        }
+        return executor
+
 
 class TaskMonitor(Task):
     """Monitor the file"""
@@ -66,11 +70,6 @@ class TaskMonitor(Task):
     name = "TaskMonitor"
     node_type = "MONITOR"
     catalog = "Monitor"
-
-    _executor = {
-        "module": "aiida_workgraph.executors.monitors",
-        "name": "task_monitor",
-    }
 
     def create_sockets(self) -> None:
         self.inputs._clear()
@@ -88,3 +87,10 @@ class TaskMonitor(Task):
         inp._link_limit = 100000
         self.add_output("workgraph.any", "result")
         self.add_output("workgraph.any", "_wait")
+
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.monitors",
+            "callable_name": "task_monitor",
+        }
+        return executor

--- a/src/aiida_workgraph/tasks/test.py
+++ b/src/aiida_workgraph/tasks/test.py
@@ -96,7 +96,7 @@ class TestArithmeticMultiplyAdd(Task):
     def get_executor(self):
         executor = {
             "use_module_path": True,
-            "callable_name": "core.arithmetic.multiply_add",
+            "module_path": "core.arithmetic.multiply_add",
             "type": "WorkflowFactory",
         }
         return executor

--- a/src/aiida_workgraph/tasks/test.py
+++ b/src/aiida_workgraph/tasks/test.py
@@ -8,11 +8,6 @@ class TestAdd(Task):
     node_type = "CALCFUNCTION"
     catalog = "Test"
 
-    _executor = {
-        "module": "aiida_workgraph.executors.test",
-        "name": "add",
-    }
-
     def create_properties(self) -> None:
         self.add_property("workgraph.aiida_float", "t", default=1.0)
 
@@ -30,6 +25,13 @@ class TestAdd(Task):
         self.add_output("workgraph.any", "_wait")
         self.add_output("workgraph.any", "_outputs")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.test",
+            "callable_name": "add",
+        }
+        return executor
+
 
 class TestSumDiff(Task):
 
@@ -37,11 +39,6 @@ class TestSumDiff(Task):
     name = "TestSumDiff"
     node_type = "CALCFUNCTION"
     catalog = "Test"
-
-    _executor = {
-        "module": "aiida_workgraph.executors.test",
-        "name": "sum_diff",
-    }
 
     def create_properties(self) -> None:
         self.properties._new("workgraph.aiida_float", "t", default=1.0)
@@ -61,6 +58,13 @@ class TestSumDiff(Task):
         self.add_output("workgraph.any", "_wait")
         self.add_output("workgraph.any", "_outputs")
 
+    def get_executor(self):
+        executor = {
+            "module_path": "aiida_workgraph.executors.test",
+            "callable_name": "sum_diff",
+        }
+        return executor
+
 
 class TestArithmeticMultiplyAdd(Task):
 
@@ -68,11 +72,6 @@ class TestArithmeticMultiplyAdd(Task):
     name = "TestArithmeticMultiplyAdd"
     node_type = "WORKCHAIN"
     catalog = "Test"
-
-    _executor = {
-        "name": "core.arithmetic.multiply_add",
-        "type": "WorkflowFactory",
-    }
 
     def create_properties(self) -> None:
         pass
@@ -93,3 +92,11 @@ class TestArithmeticMultiplyAdd(Task):
         self.add_output("workgraph.aiida_int", "result")
         self.add_output("workgraph.any", "_wait")
         self.add_output("workgraph.any", "_outputs")
+
+    def get_executor(self):
+        executor = {
+            "use_module_path": True,
+            "callable_name": "core.arithmetic.multiply_add",
+            "type": "WorkflowFactory",
+        }
+        return executor

--- a/src/aiida_workgraph/utils/inspect_aiida_components.py
+++ b/src/aiida_workgraph/utils/inspect_aiida_components.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union, Tuple
+import inspect
+from aiida.engine.processes.ports import PortNamespace
+from aiida_workgraph.utils import build_callable
+from aiida_workgraph.config import builtin_inputs, builtin_outputs
+from aiida_workgraph.orm.mapping import type_mapping
+
+
+def add_input_recursive(
+    inputs: List[List[Union[str, Dict[str, Any]]]],
+    port: PortNamespace,
+    prefix: Optional[str] = None,
+    required: bool = True,
+) -> List[List[Union[str, Dict[str, Any]]]]:
+    """Add input recursively."""
+    if prefix is None:
+        port_name = port.name
+    else:
+        port_name = f"{prefix}.{port.name}"
+    required = port.required and required
+    input_names = [input["name"] for input in inputs]
+    if isinstance(port, PortNamespace):
+        # TODO the default value is {} could cause problem, because the address of the dict is the same,
+        # so if you change the value of one port, the value of all the ports of other tasks will be changed
+        # consider to use None as default value
+        if port_name not in input_names:
+            inputs.append(
+                {
+                    "identifier": "workgraph.namespace",
+                    "name": port_name,
+                    "metadata": {
+                        "arg_type": "kwargs",
+                        "required": required,
+                        "dynamic": port.dynamic,
+                    },
+                }
+            )
+        for value in port.values():
+            add_input_recursive(inputs, value, prefix=port_name, required=required)
+    else:
+        if port_name not in input_names:
+            # port.valid_type can be a single type or a tuple of types,
+            # we only support single type for now
+            if isinstance(port.valid_type, tuple) and len(port.valid_type) > 1:
+                socket_type = "workgraph.any"
+            if isinstance(port.valid_type, tuple) and len(port.valid_type) == 1:
+                socket_type = type_mapping.get(port.valid_type[0], "workgraph.any")
+            else:
+                socket_type = type_mapping.get(port.valid_type, "workgraph.any")
+            inputs.append(
+                {
+                    "identifier": socket_type,
+                    "name": port_name,
+                    "metadata": {"arg_type": "kwargs", "required": required},
+                }
+            )
+    return inputs
+
+
+def add_output_recursive(
+    outputs: List[List[Union[str, Dict[str, Any]]]],
+    port: PortNamespace,
+    prefix: Optional[str] = None,
+    required: bool = True,
+) -> List[List[Union[str, Dict[str, Any]]]]:
+    """Add output recursively."""
+    if prefix is None:
+        port_name = port.name
+    else:
+        port_name = f"{prefix}.{port.name}"
+    required = port.required and required
+    output_names = [output["name"] for output in outputs]
+    if isinstance(port, PortNamespace):
+        # TODO the default value is {} could cause problem, because the address of the dict is the same,
+        # so if you change the value of one port, the value of all the ports of other tasks will be changed
+        # consider to use None as default value
+        if port_name not in output_names:
+            outputs.append(
+                {
+                    "identifier": "workgraph.namespace",
+                    "name": port_name,
+                    "metadata": {"required": required, "dynamic": port.dynamic},
+                }
+            )
+        for value in port.values():
+            add_output_recursive(outputs, value, prefix=port_name, required=required)
+    else:
+        if port_name not in output_names:
+            outputs.append(
+                {
+                    "identifier": "workgraph.any",
+                    "name": port_name,
+                    "metadata": {"required": required},
+                }
+            )
+    return outputs
+
+
+def get_task_data_from_aiida_component(
+    tdata: Dict[str, Any],
+    inputs: Optional[List[str]] = None,
+    outputs: Optional[List[str]] = None,
+) -> Tuple["Task", Dict[str, Any]]:
+    """Register a task from a AiiDA component.
+    For example: CalcJob, WorkChain, CalcFunction, WorkFunction."""
+    import importlib
+    from aiida_workgraph.utils import inspect_aiida_component_type
+
+    tdata.setdefault("metadata", {})
+    inputs = [] if inputs is None else inputs
+    outputs = [] if outputs is None else outputs
+    if "module_path" in tdata:
+        module = importlib.import_module("{}".format(tdata.get("module_path", "")))
+        executor = getattr(module, tdata["callable_name"])
+    else:
+        executor = tdata["callable"]
+    task_type = inspect_aiida_component_type(executor)
+    if not task_type:
+        raise ValueError(f"The callable {executor} is not a valid AiiDA component.")
+    spec = executor.spec()
+    for _, port in spec.inputs.ports.items():
+        add_input_recursive(inputs, port, required=port.required)
+    for _, port in spec.outputs.ports.items():
+        add_output_recursive(outputs, port, required=port.required)
+    # Only check this for calcfunction and workfunction
+    if inspect.isfunction(executor) and spec.inputs.dynamic:
+        if hasattr(executor.process_class, "_varargs"):
+            name = executor.process_class._varargs
+        else:
+            name = (
+                executor.process_class._var_keyword
+                or executor.process_class._var_positional
+            )
+        # if user already defined the var_args in the inputs, skip it
+        if name not in [input["name"] for input in inputs]:
+            inputs.append(
+                {
+                    "identifier": "workgraph.namespace",
+                    "name": name,
+                    "metadata": {"arg_type": "var_kwargs", "dynamic": True},
+                }
+            )
+
+    tdata["identifier"] = tdata.pop("identifier", executor.__name__)
+    tdata["executor"] = build_callable(executor)
+    if task_type.upper() in ["CALCFUNCTION", "WORKFUNCTION"]:
+        outputs = (
+            [{"identifier": "workgraph.any", "name": "result"}]
+            if not outputs
+            else outputs
+        )
+    # add built-in sockets
+    for output in builtin_outputs:
+        outputs.append(output.copy())
+    for input in builtin_inputs:
+        inputs.append(input.copy())
+    tdata["metadata"]["node_class"] = {
+        "module_path": "aiida_workgraph.task",
+        "callable_name": "Task",
+    }
+    tdata["metadata"]["task_type"] = task_type
+    tdata["inputs"] = inputs
+    tdata["outputs"] = outputs
+    return tdata

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -99,12 +99,12 @@ def test_set_dynamic_port_input(decorated_add) -> None:
     Use can pass AiiDA nodes as values of the dynamic port,
     and the task will create the input for each item in the dynamic port.
     """
-    from .utils.test_workchain import WorkChainWithDynamicNamespace
+    from .utils.test_workchain import WorkChainWithNestNamespace
 
     wg = WorkGraph(name="test_set_dynamic_port_input")
     task1 = wg.add_task(decorated_add)
     task2 = wg.add_task(
-        WorkChainWithDynamicNamespace,
+        WorkChainWithNestNamespace,
         dynamic_port={
             "input1": None,
             "input2": orm.Int(2),
@@ -125,6 +125,30 @@ def test_set_dynamic_port_input(decorated_add) -> None:
         "nested": {"input4": orm.Int(4)},
     }
     assert len(wg.links) == 3
+
+
+def test_set_dynamic_port_output(add_code) -> None:
+    """Test setting dynamic port input of a task.
+    Use can pass AiiDA nodes as values of the dynamic port,
+    and the task will create the input for each item in the dynamic port.
+    """
+    from .utils.test_workchain import WorkChainWithNestNamespace
+
+    wg = WorkGraph(name="test_set_dynamic_port_input")
+    task1 = wg.add_task(WorkChainWithNestNamespace, name="task1")
+    task1.set(
+        {
+            "add": {"x": orm.Int(1), "y": orm.Int(2), "code": add_code},
+            "multiply_add": {
+                "x": orm.Int(1),
+                "y": orm.Int(2),
+                "z": orm.Int(3),
+                "code": add_code,
+            },
+        }
+    )
+    wg.run()
+    assert wg.tasks.task1.outputs.dynamic_port.result1.value == 5
 
 
 def test_set_inputs(decorated_add: Callable) -> None:

--- a/tests/test_workchain.py
+++ b/tests/test_workchain.py
@@ -35,15 +35,15 @@ def test_build_workchain(add_code):
     multiply_add1 = wg.add_task(
         MultiplyAddWorkChain,
         "multiply_add1",
-        x=Int(4).store(),
-        y=Int(2).store(),
-        z=Int(3).store(),
+        x=Int(4),
+        y=Int(2),
+        z=Int(3),
     )
     multiply_add2 = wg.add_task(
         MultiplyAddWorkChain,
         "multiply_add2",
-        x=Int(2).store(),
-        y=Int(3).store(),
+        x=Int(2),
+        y=Int(3),
     )
     wg.add_link(code1.outputs[0], multiply_add1.inputs["code"])
     wg.add_link(code1.outputs[0], multiply_add2.inputs["code"])


### PR DESCRIPTION
This PR adds an `AiiDAProcessTask`, which can take an `executor` as input and thus create the input and output sockets based on the executor. However, I decided not to use it because it would not work if the user used it directly in the `add_task` method.

