### PR TITLE
Use `TaggedValue` to track the graph inputs

### DIFF
--- a/docs/gallery/howto/autogen/monitor.py
+++ b/docs/gallery/howto/autogen/monitor.py
@@ -49,7 +49,8 @@ import datetime
 
 
 @task.monitor
-def monitor_time(time):
+def monitor_time(time: str):
+    time = datetime.datetime.fromisoformat(time)
     return datetime.datetime.now() > time
 
 
@@ -65,7 +66,7 @@ def TimeMonitor(time, x, y):
 
 
 wg = TimeMonitor.build_graph(
-    time=datetime.datetime.now() + datetime.timedelta(seconds=5),
+    time=(datetime.datetime.now() + datetime.timedelta(seconds=5)).isoformat(),
     x=1,
     y=2,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "aiida-workgraph"
-dynamic = ["version"] # read from aiida_workgraph/__init__.py
+dynamic = ["version"]  # read from aiida_workgraph/__init__.py
 description = "Design flexible node-based workflow for AiiDA calculation."
-authors = [{ name = "Xing Wang", email = "xingwang1991@gmail.com" }]
+authors = [{name = "Xing Wang", email = "xingwang1991@gmail.com"}]
 readme = "README.md"
-license = { file = "LICENSE" }
+license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 1 - Planning",
     "Framework :: AiiDA",
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.2.19",
+    "node-graph @ git+https://github.com/scinode/node-graph.git",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",
@@ -61,7 +61,10 @@ docs = [
     "sphinx-autobuild",
     "click~=8.1.0",
 ]
-pre-commit = ["pre-commit~=2.2", "pylint~=2.17.4"]
+pre-commit = [
+    "pre-commit~=2.2",
+    "pylint~=2.17.4",
+]
 tests = [
     'pgtest~=1.3',
     "pytest~=7.0",
@@ -99,9 +102,9 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 "workgraph.select" = "aiida_workgraph.tasks.builtins:Select"
 "workgraph.set_context" = "aiida_workgraph.tasks.builtins:SetContext"
 "workgraph.get_context" = "aiida_workgraph.tasks.builtins:GetContext"
-"workgraph.monitor_time" = "aiida_workgraph.tasks.monitors:monitor_time"
-"workgraph.monitor_file" = "aiida_workgraph.tasks.monitors:monitor_file"
-"workgraph.monitor_task" = "aiida_workgraph.tasks.monitors:monitor_task"
+"workgraph.time_monitor" = "aiida_workgraph.tasks.monitors:TimeMonitor"
+"workgraph.file_monitor" = "aiida_workgraph.tasks.monitors:FileMonitor"
+"workgraph.task_monitor" = "aiida_workgraph.tasks.monitors:TaskMonitor"
 "workgraph.aiida_int" = "aiida_workgraph.tasks.builtins:AiiDAInt"
 "workgraph.aiida_float" = "aiida_workgraph.tasks.builtins:AiiDAFloat"
 "workgraph.aiida_string" = "aiida_workgraph.tasks.builtins:AiiDAString"
@@ -145,8 +148,13 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 [project.entry-points."aiida_workgraph.type_mapping"]
 "workgraph.builtins_mapping" = "aiida_workgraph.orm.mapping:builtins_type_mapping"
 
+
 [tool.flit.sdist]
-exclude = ["docs/", "tests/"]
+exclude = [
+    "docs/",
+    "tests/",
+]
+
 
 [tool.pylint.format]
 max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph @ git+https://github.com/superstar54/node-graph.git@use_wrapt_proxy",
+    "node-graph==0.2.21",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "aiida-workgraph"
-dynamic = ["version"]  # read from aiida_workgraph/__init__.py
+dynamic = ["version"] # read from aiida_workgraph/__init__.py
 description = "Design flexible node-based workflow for AiiDA calculation."
-authors = [{name = "Xing Wang", email = "xingwang1991@gmail.com"}]
+authors = [{ name = "Xing Wang", email = "xingwang1991@gmail.com" }]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 classifiers = [
     "Development Status :: 1 - Planning",
     "Framework :: AiiDA",
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph @ git+https://github.com/scinode/node-graph.git",
+    "node-graph @ git+https://github.com/superstar54/node-graph.git@use_wrapt_proxy",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",
@@ -61,10 +61,7 @@ docs = [
     "sphinx-autobuild",
     "click~=8.1.0",
 ]
-pre-commit = [
-    "pre-commit~=2.2",
-    "pylint~=2.17.4",
-]
+pre-commit = ["pre-commit~=2.2", "pylint~=2.17.4"]
 tests = [
     'pgtest~=1.3',
     "pytest~=7.0",
@@ -102,9 +99,9 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 "workgraph.select" = "aiida_workgraph.tasks.builtins:Select"
 "workgraph.set_context" = "aiida_workgraph.tasks.builtins:SetContext"
 "workgraph.get_context" = "aiida_workgraph.tasks.builtins:GetContext"
-"workgraph.time_monitor" = "aiida_workgraph.tasks.monitors:TimeMonitor"
-"workgraph.file_monitor" = "aiida_workgraph.tasks.monitors:FileMonitor"
-"workgraph.task_monitor" = "aiida_workgraph.tasks.monitors:TaskMonitor"
+"workgraph.monitor_time" = "aiida_workgraph.tasks.monitors:monitor_time"
+"workgraph.monitor_file" = "aiida_workgraph.tasks.monitors:monitor_file"
+"workgraph.monitor_task" = "aiida_workgraph.tasks.monitors:monitor_task"
 "workgraph.aiida_int" = "aiida_workgraph.tasks.builtins:AiiDAInt"
 "workgraph.aiida_float" = "aiida_workgraph.tasks.builtins:AiiDAFloat"
 "workgraph.aiida_string" = "aiida_workgraph.tasks.builtins:AiiDAString"
@@ -148,13 +145,8 @@ workgraph = "aiida_workgraph.cli.cmd_workgraph:workgraph"
 [project.entry-points."aiida_workgraph.type_mapping"]
 "workgraph.builtins_mapping" = "aiida_workgraph.orm.mapping:builtins_type_mapping"
 
-
 [tool.flit.sdist]
-exclude = [
-    "docs/",
-    "tests/",
-]
-
+exclude = ["docs/", "tests/"]
 
 [tool.pylint.format]
 max-line-length = 120

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -351,8 +351,9 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Finalize the workgraph.
         Output the results of the workgraph and the new data.
         """
-        # expose outputs of the workgraph
+        # in case we expose the ctx and inputs as outputs directly
         self.task_manager.state_manager.update_meta_tasks("graph_ctx")
+        self.task_manager.state_manager.update_meta_tasks("graph_inputs")
         self.out_many(self.ctx._task_results["graph_outputs"])
         # output the new data
         if self.ctx._new_data:

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -467,14 +467,7 @@ class GraphTask(Task):
                 executor.__globals__[executor.__name__] = task.graph()(executor)
         if getattr(executor, "is_decoratored", False):
             executor = executor._func
-        graph_task_output_names = [
-            output._name
-            for output in self.outputs
-            if not output._metadata.builtin_socket
-        ]
-        wg = _run_func_with_wg(
-            executor, graph_task_output_names, args, kwargs, var_kwargs
-        )
+        wg = _run_func_with_wg(executor, self.__class__, args, kwargs, var_kwargs)
         wg.name = self.name
 
         wg.parent_uuid = engine_process.node.uuid

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -12,6 +12,7 @@ from aiida_pythonjob.calculations.pyfunction import PyFunction
 from aiida_shell.calculations.shell import ShellJob
 import inspect
 from yaml.constructor import ConstructorError
+from node_graph.socket import TaggedValue
 
 
 def inspect_aiida_component_type(executor: Callable) -> str:
@@ -330,6 +331,8 @@ def get_raw_value(identifier, value: Any) -> Any:
         "workgraph.aiida_string",
         "workgraph.aiida_bool",
     ]:
+        if isinstance(value, TaggedValue):
+            value = value.__wrapped__
         if value is not None and isinstance(value, orm.Data):
             return value.value
         else:
@@ -566,7 +569,6 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
     values to AiiDA Data nodes, if needed.
     """
     from aiida_pythonjob.data.serializer import general_serializer
-    from node_graph.socket import TaggedValue
 
     if input_socket["identifier"] == "workgraph.namespace":
         for socket in input_socket["sockets"].values():

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -442,6 +442,10 @@ def workgraph_to_short_json(
         if len(node["inputs"]) == 0 and len(node["outputs"]) == 0:
             del wgdata_short["nodes"][name]
 
+    # remove the inputs socket of "graph_inputs"
+    if "graph_inputs" in wgdata_short["nodes"]:
+        wgdata_short["nodes"]["graph_inputs"]["inputs"] = []
+
     return wgdata_short
 
 
@@ -562,6 +566,7 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
     values to AiiDA Data nodes, if needed.
     """
     from aiida_pythonjob.data.serializer import general_serializer
+    from node_graph.socket import TaggedValue
 
     if input_socket["identifier"] == "workgraph.namespace":
         for socket in input_socket["sockets"].values():
@@ -570,4 +575,6 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
         value = input_socket.get("property", {}).get("value")
         if value is None or isinstance(value, orm.Data):
             return
+        if isinstance(value, TaggedValue):
+            value = value.__wrapped__
         input_socket["property"]["value"] = general_serializer(value)

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -12,6 +12,10 @@ def test_tuple_outputs(decorated_add, decorated_multiply):
         return sum_result, product_result
 
     wg = add_multiply.build_graph(1, 2)
+    # graph inputs
+    assert wg.inputs.a.value == 1
+    assert wg.inputs.b.value == 2
+    # graph outputs
     assert "sum" in wg.outputs
     assert "product" in wg.outputs
 

--- a/tests/test_group_inputs_outputs.py
+++ b/tests/test_group_inputs_outputs.py
@@ -1,4 +1,4 @@
-from aiida_workgraph import WorkGraph
+from aiida_workgraph import WorkGraph, task
 
 
 def test_group_inputs_outputs(decorated_add):
@@ -41,3 +41,25 @@ def test_load_from_db():
     wg3 = WorkGraph.load(wg2.pk)
     assert wg3.inputs.x == 1
     assert wg3.inputs.z == 3
+
+
+def test_detect_graph_inputs(decorated_add):
+    """Test that graph inputs are detected correctly."""
+
+    # case 1: multiple graph inputs share the same value
+    @task.graph
+    def graph1(x, y):
+        decorated_add(x=x, y=y)
+
+    wg = graph1.build_graph(x=1, y=1)
+    assert "graph_inputs.x -> add.x" in wg.links
+    assert "graph_inputs.y -> add.y" in wg.links
+
+    # case 2: input variable was renamed
+    @task.graph
+    def graph1(x, y):
+        z = y
+        decorated_add(x=x, y=z)
+
+    assert "graph_inputs.x -> add.x" in wg.links
+    assert "graph_inputs.y -> add.y" in wg.links


### PR DESCRIPTION
Resolves #603. supercedes #614 

## Considerations for detecting graph-level inputs

### Pros

* Clear visualization of graph inputs, similar to the context manager approach.
* When the WorkGraph runs, graph-level inputs are serialized and passed to tasks, so the data flow within the AiiDA process can be tracked. Otherwise, tasks would serialize their raw inputs, creating multiple distinct AiiDA data nodes for the same data.
* Serialization requires users to declare the input structure, which makes graphs more robust and less error prone.

### Cons

* The serialization requirement forces users to declare the input structure, which raises the learning curve for new users. They also need to understand the concept of namespaces.

## Implementation

In this PR, we use the `TaggedValue` class, which transparently behaves like the wrapped value, as well as attach a `_socket` attribute referencing its originating graph input socket.
When a `TaggedValue` is passed to a task's socket, a link will be made instead of assigning the value. Since this happens at runtime, it captures complex control flow.
This should be robust and cover all possible cases.

## 

Example:

```python
@task
def add(x, y):
    return x + y

@task
def multiply(x, y):
    return x * y

@task.graph
def add_multiply(a, b, c):
    sum = add(x=a, y=b).result
    if a > 0:
        a = add(x=a, y=b).result
        product = multiply(a, y=c)
    else:
        product = multiply(a, y=c)
    return product

wg = add_multiply.build_graph(a=1, b=2, c=3)
wg
```

## Possible limitation
A potential limitation is whether the `TaggedValue` class is general enough to wrap all types of Python objects. The implementation uses the [wrapt](https://github.com/GrahamDumpleton/wrapt) package, which is a widely-adopted library (used by over 601,000 packages on GitHub). This widespread usage suggests that it is robust enough for this application.
