### PR TITLE
Do not de-serialize data when loading PytohnJob task

### DIFF
--- a/docs/gallery/built-in/autogen/shelljob.py
+++ b/docs/gallery/built-in/autogen/shelljob.py
@@ -170,7 +170,7 @@ wg.to_html()
 
 wg.submit(wait=True, timeout=100)
 print("State of WorkGraph    : {}".format(wg.state))
-print("Result               : {}".format(expr_2.node.outputs.result.value))
+print("Result               : {}".format(expr_2.outputs.result.value))
 
 
 # %%

--- a/docs/gallery/tutorial/autogen/qe.py
+++ b/docs/gallery/tutorial/autogen/qe.py
@@ -308,7 +308,7 @@ wg.add_link(paras_task.outputs[0], pw_relax1.inputs.base.pw.parameters)
 # wg.submit(wait=True, timeout=200)
 # print(
 #     "\nEnergy of a relaxed N2 molecule: {:0.3f}".format(
-#         pw_relax1.node.outputs.output_parameters.get_dict()["energy"]
+#         pw_relax1.outputs.output_parameters.get_dict()["energy"]
 #     )
 # )
 

--- a/docs/source/built-in/pythonjob.ipynb
+++ b/docs/source/built-in/pythonjob.ipynb
@@ -23,17 +23,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 1,
       "id": "c6b83fb5",
       "metadata": {},
       "outputs": [
         {
           "data": {
             "text/plain": [
-              "Profile<uuid='57ccbf7d9e2b41b39edb2bfdaf725feb' name='default'>"
+              "Profile<uuid='91ab760297b7474e99505a4bc4da8805' name='presto'>"
             ]
           },
-          "execution_count": 8,
+          "execution_count": 1,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -2228,7 +2228,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 6,
       "id": "a96cbbcb",
       "metadata": {},
       "outputs": [
@@ -2236,7 +2236,8 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "WorkGraph process created, PK: 151330\n",
+            "WorkGraph process created, PK: 55608\n",
+            "Process 55608 finished with state: FINISHED\n",
             "exit status:  410\n",
             "exit message:  Sum is negative\n"
           ]
@@ -2257,8 +2258,8 @@
         "wg.add_task(add, name=\"add\", x=1, y=-2)\n",
         "wg.submit(wait=True)\n",
         "\n",
-        "print(\"exit status: \",  wg.tasks.add.node.exit_status)\n",
-        "print(\"exit message: \",  wg.tasks.add.node.exit_message)"
+        "print(\"exit status: \",  wg.tasks.add.process.exit_status)\n",
+        "print(\"exit message: \",  wg.tasks.add.process.exit_message)"
       ]
     },
     {
@@ -2298,8 +2299,11 @@
         "    Simply make the inputs positive by taking the absolute value.\n",
         "    \"\"\"\n",
         "    # modify task inputs\n",
-        "    task.set({\"x\": abs(task.inputs[\"x\"].value),\n",
-        "              \"y\": abs(task.inputs[\"y\"].value)})\n",
+        "    # because the error_handler is ran by the engine\n",
+        "    # all the inputs are serialized to AiiDA data\n",
+        "    # therefore, we need use the `value` attribute to get the raw data\n",
+        "    task.set({\"x\": abs(task.inputs[\"x\"].value.value),\n",
+        "              \"y\": abs(task.inputs[\"y\"].value.value)})\n",
         "    \n",
         "    msg = \"Run error handler: handle_negative_sum.\"\n",
         "    return msg\n",
@@ -2320,8 +2324,8 @@
         "wg = WorkGraph(\"test_PythonJob\")\n",
         "wg.add_task(add, name=\"add1\", x=1, y=-2, computer=\"localhost\")\n",
         "wg.submit(wait=True)\n",
-        "print(\"exit status: \",  wg.tasks[\"add1\"].node.exit_status)\n",
-        "print(\"exit message: \",  wg.tasks[\"add1\"].node.exit_message)"
+        "print(\"exit status: \",  wg.tasks[\"add1\"].process.exit_status)\n",
+        "print(\"exit message: \",  wg.tasks[\"add1\"].process.exit_message)"
       ]
     },
     {
@@ -2388,7 +2392,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.10.4 ('scinode')",
+      "display_name": "aiida",
       "language": "python",
       "name": "python3"
     },
@@ -2403,11 +2407,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.11.0"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "2f450c1ff08798c4974437dd057310afef0de414c25d1fd960ad375311c3f6ff"
-      }
     }
   },
   "nbformat": 4,

