### PR TITLE
Repair stuck processes in scheduler

### DIFF
--- a/docs/source/howto/scheduler.ipynb
+++ b/docs/source/howto/scheduler.ipynb
@@ -282,6 +282,11 @@
     "Failure to do so can result in processes that are not properly tracked or submitted via the scheduler.\n",
     "\n",
     "\n",
+    "## ⚠️ Warning: `verdi process repair`\n",
+    "\n",
+    "Currently, the command `verdi process repair` will send the stuck processes to the normal AiiDA daemon worker queue, instead of the scheduler. This destroys the scheduler's ability to track the processes. Also, may result in running the same process multiple times.\n",
+    "\n",
+    "\n",
     "## Persistent Scheduler\n",
     "\n",
     "Last but not least, the scheduler is **persistent**. You can stop and restart it at any time using the same scheduler name, and all associated information will be preserved automatically."

--- a/src/aiida_workgraph/cli/cmd_scheduler.py
+++ b/src/aiida_workgraph/cli/cmd_scheduler.py
@@ -344,7 +344,24 @@ def play_processes(name, processes, timeout):
         Scheduler.play_processes(name=name, pks=pks, timeout=timeout)
     except kiwipy.exceptions.UnroutableError:
         echo.echo_error(
-            f"Failed to set max_processes for scheduler {name}. Is the scheduler running?"
+            f"Failed to play processes for scheduler {name}. Is the scheduler running?"
+        )
+
+
+@scheduler.command()
+@click.argument("name", required=True, type=str)
+@arguments.PROCESSES()
+@options.TIMEOUT(default=None, required=False, type=int)
+@decorators.requires_broker
+@decorators.check_circus_zmq_version
+def repair_processes(name, processes, timeout):
+    """Repair processes in the scheduler."""
+    pks = [p.pk for p in processes]
+    try:
+        Scheduler.repair_processes(name=name, pks=pks, timeout=timeout)
+    except kiwipy.exceptions.UnroutableError:
+        echo.echo_error(
+            f"Failed to play processes for scheduler {name}. Is the scheduler running?"
         )
 
 

--- a/src/aiida_workgraph/engine/scheduler/scheduler.py
+++ b/src/aiida_workgraph/engine/scheduler/scheduler.py
@@ -398,6 +398,14 @@ class Scheduler:
                 break
 
             node = self._validate_before_continue(pk)
+            if node is False:
+                # process is already terminated or doesn't exist anymore
+                self.node.remove_waiting_process(pk)
+                LOGGER.warning(
+                    "Try to launch process pk=%d, but it is already terminated or doesn't exist anymore.",
+                    pk,
+                )
+                continue
 
             if not self._has_capacity(node):
                 # queue is full – but there *is* work waiting

--- a/src/aiida_workgraph/engine/scheduler/scheduler.py
+++ b/src/aiida_workgraph/engine/scheduler/scheduler.py
@@ -17,7 +17,7 @@ from plumpy.process_comms import (
     CONTINUE_TASK,
 )
 from aiida.common import exceptions
-from aiida.orm import load_node, QueryBuilder, Node
+from aiida.orm import load_node, QueryBuilder, Node, CalcJobNode
 from aiida.engine.processes import ProcessState
 from aiida.manage import get_manager
 from aiida.brokers.rabbitmq.utils import (
@@ -70,18 +70,24 @@ class Scheduler:
         self,
         name: str,
         max_calcjobs: Optional[int] = None,
+        max_workflows: Optional[int] = None,
         max_processes: Optional[int] = None,
         poll_interval: Union[int, float] = 60,
         reset: bool = False,
     ):
         """
         :param name: A unique name for this scheduler.
-        :param max_calcjobs: Maximum number of processes to run concurrently
+        :param max_calcjobs: Maximum number of calcjobs to run concurrently
+        :param max_workflows: Maximum number of top-level workflows to run concurrently
         :param max_processes: Maximum number of processes to run concurrently
         :param poll_interval: Interval in seconds for the fallback polling mechanism
                               (if an AiiDA broadcast is missed).
         """
         self.name = name
