### PR TITLE
Auto detect and link graph inputs for `graph` tasks

### DIFF
--- a/docs/gallery/tutorial/autogen/eos.py
+++ b/docs/gallery/tutorial/autogen/eos.py
@@ -155,7 +155,7 @@ scf_inputs = {
 # set the input parameters for each task
 wg = eos_workgraph(si, [0.95, 1.0, 1.05], scf_inputs)
 print("Waiting for the workgraph to finish...")
-wg.submit(wait=True, timeout=300)
+wg.run()
 # one can also run the workgraph directly
 # wg.run()
 wg.to_html()
@@ -184,7 +184,14 @@ print("B: {B}\nv0: {v0}\ne0: {e0}\nv0: {v0}".format(**data))
 from aiida_workgraph import WorkGraph, task, Map
 
 
-@task.graph()
+@task.graph(
+    inputs={
+        "scf_inputs": {
+            "identifier": "workgraph.namespace",
+            "metadata": {"dynamic": True},
+        }
+    }
+)
 def eos_workgraph(
     structure: orm.StructureData = None, scales: list = None, scf_inputs: dict = None
 ):
@@ -199,6 +206,11 @@ def eos_workgraph(
 
 
 # %%
+# .. note::
+#
+#    The input `scf_inputs` is a dictionary which includes many AiiDA nodes (e.g., Code, Dict), which means it's a **namespace** socket.
+#    For a full explanation of how to use namespaces, please refer to the section on :ref:`Dynamic Namespaces <dynamic_namespaces>`.
+#
 # Use it inside another workgraph
 # -------------------------------
 # For example, we want to combine relax with eos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.2.19",
+    "node-graph==0.2.20",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -99,7 +99,7 @@ def _assign_wg_outputs(
 
 def _run_func_with_wg(
     func: Callable,
-    graph_task_output_names: List[str],
+    TaskCls: callable,
     args: tuple,
     kwargs: dict,
     var_kwargs: Optional[dict] = None,
@@ -110,9 +110,46 @@ def _run_func_with_wg(
     """
     merged = {**kwargs, **(var_kwargs or {})}
     with WorkGraph(func.__name__) as wg:
+        wg.graph_inputs.inputs = TaskCls.InputCollectionClass._from_dict(
+            TaskCls._ndata.get("inputs", {}),
+            node=wg.graph_inputs,
+            pool=TaskCls.SocketPool,
+            graph=wg,
+        )
+        graph_task_output_names = [
+            name
+            for name, socket in TaskCls._ndata.get("outputs", {})
+            .get("sockets", {})
+            .items()
+            if not socket.get("metadata", {}).get("builtin_socket", False)
+        ]
+        wg.inputs = prepare_function_inputs(func, *args, **merged)
         raw = func(*args, **merged)
         _assign_wg_outputs(raw, wg, graph_task_output_names)
         return wg
+
+
+def prepare_function_inputs(func, *call_args, **call_kwargs):
+    """Prepare the inputs for the function call.
+    This function extracts the arguments from the function signature and
+    assigns them to the inputs dictionary."""
+    inputs = dict(call_kwargs or {})
+    if func is not None:
+        arguments = list(call_args)
+        orginal_func = func._func if hasattr(func, "_func") else func
+        for name, parameter in inspect.signature(orginal_func).parameters.items():
+            if parameter.kind in [
+                parameter.POSITIONAL_ONLY,
+                parameter.POSITIONAL_OR_KEYWORD,
+            ]:
+                try:
+                    inputs[name] = arguments.pop(0)
+                except IndexError:
+                    pass
+            elif parameter.kind is parameter.VAR_POSITIONAL:
+                # not supported
+                raise ValueError("VAR_POSITIONAL is not supported.")
+    return inputs
 
 
 def _make_wrapper(TaskCls, func=None):
@@ -133,23 +170,7 @@ def _make_wrapper(TaskCls, func=None):
         if active_zone:
             active_zone.children.add(task)
 
-        inputs = dict(call_kwargs or {})
-        if func is not None:
-            arguments = list(call_args)
-            orginal_func = func._func if hasattr(func, "_func") else func
-
-            for name, parameter in inspect.signature(orginal_func).parameters.items():
-                if parameter.kind in [
-                    parameter.POSITIONAL_ONLY,
-                    parameter.POSITIONAL_OR_KEYWORD,
-                ]:
-                    try:
-                        inputs[name] = arguments.pop(0)
-                    except IndexError:
-                        pass
-                elif parameter.kind is parameter.VAR_POSITIONAL:
-                    # not supported
-                    raise ValueError("VAR_POSITIONAL is not supported.")
+        inputs = prepare_function_inputs(func, *call_args, **call_kwargs)
         task.set(inputs)
         return task.outputs
 
@@ -293,15 +314,8 @@ class TaskDecoratorCollection:
 
             def build_graph(*args, **kwargs):
                 """This function is used to get the graph from the wrapped function."""
-                graph_task_output_names = [
-                    name
-                    for name, socket in TaskCls._ndata.get("outputs", {})
-                    .get("sockets", {})
-                    .items()
-                    if not socket.get("metadata", {}).get("builtin_socket", False)
-                ]
 
-                return _run_func_with_wg(func, graph_task_output_names, args, kwargs)
+                return _run_func_with_wg(func, TaskCls, args, kwargs)
 
             wrapped_func.build_graph = build_graph
 

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -467,14 +467,7 @@ class GraphTask(Task):
                 executor.__globals__[executor.__name__] = task.graph()(executor)
         if getattr(executor, "is_decoratored", False):
             executor = executor._func
-        graph_task_output_names = [
-            output._name
-            for output in self.outputs
-            if not output._metadata.builtin_socket
-        ]
-        wg = _run_func_with_wg(
-            executor, graph_task_output_names, args, kwargs, var_kwargs
-        )
+        wg = _run_func_with_wg(executor, self.__class__, args, kwargs, var_kwargs)
         wg.name = self.name
 
         wg.parent_uuid = engine_process.node.uuid

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -442,6 +442,10 @@ def workgraph_to_short_json(
         if len(node["inputs"]) == 0 and len(node["outputs"]) == 0:
             del wgdata_short["nodes"][name]
 
+    # remove the inputs socket of "graph_inputs"
+    if "graph_inputs" in wgdata_short["nodes"]:
+        wgdata_short["nodes"]["graph_inputs"]["inputs"] = []
+
     return wgdata_short
 
 

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -12,6 +12,10 @@ def test_tuple_outputs(decorated_add, decorated_multiply):
         return sum_result, product_result
 
     wg = add_multiply.build_graph(1, 2)
+    # graph inputs
+    assert wg.inputs.a.value == 1
+    assert wg.inputs.b.value == 2
+    # graph outputs
     assert "sum" in wg.outputs
     assert "product" in wg.outputs
 

--- a/tests/test_group_inputs_outputs.py
+++ b/tests/test_group_inputs_outputs.py
@@ -1,4 +1,5 @@
 from aiida_workgraph import WorkGraph, task
+import pytest
 
 
 def test_group_inputs_outputs(decorated_add):
@@ -61,7 +62,12 @@ def test_detect_graph_inputs(decorated_add):
         z = y
         decorated_add(x=x, y=z)
 
-    wg = graph1.build_graph(x=1, y=1)
+    # here will raise an warning, check the warning message
+    with pytest.warns(
+        UserWarning,
+        match="Could not automatically resolve link for input 'y' of task 'add'",
+    ):
+        wg = graph1.build_graph(x=1, y=1)
     assert "graph_inputs.x -> add.x" in wg.links
     # in this case, `x` and `y` share the same value, we can not distinguish them
     # so use the first one, which is `x`


### PR DESCRIPTION


Resolves #603.

## Considerations for detecting graph-level inputs

### Pros

* Clear visualization of graph inputs, similar to the context manager approach.
* When the WorkGraph runs, graph-level inputs are serialized and passed to tasks, so the data flow within the AiiDA process can be tracked. Otherwise, tasks would serialize their raw inputs, creating multiple distinct AiiDA data nodes for the same data.
* Serialization requires users to declare the input structure, which makes graphs more robust and less error prone.

### Cons

* The serialization requirement forces users to declare the input structure, which raises the learning curve for new users. They also need to understand the concept of namespaces.

## Implementation

There are many ways to track inputs. One option is static analysis with Python’s `ast` module, as mentioned in #603. However, static analysis cannot see branches and values that only materialize at runtime.

In this PR, we record the `id` of input values and build `value` to `id` mappings for the graph-level inputs and for every task’s inputs. Using these mappings, we can detect which tasks each input value flows into. Since this happens at runtime, it captures complex control flow.

Example:

```python
@task
def add(x, y):
    return x + y

@task
def multiply(x, y):
    return x * y

@task.graph
def add_multiply(a, b, c):
    sum = add(x=a, y=b).result
    if a > 0:
        a = add(x=a, y=b).result
        product = multiply(a, y=c)
    else:
        product = multiply(a, y=c)
    return product

wg = add_multiply.build_graph(a=1, b=2, c=3)
wg
```

If `a = -1`, the branch and data flow change accordingly.

## Limitations of the current approach

In Python:

```python
x = 1
y = x
add(1, y=y)
```

Here `x`, `y`, and `1` can share the same identity, so you cannot distinguish variable names from the literal value using identity alone. Using `ast` helps recover variable names from source, but covering all real-world cases is difficult, and correctness is hard to guarantee.

## Alternative approach

* Define `inputs` in the decorator.
* Inside the function, use `wg.inputs` explicitly.

This is opt in. If users do not reference `wg.inputs`, this mode is not activated and `wg.inputs` is cleared.

```python
@task.graph(inputs={"nested": {"identifier": "workgraph.namespace",
                               "sockets": {"a": {"identifier": "any"},
                                           "b": {"identifier": "any"}}}})
def AddMultiply(x, y, nested: dict):
    wg = get_current_graph()
    x = add(x=wg.inputs.x, y=wg.inputs.y).result
    y = add(x=wg.inputs.nested["a"], y=wg.inputs.nested["b"]).result
    return multiply(x=x, y=y).result

wg = AddMultiply.build_graph(
    x=1,
    y=2,
    nested={"a": 1, "b": 3},
)
```