### PR TITLE
Use spec

### DIFF
--- a/docs/gallery/advanced/autogen/node_graph_programming.py
+++ b/docs/gallery/advanced/autogen/node_graph_programming.py
@@ -15,7 +15,7 @@ Write workflows using the node-graph programming paradigm
 #
 # First, we set up our AiiDA environment:
 
-from aiida_workgraph import WorkGraph, task
+from aiida_workgraph import WorkGraph, task, spec
 from aiida import load_profile
 
 load_profile()
@@ -193,15 +193,8 @@ wg.to_html()
 # which indicates that `result` is a dynamic output and will be a namespace.
 
 
-@task(
-    outputs={
-        "result": {
-            "identifier": "workgraph.namespace",
-            "metadata": {"dynamic": True},
-        }
-    }
-)
-def generate_data(N):
+@task
+def generate_data(N) -> spec.namespace(result=spec.dynamic(any)):
     """Generates a dictionary with N items."""
     data = {f"item_{i}": i for i in range(N)}
     return {"result": data}

--- a/docs/gallery/concept/autogen/socket_concept.py
+++ b/docs/gallery/concept/autogen/socket_concept.py
@@ -9,7 +9,7 @@ This guide will walk you through how to define, customize, and organize sockets 
 
 """
 from aiida.manage import load_profile
-from aiida_workgraph import task, WorkGraph
+from aiida_workgraph import task, WorkGraph, spec
 from aiida import orm
 
 # Load the AiiDA profile to interact with the database
@@ -47,13 +47,8 @@ print("Output sockets: ", task1.get_output_names())
 # - The function returns a dictionary: The keys of the returned dictionary must match the socket names.
 
 
-@task(
-    outputs={
-        "sum": {"identifier": "workgraph.Any"},
-        "difference": {"identifier": "workgraph.Any"},
-    }
-)
-def add_and_subtract(x, y):
+@task
+def add_and_subtract(x, y) -> spec.namespace(sum=any, difference=any):
     """Return the sum and difference of two numbers in a dict."""
     return {
         "sum": x + y,
@@ -74,13 +69,8 @@ print("Output sockets: ", task2.get_output_names())
 #    Be sure that the number of elements in the returned tuple matches the number of defined output sockets.
 
 
-@task(
-    outputs={
-        "sum": {"identifier": "workgraph.Any"},
-        "difference": {"identifier": "workgraph.Any"},
-    }
-)
-def add_and_subtract(x, y):
+@task
+def add_and_subtract(x, y) -> spec.namespace(sum=any, difference=any):
     """Return the sum and difference of two numbers as a tuple."""
     return x + y, x - y
 
@@ -186,26 +176,14 @@ with WorkGraph("simple_namespace_example") as wg:
 # -----------------
 # For more complex data structures, you can define nested namespaces. This allows you to create a hierarchical organization for your sockets.
 
-
-@task(
-    outputs={
-        "normal": {
-            "identifier": "workgraph.namespace",
-            "sockets": {
-                "sum": {"identifier": "workgraph.any"},
-                "product": {"identifier": "workgraph.any"},
-            },
-        },
-        "squared": {
-            "identifier": "workgraph.namespace",
-            "sockets": {
-                "sum": {"identifier": "workgraph.any"},
-                "product": {"identifier": "workgraph.any"},
-            },
-        },
-    }
+out = spec.namespace(
+    normal=spec.namespace(sum=any, product=any),
+    squared=spec.namespace(sum=any, product=any),
 )
-def advanced_math(x, y):
+
+
+@task
+def advanced_math(x, y) -> out:
     """A task with a nested output structure."""
     return {
         "normal": {"sum": x + y, "product": x * y},
@@ -235,15 +213,8 @@ with WorkGraph("nested_namespace_example") as wg:
 # To create one, define a namespace socket and set its metadata to `{"dynamic": True}`.
 
 
-@task(
-    outputs={
-        "squares": {
-            "identifier": "workgraph.namespace",
-            "metadata": {"dynamic": True},
-        }
-    }
-)
-def generate_squares(n: int):
+@task
+def generate_squares(n: int) -> spec.namespace(squares=spec.dynamic(int)):
     """Generates a dynamic number of square values."""
     # The return dictionary must match the output socket names.
     # The value for the "squares" dynamic namespace is another dictionary,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph==0.2.21",
+    "node-graph @ git+https://github.com/superstar54/node-graph.git@parse_definition_from_type_hint",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph @ git+https://github.com/superstar54/node-graph.git@parse_definition_from_type_hint",
+    "node-graph==0.2.22",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/__init__.py
+++ b/src/aiida_workgraph/__init__.py
@@ -5,6 +5,7 @@ from .tasks import TaskPool
 from .tasks.factory.shelljob_task import shelljob
 from .utils.flow_control import if_, while_, map_
 from .manager import get_current_graph, If, Map, While, Zone
+from node_graph import spec
 
 __version__ = "0.6.0"
 
@@ -23,4 +24,5 @@ __all__ = [
     "While",
     "TaskPool",
     "shelljob",
+    "spec",
 ]

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -428,23 +428,9 @@ class TaskDecoratorCollection:
                     f"Function '{func.__name__}' defines parameter(s) {sorted(conflicts)}, "
                     "which conflict with default 'monitor' arguments."
                 )
-            task_inputs = inputs if inputs is not None else {}
-            # Add default interval and timeout
-            task_inputs.update(
-                {
-                    "interval": {
-                        "identifier": "workgraph.float",
-                        "property": {"default": 5},
-                    },
-                    "timeout": {
-                        "identifier": "workgraph.float",
-                        "property": {"default": 3600},
-                    },
-                }
-            )
             TaskCls = MonitorFunctionTaskFactory.from_function(
                 func=func,
-                inputs=task_inputs,
+                inputs=inputs,
                 outputs=outputs,
             )
 

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -16,8 +16,8 @@ from aiida_workgraph.tasks.factory import (
 
 def build_task(
     executor: Union[Callable, str],
-    inputs: Optional[List[str | dict]] = None,
-    outputs: Optional[List[str | dict]] = None,
+    inputs: Optional[type | list] = None,
+    outputs: Optional[type | list] = None,
 ) -> Task:
     """Build task from executor."""
 
@@ -31,8 +31,8 @@ def build_task(
 
 def build_task_from_callable(
     executor: Callable,
-    inputs: Optional[List[str | dict]] = None,
-    outputs: Optional[List[str | dict]] = None,
+    inputs: Optional[type | list] = None,
+    outputs: Optional[type | list] = None,
 ) -> Task:
     """Build task from a callable object.
     First, check if the executor is already a task.
