### PR TITLE
Load `wg` when restart

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -352,6 +352,8 @@ class WorkGraph(node_graph.NodeGraph):
         for task in wg.tasks:
             if hasattr(task, "children"):
                 task.children.add(wgdata["nodes"][task.name].get("children", []))
+        # reinstate the tasks
+        wgdata["tasks"] = wgdata.pop("nodes")
 
         return wg
 


### PR DESCRIPTION
Fix #631 

- Load `wg` when load the process, e.g., when daemon restart
- Save the wogkraph data in the context, so that one can resume from checkpoint
- When an error handler is run, also update the workgraph data in the context.