--- a/docs/source/howto/context.ipynb
+++ b/docs/source/howto/context.ipynb
@@ -170,7 +170,7 @@
    "source": [
     "wg.submit(wait=True)\n",
     "print(\"State of WorkGraph         : {}\".format(wg.state))\n",
-    "print('Result of add1            : {}'.format(wg.tasks[\"add1\"].node.outputs.result.value))"
+    "print('Result of add1            : {}'.format(wg.tasks.add1.outputs.result.value))"
    ]
   },
   {

--- a/docs/source/howto/continue_finished_workgraph.ipynb
+++ b/docs/source/howto/continue_finished_workgraph.ipynb
@@ -146,9 +146,9 @@
    ],
    "source": [
     "print(\"State of WorkGraph   : {}\".format(wg2.state))\n",
-    "print('Result of add1      : {}'.format(wg.tasks[\"add1\"].node.outputs.result.value))\n",
-    "print('Result of multiply1 : {}'.format(wg.tasks[\"multiply1\"].node.outputs.result.value))\n",
-    "print('Result of add2      : {}'.format(wg2.tasks[\"add2\"].node.outputs.result.value))"
+    "print('Result of add1      : {}'.format(wg.tasks.add1.outputs.result.value))\n",
+    "print('Result of multiply1 : {}'.format(wg.tasks.multiply1.outputs.result.value))\n",
+    "print('Result of add2      : {}'.format(wg2.tasks.add2.outputs.result.value))"
    ]
   },
   {

--- a/docs/source/howto/error_resistant.ipynb
+++ b/docs/source/howto/error_resistant.ipynb
@@ -469,8 +469,8 @@
     "wg = WorkGraph(\"test_PythonJob\")\n",
     "wg.add_task(add, name=\"add1\", x=1, y=-2, computer=\"localhost\")\n",
     "wg.submit(wait=True)\n",
-    "print(\"exit status: \",  wg.tasks[\"add1\"].node.exit_status)\n",
-    "print(\"exit message: \",  wg.tasks[\"add1\"].node.exit_message)"
+    "print(\"exit status: \",  wg.tasks[\"add1\"].process.exit_status)\n",
+    "print(\"exit message: \",  wg.tasks[\"add1\"].process.exit_message)"
    ]
   },
   {

--- a/docs/source/howto/waiting_on.ipynb
+++ b/docs/source/howto/waiting_on.ipynb
@@ -139,7 +139,7 @@
    ],
    "source": [
     "print(\"State of WorkGraph         : {}\".format(wg.state))\n",
-    "print('Result of sum1: {}'.format(wg.tasks[\"sum1\"].node.outputs.result.value))"
+    "print('Result of sum1: {}'.format(wg.tasks.sum1.outputs.result.value))"
    ]
   },
   {

--- a/src/aiida_workgraph/tasks/factory/pythonjob_task.py
+++ b/src/aiida_workgraph/tasks/factory/pythonjob_task.py
@@ -51,7 +51,7 @@ class PythonJobTask(Task):
 
     def update_from_dict(self, data: Dict[str, Any], **kwargs) -> "PythonJobTask":
         """Overwrite the update_from_dict method to handle the PythonJob data."""
-        self.deserialize_pythonjob_data(data["inputs"]["sockets"])
+        # self.deserialize_pythonjob_data(data["inputs"]["sockets"])
         super().update_from_dict(data)
 
     @classmethod

--- a/tests/test_calcfunction.py
+++ b/tests/test_calcfunction.py
@@ -9,8 +9,7 @@ def test_run(wg_calcfunction: WorkGraph) -> None:
     wg.run()
     print("state: ", wg.state)
     # print("results: ", results[])
-    assert wg.tasks["sumdiff2"].node.outputs.sum == 9
-    assert wg.tasks["sumdiff2"].outputs.sum.value == 9
+    assert wg.tasks.sumdiff2.outputs.sum.value == 9
 
 
 def test_dynamic_inputs() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -19,15 +19,17 @@ def test_run_order(decorated_add) -> None:
 @pytest.mark.skip(reason="The test is not stable.")
 def test_reset_node(wg_engine: WorkGraph) -> None:
     """Modify a node during the excution of a WorkGraph."""
+    from aiida import orm
+
     wg = wg_engine
     wg.name = "test_reset"
     wg.submit()
     time.sleep(15)
-    wg.tasks["add3"].set({"y": aiida.orm.Int(10).store()})
+    wg.tasks["add3"].set({"y": orm.Int(10).store()})
     wg.save()
     wg.wait()
     wg.update()
-    assert wg.tasks["add5"].node.outputs.sum == 21
+    assert wg.tasks.add5.outputs.sum == 21
     assert wg.process.base.extras.get("_workgraph_queue_index") == 1
     assert len(wg.process.base.extras.get("_workgraph_queue")) == 1
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -26,4 +26,4 @@ def test_multiply_link() -> None:
     wg.add_link(float3.outputs[0], sum1.inputs.datas)
     # wg.submit(wait=True)
     wg.run()
-    assert sum1.node.outputs.result.value == 6
+    assert sum1.outputs.result.value == 6

--- a/tests/test_normal_function.py
+++ b/tests/test_normal_function.py
@@ -12,7 +12,7 @@ def test_normal_function_run(
     add2 = wg.add_task(decorated_add, "add2", x=6)
     wg.add_link(add1.outputs.result, add2.inputs["y"])
     wg.run()
-    assert wg.tasks.add2.node.outputs.result == 11
+    assert wg.tasks.add2.outputs.result == 11
 
 
 @pytest.mark.usefixtures("started_daemon_client")
@@ -25,4 +25,4 @@ def test_normal_function_submit(
     add2 = wg.add_task(decorated_add, "add2", x=6)
     wg.add_link(add1.outputs.result, add2.inputs["y"])
     wg.submit(wait=True)
-    assert wg.tasks.add2.node.outputs.result == 11
+    assert wg.tasks.add2.outputs.result == 11

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -315,11 +315,13 @@ def test_exit_code(fixture_localhost, python_executable_path):
         """Handle the failure code 410 of the `add`.
         Simply make the inputs positive by taking the absolute value.
         """
-
+        # because the error_handler is ran by the engine
+        # all the inputs are serialized to AiiDA data
+        # therefore, we need use the `value` attribute to get the raw data
         task.set(
             {
-                "x": abs(task.inputs.x.value),
-                "y": abs(task.inputs["y"].value),
+                "x": abs(task.inputs.x.value.value),
+                "y": abs(task.inputs.y.value.value),
             }
         )
 
@@ -355,5 +357,5 @@ def test_exit_code(fixture_localhost, python_executable_path):
         == "Some elements are negative"
     )
     # the final task should have exit status 0
-    assert wg.tasks.add1.node.exit_status == 0
+    assert wg.tasks.add1.process.exit_status == 0
     assert (wg.tasks.add1.outputs.sum.value.value == np.array([2, 3])).all()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -29,7 +29,7 @@ def test_shell_command(fixture_localhost):
     # also check if we can set the computer explicitly
     job1.set({"metadata.computer": load_computer("localhost")})
     wg.run()
-    assert job1.node.outputs.stdout.get_content() == "string astring b"
+    assert job1.outputs.stdout.value.get_content() == "string astring b"
 
 
 def test_shell_code():
@@ -46,7 +46,7 @@ def test_shell_code():
         },
     )
     wg.run()