+        self._max_calcjobs = max_calcjobs
+        self._max_workflows = max_workflows
+        self._max_processes = max_processes
+
         self._node: SchedulerNode = None
         self._poll_interval = poll_interval
 
@@ -112,11 +118,6 @@ class Scheduler:
 
         self.process_controller = get_manager().get_process_controller()
 
-        if max_calcjobs is not None:
-            self.node.max_calcjobs = max_calcjobs
-        if max_processes is not None:
-            self.node.max_processes = max_processes
-
     @property
     def node(self) -> SchedulerNode:
         """Return (and lazily create) the SchedulerNode that stores all data for this scheduler."""
@@ -125,9 +126,12 @@ class Scheduler:
             qb.append(SchedulerNode, filters={"attributes.name": self.name})
             if qb.count() == 0:
                 # Create a new SchedulerNode
-                self._node = SchedulerNode()
-                self._node.name = self.name
-                self._node.next_priority = 0
+                self._node = SchedulerNode(
+                    name=self.name,
+                    max_calcjobs=self._max_calcjobs,
+                    max_workflows=self._max_workflows,
+                    max_processes=self._max_processes,
+                )
                 self._node.store()
                 LOGGER.info(
                     f"Created new SchedulerNode for {self.name}, pk={self._node.pk}"
@@ -149,10 +153,7 @@ class Scheduler:
         """
         Reset the scheduler by clearing the waiting and running process lists.
         """
-        self.node.waiting_process = []
-        self.node.running_process = []
-        self.node.running_calcjob = []
-        self.node.next_priority = 0
+        self.node.reset()
         LOGGER.info("Scheduler '%s' reset.", self.name)
 
     def _get_next_priority(self) -> int:
@@ -290,7 +291,9 @@ class Scheduler:
         if intent.lower() == Intent.PLAY:
             pks = msg[MESSAGE_TEXT_KEY]
             for pk in pks:
-                self._loop.call_soon(self.continue_process, pk)
+                node = self._validate_before_continue(pk)
+                if node is not False:
+                    self._loop.call_soon(self.continue_process, pk)
 
         if intent.lower() == Intent.REPAIR:
             pks = msg[MESSAGE_TEXT_KEY]
@@ -303,9 +306,15 @@ class Scheduler:
             if identifier.lower() == "max_calcjobs":
                 self.node.max_calcjobs = value
                 self.consume_process_queue()
+                return self.node.max_calcjobs
+            elif identifier.lower() == "max_workflows":
+                self.node.max_workflows = value
+                self.consume_process_queue()
+                return self.node.max_workflows
             elif identifier.lower() == "max_processes":
                 self.node.max_processes = value
                 self.consume_process_queue()
+                return self.node.max_processes
             elif identifier.lower() == "priority":
                 processes = data.get("processes")
                 for pk in processes:
@@ -318,6 +327,7 @@ class Scheduler:
             status_info = {
                 "priority": self.node.get_process_priority(),
                 "running_process": self.node.running_process,
+                "running_workflow": self.node.running_workflow,
                 "running_calcjob": self.node.running_calcjob,
             }
             return status_info
@@ -345,39 +355,62 @@ class Scheduler:
             return parent_node.base.extras.get(SCHEDULER_PRIORITY_KEY, 0)
         return self._get_next_priority()
 
-    def should_run_next_process(self) -> bool:
+    def _has_capacity(self, node: Node) -> bool:
+        """Return True if we have a free slot to run *node* (CalcJob or WorkChain)."""
+        if isinstance(node, CalcJobNode):
+            return len(self.node.running_calcjob) < self.node.max_calcjobs
+        if SchedulerNode.is_top_level_workflow(node):
+            return len(self.node.running_workflow) < self.node.max_workflows
+        return len(self.node.running_process) < self.node.max_processes
+
+    def _next_waiting_pk(self) -> Optional[int]:
         """
-        Check if we can run another process. This is true if the number of
-        running processes is less than the maximum.
+        Return the PK of the waiting process with the **highest** priority
+        (largest integer). None if the waiting list is empty.
         """
-        cond1 = len(self.node.running_calcjob) < self.node.max_calcjobs
-        cond2 = len(self.node.running_process) < self.node.max_processes
-        return cond1 and cond2
+        priorities = self.node.get_process_priority()
+        return max(priorities, key=priorities.get) if priorities else None
+
+    def _log_summary(self):
+        LOGGER.info(
+            "waiting=%d  process=%d/%d  calcjob=%d/%d, workflow=%d/%d",
+            len(self.node.waiting_process),
+            len(self.node.running_process),
+            self.node.max_processes,
+            len(self.node.running_calcjob),
+            self.node.max_calcjobs,
+            len(self.node.running_workflow),
+            self.node.max_workflows,
+        )
 
     def consume_process_queue(self) -> None:
         """
-        Attempt to start processes from the waiting queue,
-        up to the concurrency limit. We pick the next process
-        with the *highest* priority.
+        Try to start as many queued processes as the capacity limits allow.
+        Never raises – all errors are logged and the loop continues.
         """
-        LOGGER.info(
-            f"Summary: waiting= {len(self.node.waiting_process)}, "
-            f"process: {len(self.node.running_process)}/{self.node.max_processes}, "
-            f"calcjob: {len(self.node.running_calcjob)}/{self.node.max_calcjobs}"
-        )
-        # While we still have capacity, pop from waiting and continue
-        while self.should_run_next_process():
-            # pick the next waiting PK with the highest priority
-            next_pk = self._pop_highest_priority_waiting_process()
-            if next_pk is None:
-                LOGGER.info("No more processes in waiting queue.")
-                return
-            self.continue_process(next_pk)
 
-        LOGGER.info(
-            "Maximum concurrency (%d) reached, waiting for a calcjob to finish...",
-            self.node.max_calcjobs,
-        )
+        self._log_summary()
+
+        while True:
+            pk = self._next_waiting_pk()
+            if pk is None:
+                LOGGER.debug("No processes waiting; scheduler idle.")
+                break
+
+            node = self._validate_before_continue(pk)
+
+            if not self._has_capacity(node):
+                # queue is full – but there *is* work waiting
+                LOGGER.debug("Capacity full; will continue when a slot frees up.")
+                break
+
+            try:
+                self.continue_process(node)
+                self._log_summary()  # live feedback after each launch
+            except Exception:  # noqa: BLE001 – keep scheduler alive
+                LOGGER.exception("Failed launching pk=%d – skipped.", pk)
+                # failed launches are *not* removed from waiting so the user can retry
+                break
 
     def _pop_highest_priority_waiting_process(self) -> Optional[int]:
         """Return the waiting process PK with the largest 'priority' extras, or None if empty."""
@@ -452,17 +485,48 @@ class Scheduler:
                 list(non_existing_processes) + list(terminated_pks)
             )
 
