### PR TITLE
Allow graph-level inputs directly

### DIFF
--- a/docs/gallery/howto/autogen/async.py
+++ b/docs/gallery/howto/autogen/async.py
@@ -42,10 +42,8 @@ with WorkGraph("AwaitableGraph") as wg:
 
 wg.run(
     inputs={
-        "graph_inputs": {
-            "x": 1,
-            "y": 2,
-        }
+        "x": 1,
+        "y": 2,
     },
 )
 

--- a/docs/gallery/howto/autogen/combine_workgraphs.py
+++ b/docs/gallery/howto/autogen/combine_workgraphs.py
@@ -67,12 +67,10 @@ wg2.to_html()
 
 wg2.submit(
     inputs={
-        "graph_inputs": {
-            "min": 1,
-            "max": 10,
-            "x": 1,
-            "y": 2,
-        }
+        "min": 1,
+        "max": 10,
+        "x": 1,
+        "y": 2,
     },
     wait=True,
 )

--- a/docs/gallery/howto/autogen/continue_workgraph.py
+++ b/docs/gallery/howto/autogen/continue_workgraph.py
@@ -36,10 +36,8 @@ with WorkGraph("AddMultiplyToBeContinued") as wg1:
 
 wg1.submit(
     inputs={
-        "graph_inputs": {
-            "x": 1,
-            "y": 2,
-        }
+        "x": 1,
+        "y": 2,
     },
     wait=True,
 )
@@ -102,9 +100,7 @@ print(f"State of new add   : {wg3.tasks.op_add1.state}")
 # %%
 wg3.submit(
     inputs={
-        "graph_inputs": {
-            "z": 5,
-        }
+        "z": 5,
     },
     wait=True,
 )

