### PR TITLE
Add basic tests for cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.9', '3.11', '3.12']
-                aiida-core-version: ['2.6.1', '2.7']
+                aiida-core-version: ['2.6', '2.7']
 
         services:
             postgres:
@@ -89,7 +89,6 @@ jobs:
             env:
                 AIIDA_WARN_v3: 1
             run: |
-                verdi config set logging.aiida_loglevel REPORT
                 pytest -v --cov --durations=0
 
         -   name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.9', '3.11', '3.12']
-                aiida-core-version: ['2.6', '2.7']
+                aiida-core-version: ['2.6.1', '2.7']
 
         services:
             postgres:
@@ -89,6 +89,7 @@ jobs:
             env:
                 AIIDA_WARN_v3: 1
             run: |
+                verdi config set logging.aiida_loglevel REPORT
                 pytest -v --cov --durations=0
 
         -   name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,14 +70,14 @@ jobs:
             with:
                 python-version: ${{ matrix.python-version }}
 
-        -   name: Install aiida-core
-            run: pip install aiida-core==${{ matrix.aiida-core-version }}
-
         -   name: Install Python dependencies
             run: |
                 pip install -e .[widget,pre-commit,tests]
                 playwright install
                 pip list
+
+        -   name: Install aiida-core
+            run: pip install aiida-core==${{ matrix.aiida-core-version }}
 
         -   name: Install system dependencies
             run: sudo apt update && sudo apt install --no-install-recommends graphviz

--- a/src/aiida_workgraph/cli/cmd_task.py
+++ b/src/aiida_workgraph/cli/cmd_task.py
@@ -32,15 +32,14 @@ def workgraph_task():
 @arguments.PROCESS()
 @click.argument("tasks", nargs=-1)
 @options.TIMEOUT()
-@options.WAIT()
 @decorators.with_dbenv()
-def task_pause(process, tasks, timeout, wait):
+def task_pause(process, tasks, timeout):
     """Pause task."""
     from aiida.engine.processes import control
     from aiida_workgraph.utils.control import pause_tasks
 
     try:
-        _, msg = pause_tasks(process.pk, tasks, timeout, wait)
+        _, msg = pause_tasks(process.pk, tasks, timeout)
     except control.ProcessTimeoutException as exception:
         echo.echo_critical(f"{exception}\n{REPAIR_INSTRUCTIONS}")
 
@@ -49,15 +48,14 @@ def task_pause(process, tasks, timeout, wait):
 @arguments.PROCESS()
 @click.argument("tasks", nargs=-1)
 @options.TIMEOUT()
-@options.WAIT()
 @decorators.with_dbenv()
-def task_play(process, tasks, timeout, wait):
+def task_play(process, tasks, timeout):
     """Play task."""
     from aiida.engine.processes import control
     from aiida_workgraph.utils.control import play_tasks
 
     try:
-        _, msg = play_tasks(process.pk, tasks, timeout, wait)
+        _, msg = play_tasks(process.pk, tasks, timeout)
     except control.ProcessTimeoutException as exception:
         echo.echo_critical(f"{exception}\n{REPAIR_INSTRUCTIONS}")
 
@@ -66,16 +64,15 @@ def task_play(process, tasks, timeout, wait):
 @arguments.PROCESS()
 @click.argument("tasks", nargs=-1)
 @options.TIMEOUT()
-@options.WAIT()
 @decorators.with_dbenv()
-def task_skip(process, tasks, timeout, wait):
+def task_skip(process, tasks, timeout):
     """Skip task."""
     from aiida.engine.processes import control
     from aiida_workgraph.utils.control import skip_tasks
 
     for task in tasks:
         try:
-            skip_tasks(process.pk, task, timeout, wait)
+            skip_tasks(process.pk, task, timeout)
 
         except control.ProcessTimeoutException as exception:
             echo.echo_critical(f"{exception}\n{REPAIR_INSTRUCTIONS}")
@@ -85,15 +82,14 @@ def task_skip(process, tasks, timeout, wait):
 @arguments.PROCESS()
 @click.argument("tasks", nargs=-1)
 @options.TIMEOUT()
-@options.WAIT()
 @decorators.with_dbenv()
-def task_kill(process, tasks, timeout, wait):
+def task_kill(process, tasks, timeout):
     """Kill task."""
     from aiida.engine.processes import control
     from aiida_workgraph.utils.control import kill_tasks
 
     print("tasks", tasks)
     try:
