### PR TITLE
Fix top level outputs link

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -593,6 +593,10 @@ class WorkGraph(node_graph.NodeGraph):
         """Add a link between two tasks."""
         if isinstance(source, Task):
             source = source.outputs["_outputs"]
+        elif source._parent is None:
+            # if the source is the top-level outputs,
+            # we use the built-in "_outputs" socket to represent it
+            source = source._outputs
         key = f"{source._node.name}.{source._scoped_name} -> {target._node.name}.{target._scoped_name}"
         if key in self.links:
             return self.links[key]

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,11 +1,11 @@
 import pytest
+from aiida_workgraph import task, WorkGraph
 
 
 @pytest.mark.usefixtures("started_daemon_client")
 def test_multiply_link() -> None:
     """Test multiply link."""
 
-    from aiida_workgraph import task, WorkGraph
     from aiida.orm import Float
 
     @task.calcfunction()
@@ -27,3 +27,14 @@ def test_multiply_link() -> None:
     # wg.submit(wait=True)
     wg.run()
     assert sum1.outputs.result.value == 6
+
+
+def test_top_level_outputs_link(decorated_add) -> None:
+    """Test link to top-level outputs."""
+
+    wg = WorkGraph(name="test_top_level_outputs_link")
+    add1 = wg.add_task(decorated_add, "add1")
+    add2 = wg.add_task(decorated_add, "add2")
+    wg.add_link(add1.outputs, add2.inputs.x)
+    # built-in "_outputs" socket is used to represent top-level outputs
+    assert "add1._outputs -> add2.x" in wg.links


### PR DESCRIPTION
If the top-level outputs is used in a link, we use the built-in `_outputs` socket to represent it.