@@ -54,7 +54,7 @@ def build_task_from_callable(
     if inspect.isfunction(executor):
         # calcfunction and workfunction
         if getattr(executor, "node_class", False):
-            return AiiDAComponentTaskFactory.from_aiida_component(
+            return AiiDAComponentTaskFactory.from_aiida_process_function(
                 executor, inputs=inputs, outputs=outputs
             )
         else:
@@ -65,9 +65,11 @@ def build_task_from_callable(
             )
     else:
         if issubclass(executor, CalcJob) or issubclass(executor, WorkChain):
-            return AiiDAComponentTaskFactory.from_aiida_component(
-                executor, inputs=inputs, outputs=outputs
-            )
+            if inputs is not None or outputs is not None:
+                raise ValueError(
+                    "Can not override inputs or outputs of an AiiDA process classes."
+                )
+            return AiiDAComponentTaskFactory.from_aiida_process_class(executor)
     raise ValueError(f"The executor {executor} is not supported.")
 
 
@@ -226,9 +228,8 @@ class TaskDecoratorCollection:
     def decorator_task(
         identifier: Optional[str] = None,
         task_type: str = "Normal",
-        properties: Optional[List[Tuple[str, str]]] = None,
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
         catalog: str = "Others",
         store_provenance: bool = True,
@@ -238,7 +239,6 @@ class TaskDecoratorCollection:
         Attributes:
             indentifier (str): task identifier
             catalog (str): task catalog
-            properties (list): task properties
             inputs (list): task inputs
             outputs (list): task outputs
         """
@@ -249,7 +249,7 @@ class TaskDecoratorCollection:
             if inspect.isfunction(callable) or callable.__module__ == "builtins":
                 # calcfunction and workfunction
                 if getattr(callable, "node_class", False):
-                    TaskCls = AiiDAComponentTaskFactory.from_aiida_component(
+                    TaskCls = AiiDAComponentTaskFactory.from_aiida_process_function(
                         callable, inputs=inputs, outputs=outputs
                     )
                 else:
@@ -265,7 +265,6 @@ class TaskDecoratorCollection:
                             func=callable,
                             identifier=identifier,
                             task_type=task_type,
-                            properties=properties,
                             inputs=inputs,
                             outputs=outputs,
                             error_handlers=error_handlers,
@@ -273,8 +272,12 @@ class TaskDecoratorCollection:
                         )
             else:
                 if issubclass(callable, CalcJob) or issubclass(callable, WorkChain):
-                    TaskCls = AiiDAComponentTaskFactory.from_aiida_component(
-                        callable, inputs=inputs, outputs=outputs
+                    if inputs is not None or outputs is not None:
+                        raise ValueError(
+                            "Can not override inputs or outputs of an AiiDA process classes."
+                        )
+                    TaskCls = AiiDAComponentTaskFactory.from_aiida_process_class(
+                        callable
                     )
             # if callable is a function, we pass it to the make_wrapper
             if not inspect.isfunction(callable):
@@ -287,7 +290,6 @@ class TaskDecoratorCollection:
     @nonfunctional_usage
     def decorator_graph(
         identifier: Optional[str] = None,
-        properties: Optional[List[Tuple[str, str]]] = None,
         inputs: Optional[List[Tuple[str, str]]] = None,
         outputs: Optional[List[Tuple[str, str]]] = None,
         catalog: str = "Others",
@@ -296,7 +298,6 @@ class TaskDecoratorCollection:
         Attributes:
             indentifier (str): task identifier
             catalog (str): task catalog
-            properties (list): task properties
             inputs (list): task inputs
             outputs (list): task outputs
         """
@@ -308,7 +309,6 @@ class TaskDecoratorCollection:
                 func=func,
                 identifier=identifier,
                 task_type="graph_task",
-                properties=properties,
                 inputs=inputs,
                 outputs=outputs,
                 catalog=catalog,
@@ -331,13 +331,13 @@ class TaskDecoratorCollection:
     @staticmethod
     @nonfunctional_usage
     def calcfunction(
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable:
         def decorator(func):
             func_decorated = calcfunction(func)
-            TaskCls = AiiDAComponentTaskFactory.from_aiida_component(
+            TaskCls = AiiDAComponentTaskFactory.from_aiida_process_function(
                 func_decorated,
                 inputs=inputs,
                 outputs=outputs,
@@ -351,13 +351,13 @@ class TaskDecoratorCollection:
     @staticmethod
     @nonfunctional_usage
     def workfunction(
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable:
         def decorator(func):
             func_decorated = workfunction(func)
-            TaskCls = AiiDAComponentTaskFactory.from_aiida_component(
+            TaskCls = AiiDAComponentTaskFactory.from_aiida_process_function(
                 func_decorated,
                 inputs=inputs,
                 outputs=outputs,
@@ -371,8 +371,8 @@ class TaskDecoratorCollection:
     @staticmethod
     @nonfunctional_usage
     def pythonjob(
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable:
         def decorator(func):
@@ -391,8 +391,8 @@ class TaskDecoratorCollection:
     @staticmethod
     @nonfunctional_usage
     def awaitable(
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
     ) -> Callable:
         def decorator(func):
             from aiida_workgraph.tasks.factory.awaitable_task import (
@@ -412,8 +412,8 @@ class TaskDecoratorCollection:
     @staticmethod
     @nonfunctional_usage
     def monitor(
-        inputs: Optional[List[str | dict]] = None,
-        outputs: Optional[List[str | dict]] = None,
+        inputs: Optional[type | list] = None,
+        outputs: Optional[type | list] = None,
     ) -> Callable:
         def decorator(func):
             from aiida_workgraph.tasks.factory.awaitable_task import (

--- a/src/aiida_workgraph/engine/task_manager.py
+++ b/src/aiida_workgraph/engine/task_manager.py
@@ -174,7 +174,7 @@ class TaskManager:
 
             self.logger.info(f"Run task: {name}, type: {task.node_type}")
             inputs = self.get_inputs(name)
-            # print("kwargs: ", inputs["kwargs"])
+            print("kwargs: ", inputs["kwargs"])
             self.ctx._task_results[task.name] = {}
             task_type = task.node_type.upper()
             if task_type in ["CALCFUNCTION", "PYFUNCTION", "WORKFUNCTION"]:

--- a/src/aiida_workgraph/tasks/factory/awaitable_task.py
+++ b/src/aiida_workgraph/tasks/factory/awaitable_task.py
@@ -77,3 +77,14 @@ class MonitorFunctionTaskFactory(DecoratedFunctionTaskFactory):
 
     default_task_type = "monitor"
     default_base_class = MonitorFunctionTask
+
+    additional_inputs = {
+        "interval": {
+            "identifier": "workgraph.float",
+            "property": {"default": 5},
+        },
+        "timeout": {
+            "identifier": "workgraph.float",
+            "property": {"default": 3600},
+        },
+    }

--- a/src/aiida_workgraph/tasks/factory/function_task.py
+++ b/src/aiida_workgraph/tasks/factory/function_task.py
@@ -1,5 +1,5 @@
 from aiida_workgraph.orm.mapping import type_mapping
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from aiida_workgraph.config import builtin_inputs, builtin_outputs
 from node_graph.executor import NodeExecutor
 from .base import BaseTaskFactory
@@ -17,7 +17,6 @@ class DecoratedFunctionTaskFactory(BaseTaskFactory):
         func: Callable,
         identifier: Optional[str] = None,
         task_type: str = None,
-        properties: Optional[List[Tuple[str, str]]] = None,
         inputs: Optional[List[Union[str, dict]]] = None,
         outputs: Optional[List[Union[str, dict]]] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
@@ -29,28 +28,21 @@ class DecoratedFunctionTaskFactory(BaseTaskFactory):
         Build the _DecoratedFunctionTask subclass from the function
         and the various decorator arguments.
         """
-        from node_graph.decorator import generate_input_sockets
+        from node_graph.nodes.utils import (
+            generate_input_sockets,
+            generate_output_sockets,
+        )
 
         node_class = node_class or cls.default_base_class
 
         task_type = task_type or cls.default_task_type
         identifier = identifier or func.__name__
-        inputs = validate_socket_data(inputs) or {}
-        properties = properties or {}
+        inputs = validate_socket_data(inputs)
         # at least one output is required
-        task_outputs = validate_socket_data(outputs) or {
-            "result": {"identifier": "workgraph.any"}
-        }
+        outputs = validate_socket_data(outputs)
         error_handlers = error_handlers or []
-        task_inputs = generate_input_sockets(
-            func, inputs, properties, type_mapping=type_mapping
-        )
-        # Mark function inputs and outputs
-        task_outputs = {
-            "name": "outputs",
-            "identifier": node_class.SocketPool.any,
-            "sockets": task_outputs,
-        }
+        task_inputs = generate_input_sockets(func, inputs, type_mapping=type_mapping)
+        task_outputs = generate_output_sockets(func, outputs, type_mapping=type_mapping)
         for out in task_outputs["sockets"].values():
             out.setdefault("metadata", {})
             out["metadata"]["function_socket"] = True
@@ -64,7 +56,6 @@ class DecoratedFunctionTaskFactory(BaseTaskFactory):
                 "node_type": task_type,
                 "catalog": catalog,
             },
-            "properties": properties,
             "inputs": task_inputs,
             "outputs": task_outputs,
             "error_handlers": error_handlers,

--- a/src/aiida_workgraph/tasks/factory/function_task.py
+++ b/src/aiida_workgraph/tasks/factory/function_task.py
@@ -10,6 +10,8 @@ class DecoratedFunctionTaskFactory(BaseTaskFactory):
     """A factory to create specialized subclasses of Task from functions."""
 
     default_task_type = "Normal"
+    additional_inputs = {}
+    additional_outputs = {}
 
     @classmethod
     def from_function(
@@ -49,6 +51,10 @@ class DecoratedFunctionTaskFactory(BaseTaskFactory):
         # add built-in sockets
         task_inputs["sockets"].update(builtin_inputs.copy())
         task_outputs["sockets"].update(builtin_outputs.copy())
+        for name, input_data in cls.additional_inputs.items():
+            task_inputs["sockets"][name] = input_data.copy()
+        for name, output in cls.additional_outputs.items():
+            task_outputs["sockets"][name] = output.copy()
 
         tdata = {
             "identifier": identifier,

--- a/src/aiida_workgraph/tasks/factory/pythonjob/factory.py
+++ b/src/aiida_workgraph/tasks/factory/pythonjob/factory.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from aiida_workgraph.tasks.factory.aiida_task import AiiDAComponentTaskFactory
 from aiida_workgraph.tasks.factory.function_task import DecoratedFunctionTaskFactory
 from aiida_pythonjob import PythonJob
@@ -29,7 +29,6 @@ class BasePythonTaskFactory(BaseTaskFactory):
         cls,
         func: Callable,
         identifier: Optional[str] = None,
-        properties: Optional[List[Tuple[str, str]]] = None,
         inputs: Optional[List[Union[str, dict]]] = None,
         outputs: Optional[List[Union[str, dict]]] = None,
         error_handlers: Optional[List[Dict[str, Any]]] = None,
@@ -39,15 +38,12 @@ class BasePythonTaskFactory(BaseTaskFactory):
         """The task is a combination of function task and AiiDA component task."""
 
         if not hasattr(func, "_TaskCls"):
-            outputs = outputs or {
-                "result": {"identifier": "workgraph.any", "name": "result"}
-            }
+            outputs = outputs
             TaskCls0 = DecoratedFunctionTaskFactory.from_function(
                 func,
                 identifier=identifier,
                 inputs=inputs,
                 outputs=outputs,
-                properties=properties,
                 error_handlers=error_handlers,
             )
         else:
@@ -56,7 +52,7 @@ class BasePythonTaskFactory(BaseTaskFactory):
             raise ValueError(
                 "Graph task cannot be run remotely. Please remove 'PythonJob'."
             )
-        TaskCls = AiiDAComponentTaskFactory.from_aiida_component(cls.process_class)
+        TaskCls = AiiDAComponentTaskFactory.from_aiida_process_class(cls.process_class)
         tdata = TaskCls0._ndata
         # merge the inputs and outputs from the process_class task to the function task
         # skip the already existed inputs and outputs

--- a/src/aiida_workgraph/tasks/factory/utils.py
+++ b/src/aiida_workgraph/tasks/factory/utils.py
@@ -17,7 +17,7 @@ def generate_tdata(
     additional_data: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Generate task data for creating a task."""
-    from node_graph.decorator import generate_input_sockets
+    from node_graph.nodes.utils import generate_input_sockets
 
     task_inputs = generate_input_sockets(
         func, inputs, properties, type_mapping=type_mapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Callable, Any, Union
 from aiida.orm import WorkflowNode
 import time
 import os
+from node_graph import spec
 
 pytest_plugins = [
     "aiida.tools.pytest_fixtures",
@@ -220,21 +221,10 @@ def decorated_add_multiply_group(decorated_add, decorated_multiply) -> Callable:
 def decorated_namespace_sum_diff() -> Callable:
     """Generate a decorated node for test."""
 
-    @task(
-        inputs={
-            "nested": {"identifier": "namespace"},
-            "nested.x": {},
-            "nested.y": {},
-        },
-        outputs={
-            "sum": {},
-            "diff": {},
-            "nested": {"identifier": "namespace"},
-            "nested.sum": {},
-            "nested.diff": {},
-        },
-    )
-    def sum_diff(x, y, nested):
+    out = spec.namespace(sum=any, diff=any, nested=spec.namespace(diff=any, sum=any))
+
+    @task
+    def sum_diff(x, y, nested: spec.namespace(x=any, y=any)) -> out:
         """Add two numbers and return the result."""
         return {
             "sum": x + y,

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -1,6 +1,7 @@
 from aiida_workgraph import WorkGraph, task
 from typing import Callable
 from aiida.orm import Float, ArrayData
+from node_graph import spec
 import numpy as np
 import pytest
 
@@ -52,14 +53,8 @@ def test_task_update_ctx(decorated_add: Callable) -> None:
 
 
 def test_task_update_nested_ctx():
-    @task(
-        outputs={
-            "results": {"identifier": "workgraph.namespace"},
-            "results.sum": {},
-            "results.product": {},
-        }
-    )
-    def add(x, y):
+    @task
+    def add(x, y) -> spec.namespace(results=spec.namespace(sum=any, product=any)):
         return {"results": {"sum": x + y, "product": x * y}}
 
     wg = WorkGraph()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -3,13 +3,14 @@ from aiida_workgraph import WorkGraph, task
 from aiida_workgraph.socket import TaskSocketNamespace
 from typing import Callable
 from aiida_workgraph.manager import get_current_graph, set_current_graph
+from node_graph import spec
 
 
 def test_custom_outputs():
     """Test custom outputs."""
 
-    @task(outputs={"sum": {}, "product": {"identifier": "workgraph.any"}})
-    def add_multiply(x, y):
+    @task
+    def add_multiply(x, y) -> spec.namespace(sum=any, product=any):
         return {"sum": x + y, "product": x * y}
 
     n = add_multiply._TaskCls()
@@ -226,16 +227,8 @@ def test_decorator_graph_namespace_outputs(decorated_add: Callable) -> None:
     """=Test namespace outputs in graph builder."""
     from aiida_workgraph.socket import TaskSocketNamespace, TaskSocket
 
-    @task.graph(
-        outputs={
-            "add1": {
-                "identifier": "workgraph.namespace",
-                "metadata": {"dynamic": True},
-            },
-            "sum": {},
-        }
-    )
-    def add_group(x, y, z):
+    @task.graph
+    def add_group(x, y, z) -> spec.namespace(add1=spec.dynamic(any), sum=any):
         outputs1 = decorated_add(x=x, y=y)
         return {"add1": outputs1, "sum": outputs1.result}
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,6 +5,7 @@ from aiida_workgraph.manager import (
     While,
     Map,
 )
+from node_graph import spec
 
 
 @task()
@@ -33,15 +34,10 @@ def test_while_and_if(decorated_add):
 def test_map(decorated_add):
     """"""
 
-    @task(
-        outputs={
-            "result": {
-                "identifier": "workgraph.namespace",
-                "metadata": {"dynamic": True},
-            }
-        }
-    )
-    def generate_list(N):
+    @task
+    def generate_list(N) -> spec.namespace(result=spec.dynamic(any)):
+        """Generate a list of N items."""
+        # This is a simple example, in practice you might want to generate more complex data
         return {"result": {f"item_{i}": i for i in range(1, N + 1)}}
 
     @task()

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -2,6 +2,7 @@ import pytest
 from aiida_workgraph import WorkGraph, task, Task, TaskPool
 from typing import Any
 import numpy as np
+from node_graph import spec
 
 
 def test_to_dict():
@@ -147,18 +148,15 @@ def test_PythonJob_namespace_output_input(fixture_localhost, python_executable_p
     """Test function with namespace output and input."""
 
     # output namespace
-    @task(
-        outputs={
-            "add_multiply": {"identifier": "workgraph.namespace"},
-            "add_multiply.add": {
-                "identifier": "workgraph.namespace",
-                "metadata": {"dynamic": True},
-            },
-            "add_multiply.multiply": {},
-            "minus": {},
-        }
+    out = spec.namespace(
+        add_multiply=spec.namespace(
+            add=spec.namespace(sum=any, total=any), multiply=any
+        ),
+        minus=any,
     )
-    def myfunc(x, y):
+
+    @task
+    def myfunc(x, y) -> out:
         return {
             "add_multiply": {"add": {"sum": x + y, "total": x + y}, "multiply": x * y},
             "minus": x - y,

--- a/tests/test_task_from_workgraph.py
+++ b/tests/test_task_from_workgraph.py
@@ -50,7 +50,7 @@ def test_build_task_from_workgraph(decorated_add: Callable) -> None:
     add1_task = wg.add_task(decorated_add, name="add1", x=1, y=3)
     wg_task = wg.add_task(sub_wg, name="sub_wg")
     # the default value of the namespace is None
-    assert wg_task.inputs["add1"]._value == {"x": x, "y": 3}
+    assert wg_task.inputs["add1"]._value == {"t": 1.0, "x": x, "y": 3}
     assert hasattr(wg.tasks.sub_wg, "workgraph")
     assert hasattr(wg.tasks.sub_wg, "links")
     assert hasattr(wg.tasks.sub_wg, "tasks")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,6 +2,7 @@ import pytest
 from aiida_workgraph import WorkGraph, task
 from typing import Callable
 from aiida import orm
+from node_graph import spec
 
 
 def test_normal_task(decorated_add) -> None:
@@ -195,12 +196,9 @@ def test_set_inputs_from_builder(add_code) -> None:
 
 def test_namespace_outputs():
     @task.calcfunction(
-        outputs={
-            "add_multiply": {"identifier": "workgraph.namespace"},
-            "add_multiply.add": {},
-            "add_multiply.multiply": {},
-            "minus": {},
-        }
+        outputs=spec.namespace(
+            add_multiply=spec.namespace(add=any, multiply=any), minus=any
+        )
     )
     def myfunc(x, y):
         return {
@@ -210,6 +208,7 @@ def test_namespace_outputs():
 
     wg = WorkGraph("test_namespace_outputs")
     wg.add_task(myfunc, name="myfunc", x=1.0, y=2.0)
+    print(wg.tasks.myfunc.outputs)
     wg.run()
     assert wg.tasks.myfunc.outputs.minus.value == -1
     assert wg.tasks.myfunc.outputs.add_multiply.add.value == 3


### PR DESCRIPTION
This PR replaces the old dict-based way of declaring sockets and namespaces with a typing API:

On top of this [branch](https://github.com/scinode/node-graph/pull/77) of node-graph.


An example explains everything:
**Before**
```python
@task(
    outputs={
        "normal": {
            "identifier": "workgraph.namespace",
            "sockets": {
                "sum": {"identifier": "workgraph.any"},
                "product": {"identifier": "workgraph.any"},
            },
        },
        "squared": {
            "identifier": "workgraph.namespace",
            "sockets": {
                "sum": {"identifier": "workgraph.any"},
                "product": {"identifier": "workgraph.any"},
            },
        },
    }
)
def advanced_math(x, y):
    """A task with a nested output structure."""
    return {
        "normal": {"sum": x + y, "product": x * y},
        "squared": {"sum": x**2 + y**2, "product": x**2 * y**2},
    }
```

**After** this PR:
```python
out = spec.namespace(
    normal=spec.namespace(sum=any, product=any),
    squared=spec.namespace(sum=any, product=any),
)

@task
def advanced_math(x, y) -> out:
    """A task with a nested output structure."""
    return {
        "normal": {"sum": x + y, "product": x * y},
        "squared": {"sum": x**2 + y**2, "product": x**2 * y**2},
    }
```
