### PR TITLE
Add `shelljob` function, and update the docs

### DIFF
--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -14,6 +14,7 @@ This section contains a collection of HowTos for various topics.
    autogen/if
    autogen/while
    autogen/context
+   autogen/shelljob
    waiting_on
    combine_workgraph
    restart

--- a/src/aiida_workgraph/__init__.py
+++ b/src/aiida_workgraph/__init__.py
@@ -2,6 +2,7 @@ from .workgraph import WorkGraph
 from .task import Task
 from .decorator import task, build_task
 from .tasks import TaskPool
+from .tasks.factory.shelljob_task import shelljob
 from .utils.flow_control import if_, while_, map_
 from .manager import active_graph, If, Map, While
 
@@ -20,4 +21,5 @@ __all__ = [
     "Map",
     "While",
     "TaskPool",
+    "shelljob",
 ]

--- a/src/aiida_workgraph/tasks/factory/shelljob_task.py
+++ b/src/aiida_workgraph/tasks/factory/shelljob_task.py
@@ -154,22 +154,20 @@ def shelljob(
     resolve_command: bool = True,
 ) -> Task:
     """Create a ShellJob task for the WorkGraph."""
-    from aiida_workgraph.manager import get_current_graph
+    from aiida_workgraph.decorator import _make_wrapper
 
-    inputs = {
-        "command": command,
-        "arguments": arguments or [],
-        "nodes": nodes or {},
-        "parser": parser,
-        "parser_outputs": parser_outputs or [],
-        "resolve_command": resolve_command,
-        "metadata": metadata or {},
-        "filenames": filenames or {},
-        "outputs": outputs or [],
-    }
-    ItemClass = ShellJobTaskFactory.create_class(inputs)
-
-    wg = get_current_graph()
-    task = wg.add_task(ItemClass)
-    task.set(inputs)
-    return task.outputs
+    TaskCls = ShellJobTaskFactory.create_class(
+        {"outputs": outputs, "parser_outputs": parser_outputs}
+    )
+    task = _make_wrapper(TaskCls)
+    outputs = task(
+        command=command,
+        arguments=arguments,
+        nodes=nodes,
+        filenames=filenames,
+        outputs=outputs,
+        parser=parser,
+        metadata=metadata,
+        resolve_command=resolve_command,
+    )
+    return outputs

--- a/src/aiida_workgraph/tasks/factory/shelljob_task.py
+++ b/src/aiida_workgraph/tasks/factory/shelljob_task.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Union, Dict, Any
 from .base import BaseTaskFactory
 from aiida_shell import ShellJob
@@ -138,3 +140,36 @@ class ShellJobTaskFactory(BaseTaskFactory):
 
         TaskCls = cls(tdata)
         return TaskCls
+
+
+def shelljob(
+    command: str,
+    arguments: Optional[List[str]] = None,
+    nodes: Optional[Dict[str, Any]] = None,
+    filenames: dict[str, str] | None = None,
+    outputs: list[str] | None = None,
+    parser: Optional[Union[Dict, str]] = None,
+    parser_outputs: Optional[List[Dict[str, Any]]] = None,
+    metadata: dict[str, Any] | None = None,
+    resolve_command: bool = True,
+) -> Task:
+    """Create a ShellJob task for the WorkGraph."""
+    from aiida_workgraph.manager import get_current_graph
+
+    inputs = {
+        "command": command,
+        "arguments": arguments or [],
+        "nodes": nodes or {},
+        "parser": parser,
+        "parser_outputs": parser_outputs or [],
+        "resolve_command": resolve_command,
+        "metadata": metadata or {},
+        "filenames": filenames or {},
+        "outputs": outputs or [],
+    }
+    ItemClass = ShellJobTaskFactory.create_class(inputs)
+
+    wg = get_current_graph()
+    task = wg.add_task(ItemClass)
+    task.set(inputs)
+    return task.outputs

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -569,6 +569,10 @@ class WorkGraph(node_graph.NodeGraph):
         from aiida_workgraph.tasks.factory.workgraph_task import WorkGraphTaskFactory
         from aiida.engine import ProcessBuilder
         from aiida_workgraph.utils import get_dict_from_builder
+        from aiida_workgraph.tasks.factory.shelljob_task import (
+            ShellJobTaskFactory,
+            shelljob,
+        )
 
         if name in ["graph_ctx", "graph_inputs", "graph_inputs"]:
             raise ValueError(f"Task name {name} can not be used, it is reserved.")
@@ -580,7 +584,9 @@ class WorkGraph(node_graph.NodeGraph):
             identifier = build_task_from_callable(identifier.process_class)
         # build the task on the fly if the identifier is a callable
         elif callable(identifier):
