### PR TITLE
Map tuple results to the wg outputs

### DIFF
--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -465,7 +465,14 @@ class GraphTask(Task):
                 executor.__globals__[executor.__name__] = task.graph()(executor)
         if getattr(executor, "is_decoratored", False):
             executor = executor._func
-        wg = _run_func_with_wg(executor, args, kwargs, var_kwargs)
+        graph_task_output_names = [
+            output._name
+            for output in self.outputs
+            if not output._metadata.builtin_socket
+        ]
+        wg = _run_func_with_wg(
+            executor, graph_task_output_names, args, kwargs, var_kwargs
+        )
         wg.name = self.name
 
         wg.parent_uuid = engine_process.node.uuid

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -1,0 +1,22 @@
+from aiida_workgraph import task, WorkGraph
+
+
+def test_tuple_outputs(decorated_add, decorated_multiply):
+    """Test mapping tuple results to the workgraph outputs."""
+
+    @task.graph(outputs=["sum", "product"])
+    def add_multiply(a, b):
+        """Task that returns the sum and product of two numbers."""
+        sum_result = decorated_add(a, b).result
+        product_result = decorated_multiply(sum_result, b).result
+        return sum_result, product_result
+
+    wg = add_multiply.get_graph(1, 2)
+    assert "sum" in wg.outputs
+    assert "product" in wg.outputs
+
+    with WorkGraph() as wg:
+        outputs = add_multiply(1, 2)
+        wg.run()
+    assert outputs.sum.value == 3
+    assert outputs.product.value == 6


### PR DESCRIPTION
Fix #588, the `graph` task can return a tuple as the result.

```python
@task.graph(outputs=['sum', 'product'])
def add_multiply(x=None, y=None):
    outputs1 = add(x=x, y=y)
    outputs2 = multiply(x=outputs1.result, y=y)
    return outputs1.result, outputs2.result
```