### PR TITLE
Add `__repr__` and `__str__` to WG

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -543,3 +543,9 @@ class WorkGraph(node_graph.NodeGraph):
         """Write a standalone html file to visualize the workgraph."""
         self._widget.value = self.to_widget_value()
         return self._widget.to_html(output=output, **kwargs)
+
+    def __repr__(self) -> str:
+        return f'WorkGraph(name="{self.name}", uuid="{self.uuid}")'
+
+    def __str__(self) -> str:
+        return f'WorkGraph(name="{self.name}", uuid="{self.uuid}")'


### PR DESCRIPTION
To avoid any confusion in the future, as occured in #411, `__repr__` and `__str__` are added to WG. `__str__` should probably be a nicer output, but just added the same as implemented in `NodeGraph` for both dunder methods, to not spend much time on it, but still have it resolved and tracked.