### PR TITLE
Fix the outputs of the WorkGraph task

### DIFF
--- a/tests/test_task_from_workgraph.py
+++ b/tests/test_task_from_workgraph.py
@@ -44,6 +44,7 @@ def test_build_task_from_workgraph(decorated_add: Callable) -> None:
     sub_wg = WorkGraph("build_task_from_workgraph")
     sub_wg.add_task(decorated_add, name="add1", x=x, y=3)
     sub_wg.add_task(decorated_add, name="add2", x=2, y=sub_wg.tasks.add1.outputs.result)
+    sub_wg.outputs.result = sub_wg.tasks.add2.outputs.result
     #
     wg = WorkGraph("build_task_from_workgraph")
     add1_task = wg.add_task(decorated_add, name="add1", x=1, y=3)
@@ -58,8 +59,10 @@ def test_build_task_from_workgraph(decorated_add: Callable) -> None:
 
     wg.add_task(decorated_add, name="add2", y=3)
     wg.add_link(add1_task.outputs.result, wg_task.inputs["add1.x"])
-    wg.add_link(wg_task.outputs["add2.result"], wg.tasks.add2.inputs.x)
+    wg.add_link(wg_task.outputs.result, wg.tasks.add2.inputs.x)
+    wg.outputs.sub_wg_result = wg_task.outputs.result
     assert len(wg_task.inputs) == 3
-    assert len(wg_task.outputs) == 4
+    assert len(wg_task.outputs) == 3
     wg.run()
     assert wg.tasks.add2.outputs.result.value.value == 12
+    assert wg.outputs.sub_wg_result.value.value == 9


### PR DESCRIPTION

If  the graph-level outputs are defined, use them, otherwise, expose the outputs of all the tasks in the workgraph as the graph-level outputs.