--- a/docs/gallery/howto/autogen/graph_level.py
+++ b/docs/gallery/howto/autogen/graph_level.py
@@ -42,12 +42,10 @@ wg.to_html()
 
 # %%
 wg.submit(
-    {
-        "graph_inputs": {
-            "x": 1,
-            "y": 2,
-            "z": 3,
-        },
+    inputs={
+        "x": 1,
+        "y": 2,
+        "z": 3,
     },
     wait=True,
 )
@@ -128,21 +126,19 @@ wg.to_html()
 
 wg.submit(
     inputs={
-        "graph_inputs": {
-            "add": {
-                "first": {
-                    "x": 1,
-                    "y": 2,
-                },
-                "second": {
-                    "x": 3,
-                    "y": 4,
-                },
+        "add": {
+            "first": {
+                "x": 1,
+                "y": 2,
             },
-            "multiply": {
-                "factor": 5,
+            "second": {
+                "x": 3,
+                "y": 4,
             },
-        }
+        },
+        "multiply": {
+            "factor": 5,
+        },
     },
     wait=True,
 )

--- a/docs/gallery/howto/autogen/monitor.py
+++ b/docs/gallery/howto/autogen/monitor.py
@@ -64,17 +64,15 @@ wg.to_html()
 # %%
 wg.run(
     inputs={
-        "graph_inputs": {
-            "monitor": {
-                "time": (
-                    datetime.datetime.now() + datetime.timedelta(seconds=5)
-                ).isoformat(),
-            },
-            "add": {
-                "x": 1,
-                "y": 2,
-            },
-        }
+        "monitor": {
+            "time": (
+                datetime.datetime.now() + datetime.timedelta(seconds=5)
+            ).isoformat(),
+        },
+        "add": {
+            "x": 1,
+            "y": 2,
+        },
     }
 )
 
@@ -145,15 +143,13 @@ wg.to_html()
 # %%
 wg.run(
     inputs={
-        "graph_inputs": {
-            "add": {
-                "x": 1,
-                "y": 2,
-            },
-            "multiply": {
-                "factor": 3,
-            },
-        }
+        "add": {
+            "x": 1,
+            "y": 2,
+        },
+        "multiply": {
+            "factor": 3,
+        },
     }
 )
 

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -101,12 +101,12 @@ class WorkGraph(node_graph.NodeGraph):
         # set task inputs
         if inputs is not None:
             for name, input in inputs.items():
-                if name == "graph_inputs":
-                    self.inputs = input
-                    break
-                if name not in self.tasks:
-                    raise KeyError(f"Task {name} not found in WorkGraph.")  # noqa: E713
-                self.tasks[name].set(input)
+                if name in self.inputs:
+                    setattr(self.inputs, name, input)
+                elif name in self.tasks:
+                    self.tasks[name].set(input)
+                else:
+                    raise KeyError(f"{name} not found in WorkGraph inputs or tasks.")
         # One can not run again if the process is alreay created. otherwise, a new process node will
         # be created again.
         if self.process is not None:
@@ -139,12 +139,12 @@ class WorkGraph(node_graph.NodeGraph):
         # set task inputs
         if inputs is not None:
             for name, input in inputs.items():
-                if name == "graph_inputs":
-                    self.inputs = input
-                    break
-                if name not in self.tasks:
-                    raise KeyError(f"Task {name} not found in WorkGraph.")  # noqa: E713
-                self.tasks[name].set(input)
+                if name in self.inputs:
+                    setattr(self.inputs, name, input)
+                elif name in self.tasks:
+                    self.tasks[name].set(input)
+                else:
+                    raise KeyError(f"{name} not found in WorkGraph inputs or tasks.")
 
         # save the workgraph to the process node
         self.save(metadata=metadata)

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -100,13 +100,8 @@ class WorkGraph(node_graph.NodeGraph):
 
         # set task inputs
         if inputs is not None:
-            for name, input in inputs.items():
-                if name in self.inputs:
-                    setattr(self.inputs, name, input)
-                elif name in self.tasks:
-                    self.tasks[name].set(input)
-                else:
-                    raise KeyError(f"{name} not found in WorkGraph inputs or tasks.")
+            self.set_inputs(inputs)
+
         # One can not run again if the process is alreay created. otherwise, a new process node will
         # be created again.
         if self.process is not None:
@@ -138,13 +133,7 @@ class WorkGraph(node_graph.NodeGraph):
 
         # set task inputs
         if inputs is not None:
-            for name, input in inputs.items():
-                if name in self.inputs:
-                    setattr(self.inputs, name, input)
-                elif name in self.tasks:
-                    self.tasks[name].set(input)
-                else:
-                    raise KeyError(f"{name} not found in WorkGraph inputs or tasks.")
+            self.set_inputs(inputs)
 
         # save the workgraph to the process node
         self.save(metadata=metadata)
@@ -159,6 +148,15 @@ class WorkGraph(node_graph.NodeGraph):
         if wait:
             self.wait(timeout=timeout, interval=interval)
         return self.process
+
+    def set_inputs(self, inputs: Dict[str, Any]):
+        for name, input in inputs.items():
+            if name in self.inputs:
+                setattr(self.inputs, name, input)
+            elif name in self.tasks:
+                self.tasks[name].set(input)
+            else:
+                raise KeyError(f"{name} not found in WorkGraph inputs or tasks.")
 
     def save(self, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Save the udpated workgraph to the process

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -230,12 +230,12 @@ def test_inputs_run_submit_api():
         return wg
 
     wg = generate_workgraph()
-    wg.run(inputs={"graph_inputs": {"x": 1, "y": 2}})
+    wg.run(inputs={"x": 1, "y": 2})
 
     assert wg.outputs.sum.value == 3
 
     wg = generate_workgraph()
-    wg.submit(inputs={"graph_inputs": {"x": 3, "y": 4}}, wait=True)
+    wg.submit(inputs={"x": 3, "y": 4}, wait=True)
 
     assert wg.outputs.sum.value == 7
 


### PR DESCRIPTION
Now `wg.run(inputs={"x": 1, "y": 2})` instead of `wg.run(inputs={"graph_inputs": {"x": 1, "y": 2}})`