### PR TITLE
Fix PythonJob need `aiida_workgraph` on remote computer

### DIFF
--- a/src/aiida_workgraph/engine/utils.py
+++ b/src/aiida_workgraph/engine/utils.py
@@ -84,7 +84,10 @@ def prepare_for_python_task(task: dict, kwargs: dict, var_kwargs: dict) -> dict:
                 function_outputs.append(
                     {"name": output["name"], "identifier": output["identifier"]}
                 )
-
+    # delete workgraph related attributes of the func if exist
+    for attr in ["task", "tdata", "node"]:
+        if hasattr(func, attr):
+            delattr(func, attr)
     inputs = prepare_pythonjob_inputs(
         function=func,
         function_inputs=function_inputs,


### PR DESCRIPTION
In the decorated function of PythonJob, we attached the WorkGraph's `Task` class to the function, this will be pickled together with the function, thus, when unpickling the function on the remote computer, it require `aiida-workgraph`. 

Thsi PR deletes the workgraph related attributes of the decorated func if exist.