-    assert job1.node.outputs.stdout.get_content() == "string astring b"
+    assert job1.outputs.stdout.value.get_content() == "string astring b"
 
 
 def test_dynamic_port():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -18,7 +18,7 @@ def test_normal_task(decorated_add) -> None:
         decorated_add, name="add", x=task1.outputs.sum, y=task1.outputs["diff"]
     )
     wg.run()
-    print("node: ", task2.node.outputs.result)
+    print("node: ", task2.outputs.result)
     wg.update()
     assert task2.outputs.result.value == 4
 

--- a/tests/test_while.py
+++ b/tests/test_while.py
@@ -176,4 +176,4 @@ def test_while_graph_builder(decorated_add, decorated_multiply, decorated_smalle
     wg.add_link(my_while1.outputs.result, add2.inputs.x)
     wg.run()
     assert add2.outputs.result.value < 31
-    assert my_while1.node.outputs.execution_count == 2
+    assert my_while1.process.outputs.execution_count == 2

--- a/tests/test_workchain.py
+++ b/tests/test_workchain.py
@@ -8,7 +8,7 @@ def test_workchain(wg_workchain):
     wg.name = "test_workchain"
     wg.run()
     # print("results: ", results[])
-    assert wg.tasks["multiply_add2"].node.outputs.result == 17
+    assert wg.tasks.multiply_add2.outputs.result == 17
 
 
 def test_build_workchain_inputs_outputs():
@@ -48,7 +48,7 @@ def test_build_workchain(add_code):
     wg.add_link(code1.outputs[0], multiply_add2.inputs["code"])
     wg.add_link(multiply_add1.outputs[0], multiply_add2.inputs["z"])
     wg.submit(wait=True, timeout=100)
-    assert wg.tasks["multiply_add2"].node.outputs.result == 17
+    assert wg.tasks.multiply_add2.outputs.result == 17
     # reload wg
     wg1 = WorkGraph.load(wg.pk)
-    assert wg1.tasks["multiply_add2"].node.outputs.result == 17
+    assert wg1.tasks.multiply_add2.outputs.result == 17

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -140,23 +140,23 @@ def test_restart_and_reset(wg_calcfunction):
         "workgraph.test_sum_diff",
         "sumdiff3",
         x=4,
-        y=wg.tasks["sumdiff2"].outputs.sum,
+        y=wg.tasks.sumdiff2.outputs.sum,
     )
     wg.name = "test_restart_0"
     wg.run()
     wg1 = WorkGraph.load(wg.process.pk)
     wg1.restart()
     wg1.name = "test_restart_1"
