### PR TITLE
Improve workgraph input deserialization behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.2.5",
+    "node-graph==0.2.6",
     "node-graph-widget>=0.0.5",
     "aiida-core>=2.3",
     "cloudpickle",

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -284,7 +284,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.ctx._new_data = {}
         self.ctx._executed_tasks = []
         # read the latest workgraph data
-        self.wg = WorkGraph.load(self.node)
+        self.wg = WorkGraph.load(self.node, safe_load=False)
         # create a builtin `_context` task with its results as the context variables
         self.ctx._task_results = {
             "graph_ctx": self.wg.ctx._value,

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -481,6 +481,23 @@ def workgraph_to_short_json(
     return wgdata_short
 
 
+def remove_output_values(outputs: Dict[str, Any]) -> None:
+    """
+    Remove output values from the outputs dictionary.
+
+    This function iterates through the outputs and removes the 'value' key from each output.
+    It is useful for cleaning up outputs before serialization or storage.
+
+    :param outputs: A dictionary of outputs to be cleaned.
+    :return: None
+    """
+    if "property" in outputs:
+        outputs["property"].pop("value", None)
+    if "sockets" in outputs:
+        for socket in outputs["sockets"].values():
+            remove_output_values(socket)
+
+
 def serialize_input_values_recursively(
     inputs: Dict[str, Any], serializer: callable = None
 ) -> None:

--- a/src/aiida_workgraph/utils/analysis.py
+++ b/src/aiida_workgraph/utils/analysis.py
@@ -195,7 +195,10 @@ class WorkGraphSaver:
         - task_actions
 
         """
-        from aiida_workgraph.utils import workgraph_to_short_json
+        from aiida_workgraph.utils import (
+            workgraph_to_short_json,
+            serialize_input_values_recursively,
+        )
 
         self.task_states = {}
         self.task_processes = {}
@@ -210,6 +213,6 @@ class WorkGraphSaver:
             self.task_actions[name] = task["action"]
             self.task_executors[name] = task.pop("executor", None)
             self.task_error_handlers[name] = task.pop("error_handlers", {})
-            self.wgdata["tasks"][name] = serialize(task)
+            serialize_input_values_recursively(task["inputs"])
         self.workgraph_error_handlers = self.wgdata.pop("error_handlers")
         self.wgdata["meta_sockets"] = serialize(self.wgdata["meta_sockets"])

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -385,7 +385,9 @@ class WorkGraph(node_graph.NodeGraph):
         return nt
 
     @classmethod
-    def load(cls, pk: int | aiida.orm.ProcessNode) -> Optional["WorkGraph"]:
+    def load(
+        cls, pk: int | aiida.orm.ProcessNode, safe_load: bool = True
+    ) -> Optional["WorkGraph"]:
         """
         Load WorkGraph from the process node with the given primary key.
 
@@ -405,7 +407,7 @@ class WorkGraph(node_graph.NodeGraph):
             )
         if not isinstance(process, WorkGraphNode):
             raise ValueError(f"Process {pk} is not a WorkGraph")
-        wgdata = get_workgraph_data(process)
+        wgdata = get_workgraph_data(process, safe_load=safe_load)
         wg = cls.from_dict(wgdata)
         wg.process = process
         wg.update()

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -73,8 +73,11 @@ class WorkGraph(node_graph.NodeGraph):
     def prepare_inputs(
         self, metadata: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
+        from aiida_workgraph.utils import remove_output_values
 
         wgdata = self.to_dict(should_serialize=True)
+        for task in wgdata["tasks"].values():
+            remove_output_values(task["outputs"])
         metadata = metadata or {}
         inputs = {"workgraph_data": wgdata, "metadata": metadata}
         return inputs
@@ -109,6 +112,7 @@ class WorkGraph(node_graph.NodeGraph):
             return
         self.check_before_run()
         inputs = self.prepare_inputs(metadata=metadata)
+        print("inputs:", inputs)
         _, node = aiida.engine.run_get_node(WorkGraphEngine, inputs=inputs)
         self.process = node
         self.update()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,27 @@
+"""
+Test serialize_input_values_recursively and deserialize_input_values_recursively
+"""
+from aiida_workgraph import WorkGraph, task
+
+
+@task.graph_builder()
+def sub_workflow(func):
+
+    wg = WorkGraph("sub_workflow")
+    wg.add_task(func)
+    return wg
+
+
+def test_func_as_input(capsys):
+    from aiida_workgraph.executors.test import add
+
+    wg = WorkGraph("test_func_as_input")
+    wg.add_task(sub_workflow, func=add, name="sub_workflow")
+    wg.save()
+
+    # load and capture stdout
+    loaded_wg = WorkGraph.load(wg.pk)
+    captured = capsys.readouterr()
+
+    assert "Info: could not deserialize input" in captured.out
+    assert "sub_workflow" in loaded_wg.tasks


### PR DESCRIPTION
This change enhances how WorkGraph inputs are deserialized, adds user controls, and ensures graceful failure handling.

* use `deserialize_unsafe` for all top-level inputs at runtime, trusting the workflow author to manage security
* default to `yaml.SafeLoader` when loading saved or imported workgraphs to guard against arbitrary Python tags
* introduce `safe_load` parameter (default true) on `WorkGraph.load` to allow switching between safe and unsafe YAML loading
* implement recursive deserialization of input values and nested sockets via `deserialize_input_values_recursively`
* catch `ConstructorError` in the recursive loader, leave the raw value intact, and print an info message stating that the workgraph is still loadable and users can inspect tasks, links and outputs, with an option to reload with `safe_load=False`
