### PR TITLE
Support submitting WorkGraph builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.2.8",
+    "node-graph==0.2.10",
     "node-graph-widget>=0.0.5",
     "aiida-core>=2.3,<=2.6.3",
     "cloudpickle",

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -351,7 +351,7 @@ def get_raw_value(identifier, value: Any) -> Any:
 def process_properties(task: Dict) -> Dict:
     """Extract raw values."""
     result = {}
-    for name, prop in task["properties"].items():
+    for name, prop in task.get("properties", {}).items():
         identifier = prop["identifier"]
         value = prop.get("value")
         result[name] = {
@@ -409,7 +409,7 @@ def workgraph_to_short_json(
         }
     for name, socket in wgdata.get("meta_sockets", {}).items():
         inputs = []
-        for input in socket["sockets"].values():
+        for input in socket.get("sockets", {}).values():
             metadata = input.get("metadata", {}) or {}
             if metadata.get("required", False):
                 inputs.append(
@@ -425,7 +425,7 @@ def workgraph_to_short_json(
             "children": [],
         }
     # Add links to nodes
-    for link in wgdata_short["links"]:
+    for link in wgdata_short.get("links", []):
         wgdata_short["nodes"][link["to_node"]]["inputs"].append(
             {
                 "name": link["to_socket"],


### PR DESCRIPTION
Reported by @t-reents , that he want to run the WorkGraph using the builder, but got some issues.

This PR fixes the issues, and here is an example of how to run it.

```python
from aiida_workgraph import WorkGraph, task
from aiida_workgraph.manager import active_graph
from aiida import load_profile
from ase.build import bulk
from aiida_workgraph.engine.workgraph import WorkGraphEngine
from aiida.engine import run_get_node

load_profile()


@task
def add(x, y):
    """A simple task that adds two numbers."""
    return x + y

wg = WorkGraph()
wg.add_task(add, x=1, y=2)
wgdata = wg.prepare_inputs()

builder = WorkGraphEngine.get_builder()
builder._update(wgdata)
_, node = run_get_node(builder)
print(f"node: ", node)
wg.process = node
wg.update()
assert wg.tasks.add.outputs.result.value == 3

```