### PR TITLE
Refactor If_ and While_ using BaseFlowBlock, fix task zone handling

### DIFF
--- a/src/aiida_workgraph/__init__.py
+++ b/src/aiida_workgraph/__init__.py
@@ -4,6 +4,6 @@ from .decorator import task, build_task
 from .tasks import TaskPool
 from .utils.flow_control import if_, while_
 
-__version__ = "0.4.10"
+__version__ = "0.5.0a1"
 
 __all__ = ["WorkGraph", "Task", "task", "build_task", "if_", "while_", "TaskPool"]


### PR DESCRIPTION

- Introduced `_add_tasks_to_zone` to properly add normal tasks, while loops, and if conditions to zones.
- Fixed `children` assignment, ensuring all task types are correctly counted.
- Refactored `If_` and `While_` to inherit from `BaseFlowBlock`, reducing duplicate code.
- Centralized task naming logic in `_generate_name` and made `_task_identifier` an overridable property.