### PR TITLE
Heper function to submit WorkChain to scheduler

### DIFF
--- a/docs/source/howto/scheduler.ipynb
+++ b/docs/source/howto/scheduler.ipynb
@@ -19,29 +19,29 @@
     "\n",
     "## Managing the Scheduler\n",
     "\n",
-    "Start a scheduler with name `test-scheduler`:\n",
+    "Start a scheduler with name `test`:\n",
     "```\n",
-    "workgraph scheduler start test-scheduler\n",
+    "workgraph scheduler start test\n",
     "```\n",
     "\n",
     "Stop the scheduler:\n",
     "```\n",
-    "workgraph scheduler stop test-scheduler\n",
+    "workgraph scheduler stop test\n",
     "```\n",
     "\n",
     "Show the status of the scheduler:\n",
     "```\n",
-    "workgraph scheduler status test-scheduler\n",
+    "workgraph scheduler status test\n",
     "```\n",
     "\n",
     "Show details of the processes submitted to the scheduler:\n",
     "```\n",
-    "workgraph scheduler show test-scheduler\n",
+    "workgraph scheduler show test\n",
     "```\n",
     "\n",
     "Set the maximum number of calcjobs that can be running at the same time:\n",
     "```\n",
-    "workgraph scheduler set-max-jobs test-scheduler 5\n",
+    "workgraph scheduler set-max-jobs test 5\n",
     "```\n",
     "\n",
     "Let's start a scheduler "
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "id": "2f30294e",
    "metadata": {},
    "outputs": [
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "!workgraph scheduler start test-scheduler --max-calcjobs 2 --max-processes 10"
+    "!workgraph scheduler start test --max-calcjobs 2 --max-processes 10"
    ]
   },
   {
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "id": "161f3696",
    "metadata": {},
    "outputs": [
@@ -84,12 +84,12 @@
      "output_type": "stream",
      "text": [
       "Name                status      pk   waiting  running   calcjob  max_calcjobs max_processes\n",
-      "\u001b[1mtest-scheduler      \u001b[0m\u001b[32m\u001b[22mRunning\u001b[0m\u001b[22m  72507     \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  2       \u001b[0m\u001b[22m  10      \u001b[0m\n"
+      "\u001b[1mtest                \u001b[0m\u001b[32m\u001b[22mRunning\u001b[0m\u001b[22m  84410     \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  0       \u001b[0m\u001b[22m  2       \u001b[0m\u001b[22m  10      \u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "!workgraph scheduler status test-scheduler"
+    "!workgraph scheduler status test"
    ]
   },
   {
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "id": "03912de1",
    "metadata": {},
    "outputs": [
@@ -113,10 +113,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WorkGraph process created, PK: 72508\n",
-      "WorkGraph process created, PK: 72509\n",
-      "WorkGraph process created, PK: 72510\n",
-      "WorkGraph process created, PK: 72520\n"
+      "WorkGraph process created, PK: 84411\n",
+      "WorkGraph process created, PK: 84412\n",
+      "WorkGraph process created, PK: 84413\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "04/14/2025 03:07:06 PM <1720302> aiida.engine.utils: [WARNING] Failed to write global variable `process|state_change|work` to `2025-04-14T15:07:06.472336+02:00` because the database was locked. If the storage plugin being used is `core.sqlite_dos` this is to be expected and can be safely ignored.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WorkGraph process created, PK: 84422\n"
      ]
     }
    ],
@@ -138,7 +151,7 @@
     "        # Set a sleep option for each job (e.g., 10 seconds per job)\n",
     "        temp.set({\"metadata.options.sleep\": 10})\n",
     "    # submit the workgraph to a scheduler called \"test-scheduler\"\n",
