### PR TITLE
Bump aiida-pythonjob to 0.3.5

### DIFF
--- a/docs/gallery/tutorial/autogen/materials_science_ase.py
+++ b/docs/gallery/tutorial/autogen/materials_science_ase.py
@@ -258,7 +258,7 @@ wg.run()
 # %%
 # The result is an AiiDA Dict node. We access its content via the `.value` attribute.
 eos_result = wg.outputs.result.value
-print("Equation of state results for Cu: ", eos_result.value)
+print("Equation of state results for Cu: ", eos_result.get_dict())
 
 # %%
 # Visualize the EOS Provenance Graph

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,5 +7,3 @@ node-graph
 anywidget
 furo
 matplotlib # for sphinx-gallery
-aiida-quantumespresso
-aiida-pseudo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.3.0",
+    "node-graph>=0.3.1",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",
     "aiida-shell~=0.8",
-    "aiida-pythonjob>=0.3.3",
+    "aiida-pythonjob>=0.3.5",
     "jsonschema",
 ]
 

--- a/src/aiida_workgraph/tasks/pythonjob_tasks.py
+++ b/src/aiida_workgraph/tasks/pythonjob_tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Callable
 from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
-from aiida_pythonjob.data.serializer import general_serializer
+from aiida_pythonjob.data.serializer import general_serializer, all_serializers
 from aiida_pythonjob.data.deserializer import deserialize_to_raw_python_data
 from aiida_workgraph.utils import create_and_pause_process
 from aiida.engine import run_get_node
@@ -79,7 +79,9 @@ class BaseSerializablePythonTask(SpecTask):
         value = socket.get("property", {}).get("value")
         if value is None or isinstance(value, orm.Data):
             return  # Already stored or is None
-        socket["property"]["value"] = general_serializer(value)
+        socket["property"]["value"] = general_serializer(
+            value, serializers=all_serializers
+        )
 
     @classmethod
     def _deserialize_socket_data(cls, socket: Dict[str, Any]) -> Any:

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -44,7 +44,7 @@ def test_task_update_ctx(decorated_add: Callable) -> None:
     wg = WorkGraph(name="test_node_set_ctx")
     add1 = wg.add_task(decorated_add, "add1", x=Float(2).store(), y=Float(3).store())
     with pytest.raises(
-        AttributeError, match="TaskSocketNamespace has no attribute 'resul'"
+        AttributeError, match="TaskSocketNamespace: add1.outputs has no attribute"
     ):
         wg.update_ctx({"sum": add1.outputs.resul})
     wg.update_ctx({"sum": add1.outputs.result})

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -29,9 +29,7 @@ def test_decorators_args() -> None:
         {
             "metadata",
             "function_data",
-            "deserializers",
             "a",
-            "serializers",
             "process_label",
             "b",
             "function_inputs",
@@ -94,9 +92,7 @@ def test_decorators_task_args(task_function):
     assert set(n.args_data["kwargs"]) == {
         "metadata",
         "function_data",
-        "deserializers",
         "a",
-        "serializers",
         "process_label",
         "b",
         "function_inputs",

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -148,7 +148,7 @@ def test_dynamic_inputs(fixture_localhost, python_executable_path) -> None:
         command_info={"label": python_executable_path},
     )
     wg.run()
-    assert (wg.tasks.add1.outputs.result.value.value == np.array([4, 6])).all()
+    assert (wg.tasks.add1.outputs.result.value.get_array() == np.array([4, 6])).all()
 
 
 def test_PythonJob_namespace_output_input(fixture_localhost, python_executable_path):
@@ -315,8 +315,8 @@ def test_exit_code(fixture_localhost, python_executable_path):
         # therefore, we need use the `value` attribute to get the raw data
         task.set_inputs(
             {
-                "x": abs(task.inputs.x.value.value),
-                "y": abs(task.inputs.y.value.value),
+                "x": abs(task.inputs.x.value.get_array()),
+                "y": abs(task.inputs.y.value.get_array()),
             }
         )
 
@@ -357,4 +357,4 @@ def test_exit_code(fixture_localhost, python_executable_path):
     )
     # the final task should have exit status 0
     assert wg.tasks.add1.process.exit_status == 0
-    assert (wg.tasks.add1.outputs.sum.value.value == np.array([2, 3])).all()
+    assert (wg.tasks.add1.outputs.sum.value.get_array() == np.array([2, 3])).all()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -83,7 +83,7 @@ def test_aiida_data_socket() -> None:
         assert add()._node.inputs.x.property.identifier == identifier
         add_task = add()._node
         add_task.set_inputs({"x": data})
-        with pytest.raises(TypeError, match="Expected value of type"):
+        with pytest.raises(TypeError, match="Invalid value for property"):
             add_task.set_inputs({"x": "{{variable}}"})
 
 
@@ -111,7 +111,7 @@ def test_socket_validate(data_type, data) -> None:
     with pytest.raises(Exception) as excinfo:
         add_task.set_inputs({"x": data})
 
-    assert "Expected value of type" in str(excinfo.value)
+    assert "Invalid value for property" in str(excinfo.value)
 
 
 @pytest.mark.skip(reason="SafeLoader not implemented for numpy")


### PR DESCRIPTION
The aiida-pythonjob has been refactored recently, and a release 0.3.5 has been made.
The good thing is that, from aiida-workgraph side, there is not much change needed. 


- aiida-pythonjob to 0.3.5
- node-graph to 0.3.1