### PR TITLE
Do not run widget hook by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.1.28",
+    "node-graph==0.1.29",
     "node-graph-widget>=0.0.4",
     "aiida-core>=2.3",
     "cloudpickle",

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -9,6 +9,7 @@ from aiida_workgraph.tasks.factory import (
     DecoratedFunctionTaskFactory,
     AiiDAComponentTaskFactory,
     WorkGraphTaskFactory,
+    PyFunctionTaskFactory,
 )
 
 
@@ -57,8 +58,10 @@ def build_task_from_callable(
                 executor, inputs=inputs, outputs=outputs
             )
         else:
-            return DecoratedFunctionTaskFactory.from_function(
-                executor, inputs=inputs, outputs=outputs
+            return PyFunctionTaskFactory.from_function(
+                executor,
+                inputs=inputs,
+                outputs=outputs,
             )
     else:
         if issubclass(executor, CalcJob) or issubclass(executor, WorkChain):
@@ -179,10 +182,6 @@ class TaskDecoratorCollection:
         """
 
         def decorator(callable):
-            from aiida_workgraph.tasks.factory import (
-                PyFunctionTaskFactory,
-            )
-            from aiida_pythonjob.decorator import pyfunction
 
             # function or builtin function
             if inspect.isfunction(callable) or callable.__module__ == "builtins":
@@ -193,7 +192,6 @@ class TaskDecoratorCollection:
                     )
                 else:
                     if store_provenance:
-                        callable = pyfunction(outputs=outputs)(callable)
                         TaskCls = PyFunctionTaskFactory.from_function(
                             callable,
                             inputs=inputs,

--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -5,7 +5,6 @@ from node_graph.executor import NodeExecutor
 from aiida_workgraph.properties import PropertyPool
 from aiida_workgraph.sockets import SocketPool
 from aiida_workgraph.socket import TaskSocketNamespace
-from node_graph_widget import NodeGraphWidget
 from aiida_workgraph.collection import (
     WorkGraphPropertyCollection,
 )
@@ -44,10 +43,6 @@ class Task(GraphNode):
         self.waiting_on = WaitingTaskSet(parent=self)
         self.process = process
         self.pk = pk
-        self._widget = NodeGraphWidget(
-            settings={"minmap": False},
-            style={"width": "80%", "height": "600px"},
-        )
         self.state = "PLANNED"
         self.action = ""
         self.show_socket_depth = 0
@@ -256,11 +251,11 @@ class Task(GraphNode):
 
     def _repr_mimebundle_(self, *args: Any, **kwargs: Any) -> any:
         # if ipywdigets > 8.0.0, use _repr_mimebundle_ instead of _ipython_display_
-        self._widget.value = self.to_widget_value()
-        if hasattr(self._widget, "_repr_mimebundle_"):
-            return self._widget._repr_mimebundle_(*args, **kwargs)
+        self.widget.value = self.to_widget_value()
+        if hasattr(self.widget, "_repr_mimebundle_"):
+            return self.widget._repr_mimebundle_(*args, **kwargs)
         else:
-            return self._widget._ipython_display_(*args, **kwargs)
+            return self.widget._ipython_display_(*args, **kwargs)
 
     def to_html(
         self, output: str = None, show_socket_depth: Optional[int] = None, **kwargs
@@ -268,8 +263,8 @@ class Task(GraphNode):
         """Write a standalone html file to visualize the task."""
         if show_socket_depth is None:
             show_socket_depth = self.show_socket_depth
-        self._widget.value = self.to_widget_value()
-        return self._widget.to_html(output=output, **kwargs)
+        self.widget.value = self.to_widget_value()
+        return self.widget.to_html(output=output, **kwargs)
 
 
 class TaskSet:

--- a/src/aiida_workgraph/utils/graph.py
+++ b/src/aiida_workgraph/utils/graph.py
@@ -8,9 +8,11 @@ def task_creation_hook(self: NodeCollection, task: Any) -> None:
     Args:
         task (Task): a task to be created.
     """
+    if not self.parent.interactive_widget:
+        return
     # send message to the widget
-    if self.parent._widget is not None:
-        self.parent._widget.send(
+    if self.parent.widget is not None:
+        self.parent.widget.send(
             {
                 "type": "add_task",
                 "data": {"label": task.name, "inputs": [], "outputs": []},
@@ -24,14 +26,16 @@ def task_deletion_hook(self: NodeCollection, task: Any) -> None:
     Args:
         task (Task): a task to be deleted.
     """
+    if not self.parent.interactive_widget:
+        return
     # remove all links to the task
     link_index = []
     for index, link in enumerate(self.parent.links):
         if link.from_node.name == task.name or link.to_node.name == task.name:
             link_index.append(index)
     del self.parent.links[link_index]
-    if self._widget is not None:
-        self.parent._widget.send({"type": "delete_node", "data": {"name": task.name}})
+    if self.widget is not None:
+        self.parent.widget.send({"type": "delete_node", "data": {"name": task.name}})
 
 
 def link_creation_hook(self: NodeCollection, link: Any) -> None:
@@ -40,8 +44,10 @@ def link_creation_hook(self: NodeCollection, link: Any) -> None:
     Args:
         link (Link): a link to be created.
     """
-    if self.parent._widget is not None:
-        self.parent._widget.send(
+    if not self.parent.interactive_widget:
+        return
+    if self.parent.widget is not None:
+        self.parent.widget.send(
             {
                 "type": "add_link",
                 "data": {
@@ -60,8 +66,10 @@ def link_deletion_hook(self: NodeCollection, link: Any) -> None:
     Args:
         link (Link): a link to be deleted.
     """
-    if self.parent._widget is not None:
-        self.parent._widget.send(
+    if not self.parent.interactive_widget:
+        return
+    if self.parent.widget is not None:
+        self.parent.widget.send(
             {
                 "type": "delete_link",
                 "data": {


### PR DESCRIPTION
- Load the widget only when used
- Do not run the widget hook by default. Switch on by setting `wg.interactive_widget=True`.

This greatly improves the performance of Jupyter Notebook.