### PR TITLE
graph_builder for loop section

### DIFF
--- a/docs/gallery/howto/autogen/graph_builder.py
+++ b/docs/gallery/howto/autogen/graph_builder.py
@@ -200,8 +200,11 @@ def add_one(x):
 @task.graph_builder(outputs=[{"name": "result", "from": "ctx.task_out"}])
 def for_loop(nb_iterations: Int):
     wg = WorkGraph()
+    results = []
     for i in range(nb_iterations.value):
         task = wg.add_task(add_one, x=i)
+        # Collect all results
+        results.append(task.outputs.result)
 
     # We cannot refer to a specific task as output in the graph builder decorator
     # as in the examples before since the name of the last task depends on the input.
@@ -211,7 +214,7 @@ def for_loop(nb_iterations: Int):
     # of the graph builder decorator.
 
     # Put result of the task to the context under the name task_out
-    wg.update_ctx({"task_out": task.outputs.result})
+    wg.update_ctx({"task_out": results})
     # If want to know more about the usage of the context please refer to the
     # context howto in the documentation
     return wg


### PR DESCRIPTION
issue #439 

Previously, in the `for_loop` function, the `task` variable was overwritten in each iteration. As a result, only the last iteration's result was accessible as `ctx.task_out`, while all previous task results were lost.

Now, a `results` variable has been added to store a list of all computed results.

This ensures that the function behaves as expected and returns all computed values instead of just the last one.