### PR TITLE
Unify `inputs` API

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -104,6 +104,9 @@ class WorkGraph(node_graph.NodeGraph):
         # set task inputs
         if inputs is not None:
             for name, input in inputs.items():
+                if name == "graph_inputs":
+                    self.inputs = input
+                    break
                 if name not in self.tasks:
                     raise KeyError(f"Task {name} not found in WorkGraph.")  # noqa: E713
                 self.tasks[name].set(input)
@@ -139,6 +142,9 @@ class WorkGraph(node_graph.NodeGraph):
         # set task inputs
         if inputs is not None:
             for name, input in inputs.items():
+                if name == "graph_inputs":
+                    self.inputs = input
+                    break
                 if name not in self.tasks:
                     raise KeyError(f"Task {name} not found in WorkGraph.")  # noqa: E713
                 self.tasks[name].set(input)

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -220,6 +220,26 @@ def test_inputs_outputs(decorated_namespace_sum_diff):
     assert wg.outputs.nested.sum.value == 5
 
 
+def test_inputs_run_submit_api():
+    """Test running a WorkGraph with inputs provided in the `run` and `submit` APIs."""
+
+    def generate_workgraph():
+        with WorkGraph() as wg:
+            wg.inputs = dict.fromkeys(["x", "y"])
+            wg.outputs.sum = wg.inputs.x + wg.inputs.y
+        return wg
+
+    wg = generate_workgraph()
+    wg.run(inputs={"graph_inputs": {"x": 1, "y": 2}})
+
+    assert wg.outputs.sum.value == 3
+
+    wg = generate_workgraph()
+    wg.submit(inputs={"graph_inputs": {"x": 3, "y": 4}}, wait=True)
+
+    assert wg.outputs.sum.value == 7
+
+
 def test_run_workgraph_builder():
     """Test running a WorkGraph using the WorkGraphEngine builder."""
     from aiida_workgraph.engine.workgraph import WorkGraphEngine


### PR DESCRIPTION
This PR unifies the API for providing graph-level or inner-task inputs in `run` and `submit`.

Closes #555 