### PR TITLE
Replace `get_graph` by `build_graph`

### DIFF
--- a/docs/gallery/concept/autogen/graph_builder_concept.py
+++ b/docs/gallery/concept/autogen/graph_builder_concept.py
@@ -56,7 +56,7 @@ def my_workflow(x, y):
 
 
 # A user can now easily create and run the workflow:
-wg = my_workflow.get_graph(x=1, y=2)
+wg = my_workflow.build_graph(x=1, y=2)
 wg.run()
 print("Workflow outputs:", wg.outputs.result)
 
@@ -222,7 +222,7 @@ with WorkGraph("ContextManagerExample") as wg:
 # Inputs (1, 2) are known upfront
 
 with WorkGraph():
-    sub_wg = my_workflow.get_graph(1, 2)
+    sub_wg = my_workflow.build_graph(1, 2)
     # Add the generated WorkGraph as a task
     sub_wg()
 

--- a/docs/gallery/migration_from_aiida_core/autogen/workchain.py
+++ b/docs/gallery/migration_from_aiida_core/autogen/workchain.py
@@ -153,7 +153,7 @@ from aiida import load_profile
 load_profile()
 
 # Generate the WorkGraph instance with a specific input.
-wg = sum_even_workgraph.get_graph(N=5)
+wg = sum_even_workgraph.build_graph(N=5)
 
 # The `to_html()` method generates an interactive visualization of the graph.
 # In a Sphinx-Gallery build, this will be embedded directly in the output.

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -291,7 +291,7 @@ class TaskDecoratorCollection:
 
             wrapped_func = _make_wrapper(TaskCls, func)
 
-            def get_graph(*args, **kwargs):
+            def build_graph(*args, **kwargs):
                 """This function is used to get the graph from the wrapped function."""
                 graph_task_output_names = [
                     name
@@ -303,7 +303,7 @@ class TaskDecoratorCollection:
 
                 return _run_func_with_wg(func, graph_task_output_names, args, kwargs)
 
-            wrapped_func.get_graph = get_graph
+            wrapped_func.build_graph = build_graph
 
             return wrapped_func
 

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -11,7 +11,7 @@ def test_tuple_outputs(decorated_add, decorated_multiply):
         product_result = decorated_multiply(sum_result, b).result
         return sum_result, product_result
 
-    wg = add_multiply.get_graph(1, 2)
+    wg = add_multiply.build_graph(1, 2)
     assert "sum" in wg.outputs
     assert "product" in wg.outputs
 

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -164,7 +164,7 @@ def test_extend_workgraph(decorated_add_multiply_group):
 
     wg = WorkGraph("test_graph_build")
     add1 = wg.add_task("workgraph.test_add", "add1", x=2, y=3)
-    add_multiply_wg = decorated_add_multiply_group.get_graph(x=0, y=4, z=5)
+    add_multiply_wg = decorated_add_multiply_group.build_graph(x=0, y=4, z=5)
     # test wait
     add_multiply_wg.tasks.multiply.waiting_on.add("add")
     # extend workgraph


### PR DESCRIPTION
Fix #590 
`get_graph` gives the impression that the graph already exists. `build_graph` is clear to the user that the graph is built using the given inputs.