-    "    wg.submit(scheduler=\"test-scheduler\")"
+    "    wg.submit(scheduler=\"test\")"
    ]
   },
   {
@@ -146,13 +159,13 @@
    "id": "208e13f9",
    "metadata": {},
    "source": [
-    "Note, all the WorkGraphs are submitted to a scheduler named `test-scheduler`. Now, you can check the progress of the Scheduler using the following command:\n",
+    "Note, all the WorkGraphs are submitted to a scheduler named `test`. Now, you can check the progress of the Scheduler using the following command:\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "1f86cb2a",
    "metadata": {},
    "outputs": [
@@ -160,28 +173,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[34m\u001b[1mReport\u001b[0m: \u001b[22mScheduler: test-scheduler\u001b[0m\n",
+      "\u001b[34m\u001b[1mReport\u001b[0m: \u001b[22mScheduler: test\u001b[0m\n",
       "\u001b[22m   PK  Created    Process label                    Process State      Priorities\n",
       "-----  ---------  -------------------------------  ---------------  ------------\n",
-      "72508  14s ago    WorkGraph<test_max_number_jobs>  ⏵ Waiting\n",
-      "72509  13s ago    WorkGraph<test_max_number_jobs>  ⏵ Waiting\n",
-      "72510  11s ago    WorkGraph<test_max_number_jobs>  ⏹ Created                  -2\n",
-      "72513  11s ago    ArithmeticAddCalculation         ⏵ Waiting\n",
-      "72516  10s ago    ArithmeticAddCalculation         ⏵ Waiting\n",
-      "72519  10s ago    ArithmeticAddCalculation         ⏹ Created                   0\n",
-      "72520  10s ago    WorkGraph<test_max_number_jobs>  ⏹ Created                   0\n",
-      "72523  10s ago    ArithmeticAddCalculation         ⏹ Created                  -3\n",
-      "72526  9s ago     ArithmeticAddCalculation         ⏹ Created                   0\n",
-      "72529  6s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
-      "72532  6s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
-      "72535  6s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
-      "72538  5s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
-      "72541  5s ago     ArithmeticAddCalculation         ⏹ Created                  -1\u001b[0m\n",
+      "84411  7s ago     WorkGraph<test_max_number_jobs>  ⏵ Waiting\n",
+      "84412  6s ago     WorkGraph<test_max_number_jobs>  ⏵ Waiting\n",
+      "84413  5s ago     WorkGraph<test_max_number_jobs>  ⏹ Created                  -2\n",
+      "84416  5s ago     ArithmeticAddCalculation         ⏵ Waiting\n",
+      "84419  5s ago     ArithmeticAddCalculation         ⏵ Waiting\n",
+      "84423  5s ago     ArithmeticAddCalculation         ⏹ Created                  -3\n",
+      "84422  5s ago     WorkGraph<test_max_number_jobs>  ⏹ Created                   0\n",
+      "84426  4s ago     ArithmeticAddCalculation         ⏹ Created                   0\n",
+      "84429  4s ago     ArithmeticAddCalculation         ⏹ Created                   0\n",
+      "84432  3s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
+      "84435  3s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
+      "84438  2s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
+      "84441  2s ago     ArithmeticAddCalculation         ⏹ Created                  -1\n",
+      "84444  2s ago     ArithmeticAddCalculation         ⏹ Created                  -1\u001b[0m\n",
       "\u001b[22m\n",
       "Total results: 14\n",
       "\u001b[0m\n",
-      "\u001b[22mname: test-scheduler\u001b[0m\n",
-      "\u001b[22mpk: 72507\u001b[0m\n",
+      "\u001b[22mname: test\u001b[0m\n",
+      "\u001b[22mpk: 84410\u001b[0m\n",
       "\u001b[22mrunning_process: 4\u001b[0m\n",
       "\u001b[22mwaiting_process: 10\u001b[0m\n",
       "\u001b[22mrunning_calcjob: 2\u001b[0m\n",
@@ -191,7 +204,7 @@
     }
    ],
    "source": [
-    "! workgraph scheduler show test-scheduler"
+    "! workgraph scheduler show test"
    ]
   },
   {
@@ -206,6 +219,58 @@
     "\n",
     "![Scheduler](../_static/images/web-scheduler.png)\n",
     "\n",
+    "\n",
+    "## WorkChain\n",
+    "The Scheduler can also be used with WorkChains. But there are two different steps compared to the normal usage of WorkChains:\n",
+    "\n",
+    "- Use the `submit_to_scheduler` function in `aiida_workgraph.utils.control`\n",
+    "- You need to overide the `submit` method of the WorkChain. For example, create a new WorkChain that inherits from the original WorkChain and override the `submit` function.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain as BaseMultiplyAddWorkChain\n",
+    "from aiida.orm import ProcessNode\n",
+    "from typing import Type, Any\n",
+    "\n",
+    "class MultiplyAddWorkChain(BaseMultiplyAddWorkChain):\n",
+    "    \"\"\"WorkChain to multiply two numbers and add a third, for testing and demonstration purposes.\"\"\"\n",
+    "    \n",
+    "    def submit(\n",
+    "        self,\n",
+    "        process: Type[\"Process\"],\n",
+    "        inputs: dict[str, Any] | None = None,\n",
+    "        **kwargs,\n",
+    "    ) -> ProcessNode:\n",
+    "        \"\"\"Submit a process inside the workchain.\"\"\"\n",
+    "        from aiida_workgraph.utils.control import submit_to_scheduler_inside_workchain\n",
+    "        submit_to_scheduler_inside_workchain(self, process, inputs, **kwargs)\n",
+    "```\n",
+    "\n",
+    "Note, you need to register a entry point for the new WorkChain, for example:\n",
+    "```\n",
+    "[project.entry-points.'aiida.workflows']\n",
+    "'test.multiply_add' = 'my_test_workchain.multiply_add:MultiplyAddWorkChain'\n",
+    "```\n",
+    "\n",
+    "Then, one can submit the WorkChain using the `submit` function in `aiida_workgraph.utils.control`:\n",
+    "```python\n",
+    "from my_test_workchain.multiply_add import MultiplyAddWorkChain\n",
+    "from aiida_workgraph.utils.control import submit_to_scheduler # <-- this is the new submit function\n",
+    "\n",
+    "x = 1\n",
+    "y = 2\n",
+    "z = 3\n",
+    "submit_to_scheduler(MultiplyAddWorkChain, inputs={\"x\": x, \"y\": y, \"z\": z, \"code\": code}, scheduler=\"test\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48e78d75",
+   "metadata": {},
+   "source": [
     "\n",
     "Last but not least, one can stop and restart the scheduler at any time using the same name, all the information will be preserved.\n",
     "\n"

--- a/src/aiida_workgraph/utils/control.py
+++ b/src/aiida_workgraph/utils/control.py
@@ -214,7 +214,9 @@ def reset_tasks(pk: int, tasks: list) -> None:
     return True, ""
 
 
-def submit(process_class, inputs: dict, scheduler: str | None = None) -> orm.Node:
+def submit_to_scheduler(
+    process_class, inputs: dict, scheduler: str | None = None
+) -> orm.Node:
     """Submit a process to the scheduler."""
     from aiida.manage import manager
     from aiida.engine.utils import instantiate_process
@@ -234,7 +236,7 @@ def submit(process_class, inputs: dict, scheduler: str | None = None) -> orm.Nod
     return node
 
 
-def inside_workchain_submit(
+def submit_to_scheduler_inside_workchain(
     self,
     process: Type["Process"],
     inputs: dict[str, Any] | None = None,


### PR DESCRIPTION
## WorkChain
The Scheduler can also be used with WorkChains. But there are two different steps compared to the normal usage of WorkChains:

- Use the `submit_to_scheduler` function in `aiida_workgraph.utils.control`
- You need to overide the `submit` method of the WorkChain. For example, create a new WorkChain that inherits from the original WorkChain and override the `submit` function.




```python
from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain as BaseMultiplyAddWorkChain
from aiida.orm import ProcessNode
from typing import Type, Any

class MultiplyAddWorkChain(BaseMultiplyAddWorkChain):
    """WorkChain to multiply two numbers and add a third, for testing and demonstration purposes."""
    
    def submit(
        self,
        process: Type["Process"],
        inputs: dict[str, Any] | None = None,
        **kwargs,
    ) -> ProcessNode:
        """Submit a process inside the workchain."""
        from aiida_workgraph.utils.control import submit_to_scheduler_inside_workchain
        submit_to_scheduler_inside_workchain(self, process, inputs, **kwargs)
```

Note, you need to register a entry point for the new WorkChain, for example:
```
[project.entry-points.'aiida.workflows']
'test.multiply_add' = 'my_test_workchain.multiply_add:MultiplyAddWorkChain'
```

Then, one can submit the WorkChain using the `submit` function in `aiida_workgraph.utils.control`:
```python
from my_test_workchain.multiply_add import MultiplyAddWorkChain
from aiida_workgraph.utils.control import submit_to_scheduler # <-- this is the new submit function

x = 1
y = 2
z = 3
submit_to_scheduler(MultiplyAddWorkChain, inputs={"x": x, "y": y, "z": z, "code": code}, scheduler="test")
```