-        kill_tasks(process.pk, tasks, timeout, wait)
+        kill_tasks(process.pk, tasks, timeout)
     except control.ProcessTimeoutException as exception:
         echo.echo_critical(f"{exception}\n{REPAIR_INSTRUCTIONS}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from click.testing import CliRunner
+from aiida_workgraph.cli.cmd_workgraph import workgraph
+
+
+def test_workgraph():
+    """Test ``verdi group path ls``"""
+    cli_runner = CliRunner()
+    result = cli_runner.invoke(workgraph, ["--help"])
+    assert result.exit_code == 0, result.exception
+    print(result.output)
+
+
+def test_graph():
+    """Test ``verdi group path ls``"""
+    cli_runner = CliRunner()
+    result = cli_runner.invoke(workgraph, ["graph", "--help"])
+    assert result.exit_code == 0, result.exception
+    print(result.output)
+
+
+def test_task():
+    """Test ``verdi group path ls``"""
+    cli_runner = CliRunner()
+    result = cli_runner.invoke(workgraph, ["task", "--help"])
+    assert result.exit_code == 0, result.exception
+    print(result.output)

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -3,9 +3,8 @@ from aiida import orm
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 
 
-def test_error_handlers(add_code):
+def test_error_handlers(add_code, capsys):
     """Test error handlers."""
-    from aiida.cmdline.utils.common import get_workchain_report
 
     def handle_negative_sum(task: Task):
         """Handle negative sum by resetting the task and changing the inputs.
@@ -42,6 +41,7 @@ def test_error_handlers(add_code):
             "add1": {"code": add_code, "x": orm.Int(1), "y": orm.Int(-2)},
         },
     )
-    report = get_workchain_report(wg.process, "REPORT")
+    captured = capsys.readouterr()
+    report = captured.out
     assert "Run error handler: handle_negative_sum." in report
     assert wg.tasks.add1.outputs.sum.value == 3

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,6 @@
 import pytest
 from aiida_workgraph import WorkGraph, task
 from typing import Callable
-from aiida.cmdline.utils.common import get_workchain_report
 from aiida import orm
 
 
@@ -46,7 +45,7 @@ def test_task_collection(decorated_add: Callable) -> None:
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_task_wait(decorated_add: Callable) -> None:
+def test_task_wait(decorated_add: Callable, capsys) -> None:
     """Run a WorkGraph with a task that waits on other tasks."""
 
     wg = WorkGraph(name="test_task_wait")
@@ -54,7 +53,8 @@ def test_task_wait(decorated_add: Callable) -> None:
     add2 = wg.add_task(decorated_add, "add2", x=2, y=2)
     add2.waiting_on.add(add1)
     wg.run()
-    report = get_workchain_report(wg.process, "REPORT")
+    captured = capsys.readouterr()
+    report = captured.out
     assert "tasks ready to run: add1" in report
 
 

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1,8 +1,7 @@
 from aiida_workgraph import WorkGraph
-from aiida.cmdline.utils.common import get_workchain_report
 
 
-def test_zone_task(decorated_add):
+def test_zone_task(decorated_add, capsys):
     """Test the zone task."""
 
     wg = WorkGraph("test_zone")
@@ -13,7 +12,8 @@ def test_zone_task(decorated_add):
     wg.add_task(decorated_add, name="add4", x=1, y=wg.tasks.add2.outputs.result)
     wg.add_task(decorated_add, name="add5", x=1, y=wg.tasks.add3.outputs.result)
     wg.run()
-    report = get_workchain_report(wg.process, "REPORT")
+    captured = capsys.readouterr()
+    report = captured.out
     assert "tasks ready to run: add2,add3" in report
     assert "tasks ready to run: add4,add5" in report
     # load the WorkGraph should add the cihld tasks


### PR DESCRIPTION
Although the CLI is not yet useful, we should add some basic tests to ensure it does not break.
See this : https://github.com/conda-forge/aiida-workgraph-feedstock/pull/15#issuecomment-3121775586

This RP:
- fixes the CLI when using aiida-core 2.7, same as this PR: https://github.com/aiidateam/aiida-workgraph/pull/605.
- add basic tests



For an unknown reason, the `test_cli` affects the report of the Process. The `get_workchain_report` gives 'No log messages recorded for this entry'. A temporary solution is to capture the output stream directly and check the output.