### PR TITLE
Do not split ctx in the GUI

### DIFF
--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -398,6 +398,7 @@ def workgraph_to_short_json(
 
         properties = process_properties(task)
         wgdata_short["nodes"][name] = {
+            "identifier": task["identifier"],
             "label": task["name"],
             "node_type": task["metadata"]["node_type"].upper(),
             "inputs": inputs,
@@ -440,44 +441,7 @@ def workgraph_to_short_json(
         node = wgdata_short["nodes"][name]
         if len(node["inputs"]) == 0 and len(node["outputs"]) == 0:
             del wgdata_short["nodes"][name]
-    # split ctx node into two nodes, one with only inputs and one with only outputs
-    ctx_node = wgdata_short["nodes"].get("graph_ctx")
-    if ctx_node:
-        ctx_inputs = []
-        ctx_outputs = []
-        for input in ctx_node["inputs"]:
-            if input.get("identifier") == "_wait":
-                continue
-            ctx_inputs.append(input)
-        for output in ctx_node["outputs"]:
-            if output.get("identifier") == "_wait":
-                continue
-            ctx_outputs.append(output)
-        wgdata_short["nodes"]["ctx_inputs"] = {
-            "label": "ctx_inputs",
-            "node_type": "graph_ctx",
-            "inputs": ctx_inputs,
-            "properties": {},
-            "outputs": [],
-            "position": [0, 0],
-            "children": [],
-        }
-        wgdata_short["nodes"]["ctx_outputs"] = {
-            "label": "ctx_outputs",
-            "node_type": "graph_ctx",
-            "inputs": [],
-            "properties": {},
-            "outputs": ctx_outputs,
-            "position": [0, 0],
-            "children": [],
-        }
-        del wgdata_short["nodes"]["graph_ctx"]
-        # update the links
-        for link in wgdata_short["links"]:
-            if link["from_node"] == "graph_ctx":
-                link["from_node"] = "ctx_inputs"
-            if link["to_node"] == "graph_ctx":
-                link["to_node"] = "ctx_outputs"
+
     return wgdata_short
 
 


### PR DESCRIPTION
Previously,  ctx node is splitted into two nodes, one with only inputs and one with only outputs. However, this make the user more confuse. In this PR, we keep the ctx as one node in the GUI.