### PR TITLE
Serialize the group_inputs and ctx

### DIFF
--- a/docs/source/howto/graph_inputs_outputs.ipynb
+++ b/docs/source/howto/graph_inputs_outputs.ipynb
@@ -363,6 +363,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70baac0a",
+   "metadata": {},
+   "source": [
+    "### Automatic serialization of raw Python data\n",
+    "\n",
+    "You can also pass raw Python values directly as inputs:\n",
+    "\n",
+    "```python\n",
+    "wg.inputs = {\n",
+    "    \"add_more\": {\n",
+    "        \"x\": 1,\n",
+    "        \"y\": 2,\n",
+    "    },\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "In this case, `WorkGraph` will automatically serialize the raw Python data into the corresponding AiiDA Data nodes (e.g., an `int` becomes `orm.Int`, a `str` becomes `orm.Str`, etc.) before execution.\n",
+    "The exact serialization logic and all supported types (and how to register your own custom serializers) are described in detail in the **Data Serialization** section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4bf575d0",
    "metadata": {},
    "source": [
@@ -379,7 +401,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "workgraph",
+   "display_name": "aiida",
    "language": "python",
    "name": "python3"
   },
@@ -393,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -639,3 +639,19 @@ def query_terminated_processes(pks: list[int]) -> list[int]:
     results = qb.all()
     terminated_pks = [res[0] for res in results]
     return terminated_pks
+
+
+def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
+    """Recursively walk over the sockets and convert raw Python
+    values to AiiDA Data nodes, if needed.
+    """
+    from aiida_pythonjob.data.serializer import general_serializer
+
+    if input_socket["identifier"] == "workgraph.namespace":
+        for socket in input_socket["sockets"].values():
+            serialize_socket_data(socket)
+    else:
+        value = input_socket.get("property", {}).get("value")
+        if value is None or isinstance(value, orm.Data):
+            return
+        input_socket["property"]["value"] = general_serializer(value)

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -73,11 +73,13 @@ class WorkGraph(node_graph.NodeGraph):
     def prepare_inputs(
         self, metadata: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        from aiida_workgraph.utils import remove_output_values
+        from aiida_workgraph.utils import remove_output_values, serialize_socket_data
 
         wgdata = self.to_dict(should_serialize=True)
         for task in wgdata["tasks"].values():
             remove_output_values(task["outputs"])
+        serialize_socket_data(wgdata["meta_sockets"]["graph_ctx"])
+        serialize_socket_data(wgdata["meta_sockets"]["graph_inputs"])
         metadata = metadata or {}
         inputs = {"workgraph_data": wgdata, "metadata": metadata}
         return inputs

--- a/tests/test_group_inputs_outputs.py
+++ b/tests/test_group_inputs_outputs.py
@@ -1,0 +1,26 @@
+from aiida_workgraph import WorkGraph
+
+
+def test_group_inputs_outputs(decorated_add):
+    """Group inputs and outputs in a WorkGraph."""
+    wg = WorkGraph("test_group_inputs_outputs")
+    wg.inputs = {
+        "add": {
+            "x": 1,
+            "y": 2,
+        },
+    }
+    task1 = wg.add_task(decorated_add, x=wg.inputs.add.x, y=wg.inputs.add.y)
+    task2 = wg.add_task(decorated_add, x=wg.inputs.add.x, y=task1.outputs.result)
+    wg.outputs.results = {
+        "sum1": task1.outputs.result,
+        "sum2": task2.outputs.result,
+    }
+    wg.run()
+    assert wg.outputs.results.sum1 == 4
+    assert wg.outputs.results.sum2 == 6
+    # the graph inputs will be serialized as AiiDA nodes
+    assert (
+        wg.process.inputs.workgraph_data.meta_sockets.graph_inputs.sockets.add.sockets.x.property.value
+        == 1
+    )


### PR DESCRIPTION
Fix #493 
Serialize group inputs and the context variables when submitting the WorkGraph.

To be consistent, we use the same serializers as the ones used by `pyfunction` and `PythonJob`.

I also updated the docs. In the documentation, I mentioned a **Data Serialization** section, which does not yet exist. But it will be added soon.