-    def continue_process(self, pk: int) -> None:
+    def _validate_before_continue(self, pk: int) -> bool | Node:
+        """
+        Validate if the process can be continued.
+        This is a placeholder for any validation logic that might be needed.
+        """
+        # Check if the process is already terminated
+        try:
+            node = load_node(pk)
+            if node.is_terminated:
+                LOGGER.warning(
+                    "Try to continue process pk=%d, but it is already terminated.",
+                    pk,
+                )
+                return False
+            return node
+        except exceptions.NotExistent:
+            LOGGER.warning(
+                "Received CONTINUE_TASK for pk=%d, but it doesn't exist anymore.",
+                pk,
+            )
+            return False
+
+    def continue_process(self, node: Node) -> None:
         """
         Actually continue an AiiDA process in the daemon. Attach a callback
         so that when it finishes, we free up a slot and can launch a new one.
         """
-        LOGGER.info("Continuing process pk=%d...", pk)
-        self.call_on_process_finish(pk)
-        # Do not wait for the future's result to avoid blocking
-        self.process_controller.continue_process(pk, nowait=False, no_reply=True)
-        self.node.append_running_process(pk)
-        self.node.remove_waiting_process(pk)
+        try:
+            pk = node.pk
+            LOGGER.info("Continuing process pk=%d...", pk)
+            self.call_on_process_finish(pk)
+            # Do not wait for the future's result to avoid blocking
+            self.process_controller.continue_process(pk, nowait=False, no_reply=True)
+            self.node.append_running_process(pk)
+            self.node.remove_waiting_process(pk)
+        except Exception:
+            LOGGER.exception(
+                "Failed to continue process pk=%d. It will be removed from the scheduler.",
+                pk,
+            )
+            self.node.remove_waiting_process(pk)
+            self.node.remove_running_process(pk)
 
     def call_on_process_finish(self, pk: int) -> None:
         """
@@ -563,7 +627,7 @@ class Scheduler:
         LOGGER.info("Scheduler '%s' closed.", self.name)
 
     @classmethod
-    def get_scheduler(cls, name: str) -> SchedulerNode:
+    def get_scheduler_node(cls, name: str) -> SchedulerNode:
         """
         Return the scheduler node associated with the given name.
         """
@@ -580,7 +644,7 @@ class Scheduler:
         """
         controller = get_manager().get_process_controller()
 
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
 
         try:
             status = controller._communicator.rpc_send(
@@ -596,7 +660,7 @@ class Scheduler:
         """
         Stop the scheduler with the given name.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
         controller._communicator.rpc_send(scheduler.pk, {"intent": "stop"})
 
@@ -605,37 +669,55 @@ class Scheduler:
         """
         Set the maximum number of calcjobs for the scheduler with the given name.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
-        controller._communicator.rpc_send(
+        result = controller._communicator.rpc_send(
             scheduler.pk,
             {
                 "intent": "set",
                 "message": {"identifier": "max_calcjobs", "value": max_calcjobs},
             },
         )
+        return result
+
+    @classmethod
+    def set_max_workflows(cls, name: str, max_workflows: int) -> None:
+        """
+        Set the maximum number of workflows for the scheduler with the given name.
+        """
+        scheduler = cls.get_scheduler_node(name)
+        controller = get_manager().get_process_controller()
+        result = controller._communicator.rpc_send(
+            scheduler.pk,
+            {
+                "intent": "set",
+                "message": {"identifier": "max_workflows", "value": max_workflows},
+            },
+        )
+        return result
 
     @classmethod
     def set_max_processes(cls, name: str, max_processes: int) -> None:
         """
         Set the maximum number of processes for the scheduler with the given name.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
-        controller._communicator.rpc_send(
+        result = controller._communicator.rpc_send(
             scheduler.pk,
             {
                 "intent": "set",
                 "message": {"identifier": "max_processes", "value": max_processes},
             },
         )
+        return result
 
     @classmethod
     def play_processes(cls, name: str, pks: list, timeout: int = 5) -> None:
         """
         Play processes with the given pks.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
         controller._communicator.rpc_send(
             scheduler.pk,
@@ -666,7 +748,7 @@ class Scheduler:
         """
         Repair processes with the given pks by continuing them in the scheduler.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
         controller._communicator.rpc_send(
             scheduler.pk,
@@ -683,7 +765,7 @@ class Scheduler:
         """
         Play a process with the given pk.
         """
-        scheduler = cls.get_scheduler(name)
+        scheduler = cls.get_scheduler_node(name)
         controller = get_manager().get_process_controller()
         controller._communicator.rpc_send(
             scheduler.pk,

--- a/src/aiida_workgraph/orm/scheduler.py
+++ b/src/aiida_workgraph/orm/scheduler.py
@@ -289,7 +289,7 @@ class SchedulerNode(Sealable, Data):
         """Set the next priority for the process."""
         self.base.attributes.set(self.NEXT_PRIORITY, value)
 
-    def get_process_priority(self) -> int:
+    def get_process_priority(self) -> dict:
         waiting_list = self.waiting_process
         if not waiting_list:
             return {}

--- a/src/aiida_workgraph/orm/scheduler.py
+++ b/src/aiida_workgraph/orm/scheduler.py
@@ -1,4 +1,4 @@
-from aiida.orm import Data, load_node, CalcJobNode, QueryBuilder, ProcessNode
+from aiida.orm import Data, load_node, Node, CalcJobNode, QueryBuilder, ProcessNode
 from aiida.common.lang import classproperty
 from aiida.orm.fields import add_field
 from aiida.orm.utils.mixins import Sealable
@@ -12,9 +12,11 @@ class SchedulerNode(Sealable, Data):
     WAITING_PROCESS = "waiting_process"
     RUNNING_PROCESS = "running_process"
     RUNNING_CALCJOB = "running_calcjob"
+    RUNNING_WORKFLOW = "running_workflow"
     FINISHED_PROCESS = "finished_process"
-    MAX_CALCJOBS = "max_calcjobs"
     MAX_PROCESSES = "max_processes"
+    MAX_CALCJOBS = "max_calcjobs"
+    MAX_WORKFLOWS = "max_workflows"
     NEXT_PRIORITY = "next_priority"
 
     __qb_fields__ = [
@@ -39,6 +41,11 @@ class SchedulerNode(Sealable, Data):
             doc="List of running processes",
         ),
         add_field(
+            RUNNING_WORKFLOW,
+            dtype=Optional[list],
+            doc="List of running workflows",
+        ),
+        add_field(
             RUNNING_CALCJOB,
             dtype=Optional[list],
             doc="List of running calcjobs",
@@ -49,14 +56,19 @@ class SchedulerNode(Sealable, Data):
             doc="List of finished processes",
         ),
         add_field(
-            MAX_CALCJOBS,
-            dtype=Optional[int],
-            doc="Maximum number of running processes",
-        ),
-        add_field(
             MAX_PROCESSES,
             dtype=Optional[int],
             doc="Maximum number of processes",
+        ),
+        add_field(
+            MAX_CALCJOBS,
+            dtype=Optional[int],
+            doc="Maximum number of running calcjobs",
+        ),
+        add_field(
+            MAX_WORKFLOWS,
+            dtype=Optional[int],
+            doc="Maximum number of workflows",
         ),
         add_field(
             NEXT_PRIORITY,
@@ -65,16 +77,33 @@ class SchedulerNode(Sealable, Data):
         ),
     ]
 
+    def __init__(
+        self,
+        name: str = "scheduler",
+        max_calcjobs: Optional[int] = None,
+        max_workflows: Optional[int] = None,
+        max_processes: Optional[int] = None,
+        **kwargs,
+    ):
+        """Initialise a ``SchedulerNode`` instance."""
+        super().__init__(**kwargs)
+        self.name = name
+        self.max_calcjobs = 100 if max_calcjobs is None else max_calcjobs
+        self.max_workflows = 100 if max_workflows is None else max_workflows
+        self.max_processes = 10000 if max_processes is None else max_processes
+
     @classproperty
     def _updatable_attributes(cls) -> Tuple[str, ...]:  # noqa: N805
         return super()._updatable_attributes + (
             cls.IS_RUNNING,
             cls.WAITING_PROCESS,
             cls.RUNNING_PROCESS,
+            cls.RUNNING_WORKFLOW,
             cls.RUNNING_CALCJOB,
             cls.FINISHED_PROCESS,
-            cls.MAX_CALCJOBS,
             cls.MAX_PROCESSES,
+            cls.MAX_CALCJOBS,
+            cls.MAX_WORKFLOWS,
             cls.NEXT_PRIORITY,
         )
 
@@ -133,6 +162,30 @@ class SchedulerNode(Sealable, Data):
         self.base.attributes.set(self.RUNNING_PROCESS, value)
 
     @property
+    def running_workflow(self) -> list:
+        """Return the list of running workflows."""
+        return self.base.attributes.get(self.RUNNING_WORKFLOW, [])
+
+    @running_workflow.setter
+    def running_workflow(self, value: list) -> None:
+        """Set the list of running workflows."""
+        self.base.attributes.set(self.RUNNING_WORKFLOW, value)
+
+    def append_running_workflow(self, pk: int) -> None:
+        running_workflow = self.running_workflow
+        if pk not in running_workflow:
+            running_workflow.append(pk)
+            self.running_workflow = running_workflow
+
+    def remove_running_workflow(self, pks: Union[int, list]) -> None:
+        if isinstance(pks, int):
+            pks = [pks]
+
+        running_workflow = set(self.running_workflow)
+        running_workflow.difference_update(pks)
+        self.running_workflow = list(running_workflow)
+
+    @property
     def running_calcjob(self) -> list:
         """Return the list of running calcjobs."""
         return self.base.attributes.get(self.RUNNING_CALCJOB, [])
@@ -156,7 +209,22 @@ class SchedulerNode(Sealable, Data):
         running_calcjob.difference_update(pks)
         self.running_calcjob = list(running_calcjob)
 
+    @classmethod
+    def is_top_level_workflow(cls, node: Node) -> bool:
+        """Check if the process is a top level workflow."""
+        from aiida.common.links import LinkType
+
+        links = node.base.links.get_incoming()
+        # find the parent node
+        parent_nodes = [
+            link.node
+            for link in links
+            if link.link_type in [LinkType.CALL_CALC, LinkType.CALL_WORK]
+        ]
+        return len(parent_nodes) == 0
+
     def append_running_process(self, pk: int) -> None:
+
         running_process = self.running_process
         if pk not in running_process:
             running_process.append(pk)
@@ -165,6 +233,9 @@ class SchedulerNode(Sealable, Data):
             node = load_node(pk)
             if isinstance(node, CalcJobNode):
                 self.append_running_calcjob(pk)
+            else:
+                if self.is_top_level_workflow(node):
+                    self.append_running_workflow(pk)
 
     def remove_running_process(self, pks: Union[int, list]) -> None:
         if isinstance(pks, int):
@@ -175,6 +246,18 @@ class SchedulerNode(Sealable, Data):
         self.running_process = list(running_process)
         # Also remove from running_calcjob
         self.remove_running_calcjob(pks)
+        # Also remove from running_workflow
+        self.remove_running_workflow(pks)
+
+    @property
+    def max_workflows(self) -> int:
+        """Return the maximum number of workflows."""
+        return self.base.attributes.get(self.MAX_WORKFLOWS, 100)
+
+    @max_workflows.setter
+    def max_workflows(self, value: int) -> None:
+        """Set the maximum number of workflows."""
+        self.base.attributes.set(self.MAX_WORKFLOWS, value)
 
     @property
     def max_calcjobs(self) -> int:
@@ -189,7 +272,7 @@ class SchedulerNode(Sealable, Data):
     @property
     def max_processes(self) -> int:
         """Return the maximum number of processes."""
-        return self.base.attributes.get(self.MAX_PROCESSES, 2000)
+        return self.base.attributes.get(self.MAX_PROCESSES, 10000)
 
     @max_processes.setter
     def max_processes(self, value: int) -> None:
@@ -228,3 +311,16 @@ class SchedulerNode(Sealable, Data):
                 node.base.extras.set("_scheduler_priority", 0)
                 self.logger.report(f"Process {pk} has no priority, setting to 0")
         return priorites
+
+    def reset(self) -> None:
+        """Reset the scheduler node."""
+        self.is_running = False
+        self.waiting_process = []
+        self.running_process = []
+        self.running_workflow = []
+        self.running_calcjob = []
+        self.finished_process = []
+        self.max_processes = 10000
+        self.max_calcjobs = 100
+        self.max_workflows = 100
+        self.next_priority = 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -12,16 +12,22 @@ import datetime
 
 def test_scheduler_node_init() -> None:
     """Test Scheduler node."""
-    s = SchedulerNode(name="test", max_calcjobs=1, max_workflows=2, max_processes=3)
-    assert s.name == "test"
+    s = SchedulerNode(
+        name="test_scheduler_node_init",
+        max_calcjobs=1,
+        max_workflows=2,
+        max_processes=3,
+    )
+    assert s.name == "test_scheduler_node_init"
     assert s.max_calcjobs == 1
     assert s.max_workflows == 2
     assert s.max_processes == 3
+    s.reset()
 
 
 def test_scheduler_node_append_process() -> None:
     """Test Scheduler node."""
-    s = SchedulerNode(name="test")
+    s = SchedulerNode(name="test_scheduler_node_append_process")
     calc_node = CalcJobNode().store()
     wf_node = WorkflowNode().store()
     s.append_running_process(calc_node.pk)
@@ -37,15 +43,19 @@ def test_scheduler_node_append_process() -> None:
     s.remove_running_process(wf_node.pk)
     assert s.running_process == []
     assert s.running_workflow == []
+    s.reset()
 
 
 def test_scheduler_init() -> None:
     """Test Scheduler."""
-    s = Scheduler(name="test", max_calcjobs=1, max_workflows=2, max_processes=3)
-    assert s.name == "test"
+    s = Scheduler(
+        name="test_scheduler_init", max_calcjobs=1, max_workflows=2, max_processes=3
+    )
+    assert s.name == "test_scheduler_init"
     assert s.node.max_calcjobs == 1
     assert s.node.max_workflows == 2
     assert s.node.max_processes == 3
+    s.reset()
 
 
 @pytest.mark.usefixtures("started_scheduler_client")
@@ -67,7 +77,12 @@ def test_scheduler_set_limit() -> None:
 
 def test_scheduler_consume_process() -> None:
     # set max_calcjobs and max_workflows to 0 so that not process wiil be consumed
-    s = Scheduler(name="test", max_calcjobs=0, max_workflows=0, max_processes=5)
+    s = Scheduler(
+        name="test_scheduler_consume_process",
+        max_calcjobs=0,
+        max_workflows=0,
+        max_processes=5,
+    )
     # Running process should be added to the running list
     wf_node = WorkflowNode().store()
     wf_node.set_process_state("running")
@@ -106,7 +121,9 @@ def test_scheduler_consume_process() -> None:
 
 def test_scheduler_capacity() -> None:
     """Test Scheduler consume process."""
-    s = Scheduler(name="test", max_calcjobs=1, max_workflows=1, max_processes=5)
+    s = Scheduler(
+        name="test_scheduler_capacity", max_calcjobs=1, max_workflows=1, max_processes=5
+    )
     assert s.node.max_calcjobs == 1
     assert s.node.max_workflows == 1
     assert s.node.max_processes == 5
@@ -121,7 +138,6 @@ def test_scheduler_capacity() -> None:
     assert SchedulerNode.is_top_level_workflow(wf_node) is True
     assert s._has_capacity(calc_node) is False
     assert s._has_capacity(wf_node) is False
-    s.reset()
 
 
 @pytest.mark.usefixtures("started_daemon_client")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,9 +2,86 @@ import pytest
 from aiida_workgraph import WorkGraph
 from aiida_workgraph.tools.pytest_fixtures.scheduler import DEFAULT_TEST_SCHEDULER_NAME
 from aiida_workgraph.engine.scheduler import Scheduler
-from aiida_workgraph.engine.scheduler.client import get_scheduler
+from aiida_workgraph.orm.scheduler import SchedulerNode
+from aiida.orm import CalcJobNode, WorkflowNode
+
+from aiida_workgraph.engine.scheduler.client import get_scheduler_node
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 import datetime
+
+
+def test_scheduler_node_init() -> None:
+    """Test Scheduler node."""
+    s = SchedulerNode(name="test", max_calcjobs=1, max_workflows=2, max_processes=3)
+    assert s.name == "test"
+    assert s.max_calcjobs == 1
+    assert s.max_workflows == 2
+    assert s.max_processes == 3
+
+
+def test_scheduler_node_append_process() -> None:
+    """Test Scheduler node."""
+    s = SchedulerNode(name="test")
+    calc_node = CalcJobNode().store()
+    wf_node = WorkflowNode().store()
+    s.append_running_process(calc_node.pk)
+    s.append_running_process(wf_node.pk)
+    assert s.running_process == [calc_node.pk, wf_node.pk]
+    assert s.running_calcjob == [calc_node.pk]
+    assert s.running_workflow == [wf_node.pk]
+    # remove calcjob
+    s.remove_running_process(calc_node.pk)
+    assert s.running_process == [wf_node.pk]
+    assert s.running_calcjob == []
+    # remove workflow
+    s.remove_running_process(wf_node.pk)
+    assert s.running_process == []
+    assert s.running_workflow == []
+
+
+def test_scheduler_init() -> None:
+    """Test Scheduler."""
+    s = Scheduler(name="test", max_calcjobs=1, max_workflows=2, max_processes=3)
+    assert s.name == "test"
+    assert s.node.max_calcjobs == 1
+    assert s.node.max_workflows == 2
+    assert s.node.max_processes == 3
+
+
+@pytest.mark.usefixtures("started_scheduler_client")
+def test_scheduler_set_limit() -> None:
+    from aiida_workgraph.engine.scheduler.client import get_scheduler_node
+
+    s = get_scheduler_node(name=DEFAULT_TEST_SCHEDULER_NAME)
+    response = Scheduler.set_max_calcjobs(DEFAULT_TEST_SCHEDULER_NAME, max_calcjobs=5)
+    # wait for scheduler to be updated
+    response.result().result()
+    assert s.max_calcjobs == 5
+    response = Scheduler.set_max_workflows(DEFAULT_TEST_SCHEDULER_NAME, max_workflows=6)
+    response.result().result()
+    assert s.max_workflows == 6
+    response = Scheduler.set_max_processes(DEFAULT_TEST_SCHEDULER_NAME, max_processes=7)
+    response.result().result()
+    assert s.max_processes == 7
+
+
+def test_scheduler_consume_process() -> None:
+    """Test Scheduler consume process."""
+    s = Scheduler(name="test2", max_calcjobs=1, max_workflows=1, max_processes=5)
+    assert s.node.max_calcjobs == 1
+    assert s.node.max_workflows == 1
+    assert s.node.max_processes == 5
+    calc_node = CalcJobNode().store()
+    wf_node = WorkflowNode().store()
+    assert s._has_capacity(calc_node) is True
+    assert s._has_capacity(wf_node) is True
+    s.node.append_running_process(calc_node.pk)
+    s.node.append_running_process(wf_node.pk)
+    assert len(s.node.running_calcjob) == 1
+    assert len(s.node.running_workflow) == 1
+    assert SchedulerNode.is_top_level_workflow(wf_node) is True
+    assert s._has_capacity(calc_node) is False
+    assert s._has_capacity(wf_node) is False
 
 
 @pytest.mark.usefixtures("started_daemon_client")
@@ -28,7 +105,7 @@ def test_submit(add_code) -> None:
     status = Scheduler.set_max_calcjobs(
         name=DEFAULT_TEST_SCHEDULER_NAME, max_calcjobs=1
     )
-    scheduler = get_scheduler(name=DEFAULT_TEST_SCHEDULER_NAME)
+    scheduler = get_scheduler_node(name=DEFAULT_TEST_SCHEDULER_NAME)
     assert scheduler.max_calcjobs == 1
     #
     wg.reset()


### PR DESCRIPTION

- Add `repair_processes` cli
- Support limiting the maximum number of running top-level workflows
- Add more tests