### PR TITLE
Fix graph-level sockets

### DIFF
--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -288,13 +288,13 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.wg = WorkGraph.load(self.node, safe_load=False)
         # init task results
         self.ctx._task_results = {}
-        self.task_manager.set_task_results()
         # create a builtin `_context` task with its results as the context variables
         self.ctx._task_results = {
             "graph_ctx": self.wg.ctx._value,
             "graph_inputs": self.wg.inputs._value,
             "graph_outputs": self.wg.outputs._value,
         }
+        self.task_manager.set_task_results()
         # set meta-tasks state
         for task_name in BUILTIN_NODES:
             self.task_manager.state_manager.set_task_runtime_info(

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -24,8 +24,8 @@ class GraphLevelTask(Task):
 
         metadata = super().get_metadata()
         metadata["node_class"] = {
-            "module_path": self.node_class.__module__,
-            "callable_name": self.node_class.__name__,
+            "module_path": self.__class__.__module__,
+            "callable_name": self.__class__.__name__,
         }
         metadata["factory_class"] = {
             "module_path": self.factory_class.__module__,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,8 @@ def wg_calcfunction() -> WorkGraph:
     sumdiff1 = wg.add_task("workgraph.test_sum_diff", "sumdiff1", x=2, y=3)
     sumdiff2 = wg.add_task("workgraph.test_sum_diff", "sumdiff2", x=4)
     wg.add_link(sumdiff1.outputs[0], sumdiff2.inputs[1])
+    wg.outputs.sum = sumdiff1.outputs.sum
+    wg.outputs.diff = sumdiff2.outputs.sum
     return wg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,8 +81,6 @@ def wg_calcfunction() -> WorkGraph:
     sumdiff1 = wg.add_task("workgraph.test_sum_diff", "sumdiff1", x=2, y=3)
     sumdiff2 = wg.add_task("workgraph.test_sum_diff", "sumdiff2", x=4)
     wg.add_link(sumdiff1.outputs[0], sumdiff2.inputs[1])
-    wg.outputs.sum = sumdiff1.outputs.sum
-    wg.outputs.diff = sumdiff2.outputs.sum
     return wg
 
 

--- a/tests/test_group_inputs_outputs.py
+++ b/tests/test_group_inputs_outputs.py
@@ -24,3 +24,20 @@ def test_group_inputs_outputs(decorated_add):
         wg.process.inputs.workgraph_data.tasks.graph_inputs.inputs.sockets.add.sockets.x.property.value
         == 1
     )
+
+
+def test_load_from_db():
+    """Test loading a WorkGraph from the database."""
+    from aiida_workgraph.tasks.builtins import GraphInputs
+
+    wg = WorkGraph("test_load_from_db")
+    wg.inputs = {"x": 1, "y": 2}
+    wg.save()
+    wg2 = WorkGraph.load(wg.pk)
+    wg2.restart()
+    assert isinstance(wg2.tasks.graph_inputs, GraphInputs)
+    wg2.inputs.z = 3
+    wg2.save()
+    wg3 = WorkGraph.load(wg2.pk)
+    assert wg3.inputs.x == 1
+    assert wg3.inputs.z == 3

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -136,6 +136,8 @@ def test_restart_and_reset(wg_calcfunction):
     Load the workgraph, modify the task, and restart the workgraph.
     Only the modified node and its child tasks will be rerun."""
     wg = wg_calcfunction
+    wg.outputs.diff = wg.tasks.sumdiff1.outputs.diff
+    wg.outputs.sum = wg.tasks.sumdiff2.outputs.sum
     wg.add_task(
         "workgraph.test_sum_diff",
         "sumdiff3",


### PR DESCRIPTION
- The `node_class` of graph-level tasks should be itself, so it can be reloaded correctly from the database.
- In the engine, initialize the results of the graph-level sockets first, so other tasks can update them.