### PR TITLE
Improve scheduler performance

### DIFF
--- a/src/aiida_workgraph/engine/scheduler/scheduler.py
+++ b/src/aiida_workgraph/engine/scheduler/scheduler.py
@@ -224,7 +224,7 @@ class Scheduler:
             if pid is None:
                 return
 
-            LOGGER.info("Received CONTINUE_TASK for pk=%d", pid)
+            LOGGER.debug("Received CONTINUE_TASK for pk=%d", pid)
             try:
                 child_node = load_node(pid)
                 priority = self._compute_priority_for_new_process(pid)
@@ -329,7 +329,7 @@ class Scheduler:
         up to the concurrency limit. We pick the next process
         with the *highest* priority.
         """
-        LOGGER.info(
+        LOGGER.debug(
             f"Summary: waiting= {len(self.node.waiting_process)}, "
             f"process: {len(self.node.running_process)}/{self.node.max_processes}, "
             f"calcjob: {len(self.node.running_calcjob)}/{self.node.max_calcjobs}"
@@ -339,11 +339,11 @@ class Scheduler:
             # pick the next waiting PK with the highest priority
             next_pk = self._pop_highest_priority_waiting_process()
             if next_pk is None:
-                LOGGER.info("No more processes in waiting queue.")
+                LOGGER.debug("No more processes in waiting queue.")
                 return
             self.continue_process(next_pk)
 
-        LOGGER.info(
+        LOGGER.debug(
             "Maximum concurrency (%d) reached, waiting for a calcjob to finish...",
             self.node.max_calcjobs,
         )
@@ -354,7 +354,7 @@ class Scheduler:
         # find the process with the highest priority
         if priorites:
             best_pk = max(priorites, key=priorites.get)
-            LOGGER.info(f"Best waiting process pk={best_pk}")
+            LOGGER.debug(f"Best waiting process pk={best_pk}")
             self.node.remove_waiting_process(best_pk)
             return best_pk
         else:

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -355,19 +355,9 @@ class WorkGraphEngine(Process, metaclass=Protect):
         :param inputs: The dictionary of process inputs.
         :return: The process node.
         """
-        from aiida.engine import utils
-        from aiida_workgraph.utils.control import continue_process_in_scheduler
+        from aiida_workgraph.utils.control import submit_to_scheduler_inside_workchain
 
-        scheduler = self.node.base.extras.get("scheduler", None)
-        if scheduler:
-            inputs = utils.prepare_inputs(inputs, **kwargs)
-            process_inited = self.runner.instantiate_process(process, **inputs)
-            self.runner.persister.save_checkpoint(process_inited)
-            process_inited.close()
-            continue_process_in_scheduler(process_inited.node, scheduler)
-            return process_inited.node
-        else:
-            return self.runner.submit(process, inputs, **kwargs)
+        return submit_to_scheduler_inside_workchain(self, process, inputs, **kwargs)
 
     def finalize(self) -> t.Optional[ExitCode]:
         """"""

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -496,3 +496,36 @@ def make_json_serializable(data):
         return [make_json_serializable(item) for item in data]
     else:
         return data
+
+
+def query_existing_processes(pks: list[int]) -> list[int]:
+    """Query all existing processes from the database."""
+    from aiida import orm
+
+    qb = orm.QueryBuilder()
+    qb.append(
+        orm.ProcessNode,
+        filters={"id": {"in": pks}},
+        project=["id"],
+    )
+    results = qb.all()
+    existing_pks = [res[0] for res in results]
+    return existing_pks
+
+
+def query_terminated_processes(pks: list[int]) -> list[int]:
+    """Query all terminated processes from the database."""
+    from aiida import orm
+
+    qb = orm.QueryBuilder()
+    qb.append(
+        orm.ProcessNode,
+        filters={
+            "id": {"in": pks},
+            "attributes.process_state": {"in": ["killed", "finished", "excepted"]},
+        },
+        project=["id"],
+    )
+    results = qb.all()
+    terminated_pks = [res[0] for res in results]
+    return terminated_pks

--- a/src/aiida_workgraph/utils/control.py
+++ b/src/aiida_workgraph/utils/control.py
@@ -70,7 +70,7 @@ def continue_process_in_scheduler(
     else:
         node = orm.load_node(pk)
     controller.continue_process(pk, nowait=False)
-    node.base.extras.set("scheduler", scheduler_name)
+    node.base.extras.set("_scheduler", scheduler_name)
 
 
 def play_process_in_scheduler(scheduler: int, pk: int | orm.Node):
@@ -264,7 +264,7 @@ def submit_to_scheduler_inside_workchain(
     from aiida.engine import utils
     from aiida_workgraph.utils.control import continue_process_in_scheduler
 
-    scheduler = self.node.base.extras.get("scheduler", None)
+    scheduler = self.node.base.extras.get("_scheduler", None)
     if scheduler:
         inputs = utils.prepare_inputs(inputs, **kwargs)
         process_inited = self.runner.instantiate_process(process, **inputs)


### PR DESCRIPTION
- Use querybuilder
- Poll all running nodes at once, set `poll_interval` to 60 seconds.
- Fix priority query