### PR TITLE
Set default name for all AiiDA component tasks

### DIFF
--- a/src/aiida_workgraph/tasks/factory/aiida_task.py
+++ b/src/aiida_workgraph/tasks/factory/aiida_task.py
@@ -162,13 +162,15 @@ def get_task_data_from_aiida_component(
 
     tdata["identifier"] = tdata.pop("identifier", callable.__name__)
     tdata["executor"] = NodeExecutor.from_callable(callable).to_dict()
-    if task_type.upper() in ["CALCFUNCTION", "AUTO_CALCFUNCTION", "WORKFUNCTION"]:
+    # Add default output result for function tasks
+    if task_type.upper() in ["CALCFUNCTION", "WORKFUNCTION"]:
         outputs = (
             [{"identifier": "workgraph.any", "name": "result"}]
             if not outputs
             else outputs
         )
-        tdata["default_name"] = callable.__name__
+    # Add default name for the task
+    tdata["default_name"] = callable.__name__
     # add built-in sockets
     for output in builtin_outputs:
         outputs.append(output.copy())


### PR DESCRIPTION
```python
from aiida_workgraph import WorkGraph, task
from aiida_quantumespresso.workflows.pw.relax import PwRelaxWorkChain
PwRelaxTask = task()(PwRelaxWorkChain)
```
Then show the `PwRelaxTask`. Before the name is `workchain`:
<img width="330" height="254" alt="Screenshot from 2025-07-14 10-55-50" src="https://github.com/user-attachments/assets/459c1361-2dc3-4724-a6e9-fa3c3283ff60" />

After this PR, the name will be `PwRelaxWorkChain`:
<img width="330" height="254" alt="Screenshot from 2025-07-14 10-54-58" src="https://github.com/user-attachments/assets/08d8b957-3d7a-4af6-b534-5cc8a24f0bf4" />


The `AUTO_CALCFUNCTION` option does not exist, thus is deleted.
