### PR TITLE
WIP implementing tracked context variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 [project.entry-points."aiida_workgraph.socket"]
 "workgraph.any" = "aiida_workgraph.sockets.builtins:SocketAny"
 "workgraph.namespace" = "aiida_workgraph.socket:TaskSocketNamespace"
+"workgraph.variables" = "aiida_workgraph.socket:ContextSocketNameSpace"
+"workgraph.variable" = "aiida_workgraph.sockets.builtins:SocketVariable"
 "workgraph.int" = "aiida_workgraph.sockets.builtins:SocketInt"
 "workgraph.float" = "aiida_workgraph.sockets.builtins:SocketFloat"
 "workgraph.string" = "aiida_workgraph.sockets.builtins:SocketString"

--- a/src/aiida_workgraph/socket.py
+++ b/src/aiida_workgraph/socket.py
@@ -1,12 +1,11 @@
-from typing import Any, Type
+from typing import Any, Type 
 
 from aiida import orm
 from node_graph.socket import (
     NodeSocket,
     NodeSocketNamespace,
 )
-
-from aiida_workgraph.property import TaskProperty
+from aiida_workgraph.property import TaskProperty 
 from aiida_workgraph.orm.mapping import type_mapping
 
 
@@ -31,8 +30,17 @@ class TaskSocket(NodeSocket):
                     "Data node does not have a value attribute. We do not know how to extract the raw Python value."
                 )
         else:
-            return self.value
+            return self.value 
 
+class ContextSocketNamespace(NodeSocketNamespace):
+    """Represent a namespace of a Task in the AiiDA WorkGraph."""
+
+    _identifier = "workgraph.context"
+    _socket_property_class = TaskProperty # I think this does not change
+    _type_mapping: dict = type_mapping
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, entry_point="aiida_workgraph.socket", **kwargs) # do we need different entry point?
 
 class TaskSocketNamespace(NodeSocketNamespace):
     """Represent a namespace of a Task in the AiiDA WorkGraph."""

--- a/src/aiida_workgraph/sockets/builtins.py
+++ b/src/aiida_workgraph/sockets/builtins.py
@@ -8,6 +8,13 @@ class SocketAny(TaskSocket):
     _socket_property_identifier: str = "workgraph.any"
 
 
+class SocketVariable(TaskSocket):
+    """Variable socket."""
+
+    _identifier: str = "workgraph.variable"
+    _socket_property_identifier: str = "workgraph.any"
+
+
 class SocketFloat(TaskSocket):
     """Float socket."""
 

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -1,6 +1,30 @@
 from typing import Any, Dict
 from aiida_workgraph.task import Task, TaskCollection
+from aiida_workgraph.socket import ContextSocketNamespace
+from aiida_workgraph.sockets.builtins import SocketVariable
 
+
+class ContextTask(Task):
+    """
+    Extend the Task class to include a 'children' attribute.
+    """
+
+    identifier = "workgraph.context"
+    name = "Context"
+    node_type = "CONTEXT"
+    catalog = "Control"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # I think this can be NodeSocketNamsepace
+        # ContextSocketNamespace is doing nothing
+        self.variables = ContextSocketNamespace("variables", node=self, pool=self.socket_pool)
+
+    def add_variable(self, name: str, **kwargs) -> SocketVariable:
+        """Add a variable socket to this node."""
+
+        context = self.variables._new("workgraph.variable", name, **kwargs)
+        return context
 
 class Zone(Task):
     """


### PR DESCRIPTION
This PR is working on issue issue #408.

For graphical visualization in the GUI we need some class that tracks the connection that the context variable is used for. The context itself is completely agnostic of its access by design. Also the context is an object of plumpy and is completely unaware of the GUI, therefore in workgraph we use the `node_graph.socket.NodeSocket` for this purpose. These are heavily coupled with `node_graph.link.NodeLink` that tracks it connection to other nodes.

For this implementation we need to create a new type of Sockets with extended capabilities:

1. We need to track usage and create new sockets internally while the user is not necessary aware of it.
```python

def increment(x): return x+1

wg.context.x = aiida.orm.Int(5) # create socket x0 with initial value
t = wg.add_task(increment, x = wg.context.x) # link socket x0 to t.inputs.x
wg.context.x = t.outputs.result # create socket x1 and link to results
t2 = wg.add_task(increment, x = wg.context.x) # link socket x1 to t2.inputs.x
```

2. We need to allow bidirectional usage as input and output
```python
wg.add_link(wg.context.x, t.inputs.x)
…
wg.add_link(t.outputs.x, wg.context.x)
```

Since a socket by itself is not containing any logic how it is populated, we need also a new `Task` class specifically for managing the `Socket`. We need to at least implement a wrapper around the sockets to implement custom `__getattr__`, and `__setattr__` to create Sockets on access. At first glance, a specialized `NodeSocketNamespace` looks like the the right way to implemnt this, but on the other hand we want to implement a very specfic access pattern that that easily can interfere with the other patterns of `NodeSocketNamespace`. So it seems better to implement a separated `AccessInterface` in `WorkGraph` or the specialized `Task` that exposes this `NodeSocketNamespace` to the user.

This requires to touch part multiple parts of the code. As we need to implement has this new `Task` and `Socket` is handled during execution (population of socket, and passing of this new socket namespace). The population of the socket is outline in this WIP but the new socket namespace is not passed to the execution time.

Furthermore, how this is implemented at the GUI is still an open question. We have a design ideas, see images in the PR on GitHub.

### Design ideas for GUI

The visualization of the aiida.orm.Int nodes is just to clarify it and is not part of this PR

#### Example 1
```python
def increment(x): return x+1

wg.context.x = aiida.orm.Int(2)
wg.add_task(increment, x = wg.context.x)
```

<img width="269" alt="image" src="https://github.com/user-attachments/assets/06fdef3c-9b4f-4731-ac2b-72039542eae0" />

#### Example 2

```python
def increment(x): return x+1

wg.context.x = aiida.orm.Int(5)
t = wg.add_task(increment, x = wg.context.x)
wg.context.x = t.outputs.result

wg.add_task(increment, x = wg.context.x)
```

<img width="415" alt="image" src="https://github.com/user-attachments/assets/1fc68545-8006-42fb-a6c6-c44f3cf74c7b" />
