### PR TITLE
Debug RTD 2.7.0rc1 issue

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
   jobs:
     post_create_environment:
       - python -m pip install --no-cache-dir .[docs]
-      - pip list
+      - pip freeze
       - rabbitmq-server -detached
       - sleep 10
       - rabbitmq-diagnostics status

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - graphviz
   - aiida-core.services
   - qe

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - aiida-core
+  - aiida-core~=2.7.0rc1
   - aiida-core.services
   - qe

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - aiida-core~=2.6.3
+  - aiida-core
   - aiida-core.services
   - qe

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - aiida-core~=2.7.0rc1
   - aiida-core.services
   - qe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
     "myst-nb~=1.0.0",
     "nbsphinx",
     "furo",
-    "aiida-core~=2.6.3",
+    "aiida-core~=2.7.0pre1",
     "aiida-quantumespresso",
     "aiida-pseudo",
     "anywidget",

--- a/src/aiida_workgraph/__init__.py
+++ b/src/aiida_workgraph/__init__.py
@@ -5,7 +5,7 @@ from .tasks import TaskPool
 from .utils.flow_control import if_, while_, map_
 from .manager import active_graph, active_if_zone, active_map_zone, active_while_zone
 
-__version__ = "0.5.2"
+__version__ = "0.5.2post0"
 
 __all__ = [
     "WorkGraph",


### PR DESCRIPTION
TODO:
- [ ] to separate PR for adding post release to aiida-workgraph. Reasoning:
>  It is better to mark the repo version as <VERSION>post after a release because then you do not accidentally download the version from pypi in your dev env which causes issues that are really hard to understand.  If you have the version 0.5.2 of workgraph you do not know if this is from a local build (pip install . ) or from pypi (pip install aiida-workgraph). For example I got node_graph dependency issues and I did not understand why. This was because the pypi version of workgraph fixed the node_graph version to a different version than the current main version. This happened because I tried to reproduce the error locally using the pip freeze from RTD. To distinguish the current version on main from the pypi version one can add a post tag to the version so it is clear which version is used. 
- [ ] Fix the actual bug:
> There seems to be a really weird dependency resolvement happening when aiida-core is both installed through conda and pypi. The error does not really make sense, and I could not reproduce it locally. When you install aiida only from on source (conda or pypi) this does not happen.


