### PR TITLE
Fix Graph task return namespace as outputs

### DIFF
--- a/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
+++ b/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
@@ -39,7 +39,7 @@ from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from aiida.engine import calcfunction, workfunction
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
-from aiida_workgraph import task
+from aiida_workgraph import task, spec
 
 # %%
 # Next, let's define a ``calcfunction`` and ``workfunction``
@@ -177,7 +177,7 @@ def multiply(x, y):
 
 
 @task.graph
-def IntegratedAddMultiply():
+def IntegratedAddMultiply() -> spec.namespace(sum=any, product=any):
     the_sum = add(1, 2).result
     the_product = multiply(the_sum, 3).result
     return {"sum": the_sum, "product": the_product}

--- a/src/aiida_workgraph/engine/task_state.py
+++ b/src/aiida_workgraph/engine/task_state.py
@@ -175,6 +175,7 @@ class TaskStateManager:
     def update_meta_tasks(self, name: str) -> None:
         """Export task results to the context based on context mapping."""
         from aiida_workgraph.utils import update_nested_dict, get_nested_dict
+        from aiida_workgraph.utils import resolve_node_link_manager_in_dict
 
         for link in self.process.wg.links:
             if link.from_node.name == name and link.to_node.name in [
@@ -190,6 +191,7 @@ class TaskStateManager:
                     result = get_nested_dict(
                         self.ctx._task_results[name], result_key, default=None
                     )
+                result = resolve_node_link_manager_in_dict(result)
                 update_nested_dict(
                     self.ctx._task_results[link.to_node.name], key, result
                 )

--- a/src/aiida_workgraph/engine/task_state.py
+++ b/src/aiida_workgraph/engine/task_state.py
@@ -175,7 +175,7 @@ class TaskStateManager:
     def update_meta_tasks(self, name: str) -> None:
         """Export task results to the context based on context mapping."""
         from aiida_workgraph.utils import update_nested_dict, get_nested_dict
-        from aiida_workgraph.utils import resolve_node_link_manager_in_dict
+        from aiida_workgraph.utils import resolve_node_link_managers
 
         for link in self.process.wg.links:
             if link.from_node.name == name and link.to_node.name in [
@@ -191,7 +191,7 @@ class TaskStateManager:
                     result = get_nested_dict(
                         self.ctx._task_results[name], result_key, default=None
                     )
-                result = resolve_node_link_manager_in_dict(result)
+                result = resolve_node_link_managers(result)
                 update_nested_dict(
                     self.ctx._task_results[link.to_node.name], key, result
                 )

--- a/src/aiida_workgraph/engine/task_state.py
+++ b/src/aiida_workgraph/engine/task_state.py
@@ -183,9 +183,13 @@ class TaskStateManager:
             ]:
                 key = link.to_socket._scoped_name
                 result_key = link.from_socket._scoped_name
-                result = get_nested_dict(
-                    self.ctx._task_results[name], result_key, default=None
-                )
+                # built-in "_outputs" means the whole task result
+                if result_key == "_outputs":
+                    result = self.ctx._task_results[name]
+                else:
+                    result = get_nested_dict(
+                        self.ctx._task_results[name], result_key, default=None
+                    )
                 update_nested_dict(
                     self.ctx._task_results[link.to_node.name], key, result
                 )

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -351,10 +351,12 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Finalize the workgraph.
         Output the results of the workgraph and the new data.
         """
+        from aiida_workgraph.utils import clean_node_links_manager
+
         # in case we expose the ctx and inputs as outputs directly
         self.task_manager.state_manager.update_meta_tasks("graph_ctx")
         self.task_manager.state_manager.update_meta_tasks("graph_inputs")
-        self.out_many(self.ctx._task_results["graph_outputs"])
+        self.out_many(clean_node_links_manager(self.ctx._task_results["graph_outputs"]))
         # output the new data
         if self.ctx._new_data:
             self.out("new_data", self.ctx._new_data)

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -360,13 +360,13 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Finalize the workgraph.
         Output the results of the workgraph and the new data.
         """
-        from aiida_workgraph.utils import resolve_node_link_manager_in_dict
+        from aiida_workgraph.utils import resolve_node_link_managers
 
         # in case we expose the ctx and inputs as outputs directly
         self.task_manager.state_manager.update_meta_tasks("graph_ctx")
         self.task_manager.state_manager.update_meta_tasks("graph_inputs")
         self.out_many(
-            resolve_node_link_manager_in_dict(self.ctx._task_results["graph_outputs"])
+            resolve_node_link_managers(self.ctx._task_results["graph_outputs"])
         )
         # output the new data
         if self.ctx._new_data:

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -360,12 +360,14 @@ class WorkGraphEngine(Process, metaclass=Protect):
         """Finalize the workgraph.
         Output the results of the workgraph and the new data.
         """
-        from aiida_workgraph.utils import clean_node_links_manager
+        from aiida_workgraph.utils import resolve_node_link_manager_in_dict
 
         # in case we expose the ctx and inputs as outputs directly
         self.task_manager.state_manager.update_meta_tasks("graph_ctx")
         self.task_manager.state_manager.update_meta_tasks("graph_inputs")
-        self.out_many(clean_node_links_manager(self.ctx._task_results["graph_outputs"]))
+        self.out_many(
+            resolve_node_link_manager_in_dict(self.ctx._task_results["graph_outputs"])
+        )
         # output the new data
         if self.ctx._new_data:
             self.out("new_data", self.ctx._new_data)

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -582,20 +582,20 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
         input_socket["property"]["value"] = general_serializer(value)
 
 
-def resolve_node_link_manager_in_dict(data: Any) -> Any:
-    """Recursively resolve all NodeLinksManagers inside a dict."""
+def resolve_node_link_managers(data: Any) -> Any:
+    """Recursively resolve all NodeLinksManagers either in a dictionary or a NodeLinksManager."""
     if isinstance(data, dict):
         results = {}
         for key, value in data.items():
-            results[key] = resolve_node_link_manager_in_dict(value)
+            results[key] = resolve_node_link_managers(value)
         return results
     elif isinstance(data, orm.NodeLinksManager):
-        return node_link_manager_as_dict(data)
+        return convert_node_link_manager_to_dict(data)
     else:
         return data
 
 
-def node_link_manager_as_dict(
+def convert_node_link_manager_to_dict(
     node_link_manager: orm.NodeLinksManager,
 ) -> Dict[str, Any]:
     """Recursively convert a NodeLinksManager to a dictionary representation."""
@@ -603,7 +603,7 @@ def node_link_manager_as_dict(
     for name in node_link_manager._get_keys():
         item = node_link_manager._get_node_by_link_label(name)
         if isinstance(item, orm.NodeLinksManager):
-            data[name] = node_link_manager_as_dict(item)
+            data[name] = convert_node_link_manager_to_dict(item)
         else:
             data[name] = item
     return data

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -580,3 +580,28 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
         if isinstance(value, TaggedValue):
             value = value.__wrapped__
         input_socket["property"]["value"] = general_serializer(value)
+
+
+def clean_node_links_manager(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively clean a NodeLinksManager to a dictionary representation."""
+    results = {}
+    for key, value in data.items():
+        if isinstance(value, orm.NodeLinksManager):
+            results[key] = node_link_manager_to_dict(value)
+        else:
+            results[key] = value
+    return results
+
+
+def node_link_manager_to_dict(
+    node_link_manager: orm.NodeLinksManager,
+) -> Dict[str, Any]:
+    """Convert a NodeLinksManager to a dictionary representation."""
+    data = {}
+    for name in node_link_manager._get_keys():
+        item = node_link_manager._get_node_by_link_label(name)
+        if isinstance(item, orm.NodeLinksManager):
+            data[name] = node_link_manager_to_dict(item)
+        else:
+            data[name] = item
+    return data

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -582,26 +582,28 @@ def serialize_socket_data(input_socket: Dict[str, Any]) -> None:
         input_socket["property"]["value"] = general_serializer(value)
 
 
-def clean_node_links_manager(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively clean a NodeLinksManager to a dictionary representation."""
-    results = {}
-    for key, value in data.items():
-        if isinstance(value, orm.NodeLinksManager):
-            results[key] = node_link_manager_to_dict(value)
-        else:
-            results[key] = value
-    return results
+def resolve_node_link_manager_in_dict(data: Any) -> Any:
+    """Recursively resolve all NodeLinksManagers inside a dict."""
+    if isinstance(data, dict):
+        results = {}
+        for key, value in data.items():
+            results[key] = resolve_node_link_manager_in_dict(value)
+        return results
+    elif isinstance(data, orm.NodeLinksManager):
+        return node_link_manager_as_dict(data)
+    else:
+        return data
 
 
-def node_link_manager_to_dict(
+def node_link_manager_as_dict(
     node_link_manager: orm.NodeLinksManager,
 ) -> Dict[str, Any]:
-    """Convert a NodeLinksManager to a dictionary representation."""
+    """Recursively convert a NodeLinksManager to a dictionary representation."""
     data = {}
     for name in node_link_manager._get_keys():
         item = node_link_manager._get_node_by_link_label(name)
         if isinstance(item, orm.NodeLinksManager):
-            data[name] = node_link_manager_to_dict(item)
+            data[name] = node_link_manager_as_dict(item)
         else:
             data[name] = item
     return data

--- a/tests/test_graph_task.py
+++ b/tests/test_graph_task.py
@@ -1,26 +1,49 @@
-from aiida_workgraph import task, WorkGraph
+from aiida_workgraph import task, WorkGraph, spec
 
 
-def test_tuple_outputs(decorated_add, decorated_multiply):
+@task
+def add_multiply(a, b) -> spec.namespace(sum=int, product=int):
+    """Task that returns a namespace with sum and product."""
+    return {"sum": a + b, "product": a * b}
+
+
+def test_tuple_namespace_outputs():
     """Test mapping tuple results to the workgraph outputs."""
 
-    @task.graph(outputs=["sum", "product"])
-    def add_multiply(a, b):
-        """Task that returns the sum and product of two numbers."""
-        sum_result = decorated_add(a, b).result
-        product_result = decorated_multiply(sum_result, b).result
-        return sum_result, product_result
+    @task.graph
+    def test_graph(
+        x, y
+    ) -> spec.namespace(
+        out1=spec.namespace(sum=int, product=int),
+        out2=spec.namespace(sum=int, product=int),
+    ):
+        return add_multiply(x, y), add_multiply(x, y)
 
-    wg = add_multiply.build_graph(1, 2)
+    wg = test_graph.build_graph(1, 2)
     # graph inputs
-    assert wg.inputs.a.value == 1
-    assert wg.inputs.b.value == 2
+    assert wg.inputs.x.value == 1
+    assert wg.inputs.y.value == 2
+    wg.run()
     # graph outputs
-    assert "sum" in wg.outputs
-    assert "product" in wg.outputs
+    assert wg.outputs.out1.sum.value == 3
+    assert wg.outputs.out1.product.value == 2
 
     with WorkGraph() as wg:
-        outputs = add_multiply(1, 2)
+        outputs = test_graph(1, 2)
         wg.run()
-    assert outputs.sum.value == 3
-    assert outputs.product.value == 6
+    assert outputs.out1.sum.value == 3
+    assert outputs.out2.product.value == 2
+
+
+def test_single_namespace_outputs():
+    """Test mapping namespace results to the workgraph outputs."""
+
+    @task.graph
+    def test_graph(x, y) -> spec.namespace(sum=int, product=int):
+        return add_multiply(x, y)
+
+    wg = test_graph.build_graph(1, 2)
+    wg.run()
+    # graph outputs
+    assert wg.outputs.sum.value == 3
+    assert wg.outputs.product.value == 2


### PR DESCRIPTION
This PR fixes:
- The generated WorkGraph should inherit the outputs from the graph task
- handle special case, where a graph task returns the whole output of a task.

Here is an example:
```python
from aiida_workgraph import task, spec

@task()
def add_multiply(x, y) -> spec.namespace(sum=int, product=int):
    return {"sum": x + y, "product": x * y}

@task.graph
def test_graph(x, y) -> spec.namespace(sum=int, product=int):
    # return the whole outputs of the task, which is a namespace
    return add_multiply(x, y)

wg = test_graph.build_graph(1, 2)
wg.run()
print(wg.outputs.sum)
print(wg.outputs.product)
```

## Fix the engine when the graph outputs contain `NodeLinkManager`

When the workgraph finishes, it will store the graph-level outputs to the AiiDA process node. This is done by:
```python
self.out_many(self.ctx._task_results["graph_outputs"])
```
 `self.ctx._task_results["graph_outputs"]` is a dict. Inside the dict, the value can be the output of a task. If the output is a namespace (`NodeLinksManager` attached to the AiiDA process node), for example
```python
In [1]: n = load_node(170588)

In [2]: n.outputs
Out[2]: <NodeLinksManager: Manager for outgoing RETURN links for node pk=170588>
```
We need to change it to a dict 
```python
{"sum": node1, "product": node2}
```
In this way, the `self.out_many` works. That's why we need this `clean_node_links_manager`.