-    wg1.tasks["sumdiff2"].set({"x": orm.Int(10).store()})
+    wg1.tasks.sumdiff2.set({"x": orm.Int(10).store()})
     wg1.run()
-    assert wg1.tasks["sumdiff1"].node.pk == wg.tasks["sumdiff1"].pk
-    assert wg1.tasks["sumdiff2"].node.pk != wg.tasks["sumdiff2"].pk
-    assert wg1.tasks["sumdiff3"].node.pk != wg.tasks["sumdiff3"].pk
-    assert wg1.tasks["sumdiff3"].node.outputs.sum == 19
+    assert wg1.tasks.sumdiff1.pk == wg.tasks.sumdiff1.pk
+    assert wg1.tasks.sumdiff2.pk != wg.tasks.sumdiff2.pk
+    assert wg1.tasks.sumdiff3.pk != wg.tasks.sumdiff3.pk
+    assert wg1.tasks.sumdiff3.outputs.sum == 19
     wg1.reset()
     assert wg1.process is None
-    assert wg1.tasks["sumdiff3"].process is None
-    assert wg1.tasks["sumdiff3"].state == "PLANNED"
+    assert wg1.tasks.sumdiff3.process is None
+    assert wg1.tasks.sumdiff3.state == "PLANNED"
 
 
 def test_extend_workgraph(decorated_add_multiply_group):
@@ -166,15 +166,13 @@ def test_extend_workgraph(decorated_add_multiply_group):
     add1 = wg.add_task("workgraph.test_add", "add1", x=2, y=3)
     add_multiply_wg = decorated_add_multiply_group(x=0, y=4, z=5)
     # test wait
-    add_multiply_wg.tasks["multiply1"].waiting_on.add("add1")
+    add_multiply_wg.tasks.multiply1.waiting_on.add("add1")
     # extend workgraph
     wg.extend(add_multiply_wg, prefix="group_")
-    assert "group_add1" in [
-        task.name for task in wg.tasks["group_multiply1"].waiting_on
-    ]
-    wg.add_link(add1.outputs[0], wg.tasks["group_add1"].inputs.x)
+    assert "group_add1" in [task.name for task in wg.tasks.group_multiply1.waiting_on]
+    wg.add_link(add1.outputs[0], wg.tasks.group_add1.inputs.x)
     wg.run()
-    assert wg.tasks["group_multiply1"].node.outputs.result == 45
+    assert wg.tasks.group_multiply1.outputs.result == 45
 
 
 def test_workgraph_group_outputs(decorated_add):

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -11,7 +11,7 @@ def test_calcfunction():
     assert wg.tasks.sumdiff1.inputs.x.value == 2.0
     assert wg.tasks.sumdiff2.inputs.x.value == 4.0
     wg.run()
-    assert wg.tasks.sumdiff2.node.outputs.sum == 9
+    assert wg.tasks.sumdiff2.outputs.sum == 9
 
 
 # skip this test for now
@@ -19,4 +19,4 @@ def test_calcfunction():
 def test_calcjob():
     wg = WorkGraph.from_yaml(os.path.join(cwd, "datas/test_calcjob.yaml"))
     wg.submit(wait=True)
-    assert wg.tasks.add2.node.outputs.sum == 9
+    assert wg.tasks.add2.outputs.sum == 9


### PR DESCRIPTION
Fix #448 

This is a temporary fix. We do not de-serialize the data when loading PythonJob task,, which means the user will need to know some basic knowledge of AiiDA data, e.g., when writing the error_handers.