-            if hasattr(identifier, "_TaskCls"):
+            if identifier is shelljob:
+                identifier = ShellJobTaskFactory.create_class(kwargs)
+            elif hasattr(identifier, "_TaskCls"):
                 identifier = identifier._TaskCls
             else:
                 identifier = build_task_from_callable(identifier)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,5 +1,5 @@
 import pytest
-from aiida_workgraph import WorkGraph, task, TaskPool
+from aiida_workgraph import WorkGraph, task, TaskPool, shelljob
 from aiida_shell.launch import prepare_code
 from aiida.orm import SinglefileData, load_computer, Int
 
@@ -35,18 +35,18 @@ def test_shell_command(fixture_localhost):
 def test_shell_code():
     """Test the ShellJob with code."""
     cat_code = prepare_code("cat")
-    wg = WorkGraph(name="test_shell_code")
-    job1 = wg.add_task(
-        TaskPool.workgraph.shelljob,
-        command=cat_code,
-        arguments=["{file_a}", "{file_b}"],
-        nodes={
-            "file_a": SinglefileData.from_string("string a"),
-            "file_b": SinglefileData.from_string("string b"),
-        },
-    )
-    wg.run()
-    assert job1.outputs.stdout.value.get_content() == "string astring b"
+    with WorkGraph(name="test_shell_code") as wg:
+        # use the code object directly
+        outputs = shelljob(
+            command=cat_code,
+            arguments=["{file_a}", "{file_b}"],
+            nodes={
+                "file_a": SinglefileData.from_string("string a"),
+                "file_b": SinglefileData.from_string("string b"),
+            },
+        )
+        wg.run()
+        assert outputs.stdout.value.get_content() == "string astring b"
 
 
 def test_dynamic_port():

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,5 +1,5 @@
 import pytest
-from aiida_workgraph import WorkGraph, task, TaskPool, shelljob
+from aiida_workgraph import WorkGraph, task, shelljob
 from aiida_shell.launch import prepare_code
 from aiida.orm import SinglefileData, load_computer, Int
 
@@ -17,7 +17,7 @@ def test_shell_command(fixture_localhost):
     """Test the ShellJob with command as a string."""
     wg = WorkGraph(name="test_shell_command")
     job1 = wg.add_task(
-        TaskPool.workgraph.shelljob,
+        shelljob,
         command="cat",
         resolve_command=True,
         arguments=["{file_a}", "{file_b}"],
@@ -53,7 +53,7 @@ def test_dynamic_port():
     """Set the nodes during/after the creation of the task."""
     wg = WorkGraph(name="test_dynamic_port")
     echo_task = wg.add_task(
-        TaskPool.workgraph.shelljob,
+        shelljob,
         name="echo",
         command="cp",
         arguments=["{file}", "copied_file"],
@@ -62,7 +62,7 @@ def test_dynamic_port():
     )
 
     cat_task = wg.add_task(
-        TaskPool.workgraph.shelljob,
+        shelljob,
         name="cat",
         command="cat",
         arguments=["{input}"],
@@ -97,7 +97,7 @@ def test_shell_graph_builder():
         wg = get_current_graph()
         # echo x + y expression
         job1 = wg.add_task(
-            TaskPool.workgraph.shelljob,
+            shelljob,
             name="job1",
             command="echo",
             arguments=["{x}", "+", "{y}"],
@@ -108,7 +108,7 @@ def test_shell_graph_builder():
         )
         # bc command to calculate the expression
         wg.add_task(
-            TaskPool.workgraph.shelljob,
+            shelljob,
             name="job2",
             command="bc",
             arguments=["{expression}"],


### PR DESCRIPTION
Previous, one can only run the ShellJob task using node-graph programming approach.

```python
from aiida_workgraph import WorkGraph

wg = WorkGraph(name="test_shell_date_with_arguments")
date_task = wg.add_task("workgraph.shelljob", command="date", arguments=["--iso-8601"])
wg.run()
```

This PR supports running a ShellJob task inside the context manager. To execute a shell command, one can use `shelljob` function:

```python
from aiida_workgraph import WorkGraph, shelljob

with WorkGraph(name="test_shell_date_with_arguments") as wg:
    outputs = shelljob(command="date", arguments=["--iso-8601"])
    wg.run()
```
to keep the API consistent, in the node-graph programming approach, one can also the the same `shelljob` as the task identifier

```python
from aiida_workgraph import WorkGraph, shelljob

wg = WorkGraph(name="test_shell_date_with_arguments")
date_task = wg.add_task(shelljob, command="date", arguments=["--iso-8601"])
wg.run()
```
While using the old `workgraph.shelljob` identifier still works.
