### PR TITLE
Decorator accept `use_pickle` argument

### DIFF
--- a/docs/gallery/migration_from_aiida_core/autogen/workchain.py
+++ b/docs/gallery/migration_from_aiida_core/autogen/workchain.py
@@ -138,7 +138,7 @@ def sum_even_workgraph(N: int):
         wg.ctx.n = n_new.result
 
     # The 'result' step: define the final output of the graph.
-    wg.outputs.result = wg.ctx.total
+    return wg.ctx.total
 
 
 # %%
@@ -153,7 +153,8 @@ from aiida import load_profile
 load_profile()
 
 # Generate the WorkGraph instance with a specific input.
-wg = sum_even_workgraph.build_graph(N=5)
+N = 5
+wg = sum_even_workgraph.build_graph(N=N)
 
 # The `to_html()` method generates an interactive visualization of the graph.
 # In a Sphinx-Gallery build, this will be embedded directly in the output.
@@ -162,7 +163,7 @@ wg.to_html()
 # %%
 # Execute the WorkGraph and print the result.
 wg.run()
-print(f"The sum of even numbers up to 10 is: {wg.outputs['result'].value}")
+print(f"The sum of even numbers up to {N} is: {wg.outputs['result'].value}")
 
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.3.1",
+    "node-graph>=0.3.3",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -181,6 +181,8 @@ class TaskDecoratorCollection:
             spec = _spec_for(obj, identifier=identifier, inputs=inputs, outputs=outputs)
             if spec.metadata["node_type"] in ["PYFUNCTION", "PYTHONJOB"]:
                 new_inputs = set_default(spec.inputs, "metadata.use_pickle", use_pickle)
+            else:
+                new_inputs = spec.inputs
             handlers = normalize_error_handlers(error_handlers)
             # allow catalog override
             spec = NodeSpec(

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -6,7 +6,7 @@ from .workgraph import WorkGraph
 import inspect
 from .task import TaskHandle
 from node_graph.node_spec import NodeSpec
-from node_graph.socket_spec import SocketSpec
+from node_graph.socket_spec import SocketSpec, set_default
 from aiida_workgraph.tasks.aiida import _build_aiida_function_nodespec
 from node_graph.error_handler import ErrorHandlerSpec, normalize_error_handlers
 
@@ -165,6 +165,7 @@ class TaskDecoratorCollection:
         error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
         catalog: str = "Others",
         store_provenance: bool = True,
+        use_pickle: bool | None = None,
     ) -> Callable:
         """Generate a decorator that register a function as a task.
 
@@ -177,12 +178,14 @@ class TaskDecoratorCollection:
 
         def decorator(obj: Union[WorkGraph, type, callable]) -> TaskHandle:
             spec = _spec_for(obj, identifier=identifier, inputs=inputs, outputs=outputs)
+            if spec.metadata["node_type"] in ["PYFUNCTION", "PYTHONJOB"]:
+                new_inputs = set_default(spec.inputs, "metadata.use_pickle", use_pickle)
             handlers = normalize_error_handlers(error_handlers)
             # allow catalog override
             spec = NodeSpec(
                 identifier=spec.identifier,
                 catalog=catalog or spec.catalog,
-                inputs=spec.inputs,
+                inputs=new_inputs,
                 outputs=spec.outputs,
                 executor=spec.executor,
                 error_handlers=handlers,

--- a/src/aiida_workgraph/tasks/awaitable_tasks.py
+++ b/src/aiida_workgraph/tasks/awaitable_tasks.py
@@ -3,7 +3,7 @@ from aiida_workgraph.task import SpecTask
 from typing import Callable, Optional, Any
 from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec
-from .function_task import build_callable_nodespec, namespace_with_defaults
+from .function_task import build_callable_nodespec
 from aiida_workgraph.socket_spec import namespace
 
 
@@ -92,10 +92,9 @@ def _build_monitor_function_nodespec(
     out_spec: Optional[SocketSpec] = None,
 ) -> NodeSpec:
     # defaults for interval/timeout — set on the NAMESPACE (keys = field names)
-    add_in = namespace_with_defaults(
-        {"interval": 5, "timeout": 3600},
-        interval=int,
-        timeout=int,
+    add_in = namespace(
+        interval=(int, 5),
+        timeout=(int, 3600),
     )
     add_out = namespace(exit_code=Any)
 

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -1,22 +1,14 @@
 from __future__ import annotations
-from dataclasses import replace
 from copy import deepcopy
-from typing import Callable, List, Optional, Any, Type, Dict
+from typing import Callable, List, Optional, Type, Dict
 from aiida_workgraph.socket_spec import (
     from_aiida_process,
     infer_specs_from_callable,
-    namespace,
 )
 from node_graph.socket_spec import SocketSpec, merge_specs
 from node_graph.node_spec import NodeSpec
 from node_graph.executor import NodeExecutor
 from node_graph.error_handler import ErrorHandlerSpec, normalize_error_handlers
-
-
-def namespace_with_defaults(defaults: dict[str, Any], **fields: Any) -> SocketSpec:
-    """Build a namespace and attach per-field default values."""
-    ns = namespace(**fields)
-    return replace(ns, defaults=deepcopy(defaults))
 
 
 def _record_specs_block(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -265,3 +265,31 @@ def test_set_current_graph():
     g2 = WorkGraph()
     set_current_graph(g2)
     assert get_current_graph() == g2
+
+
+def test_use_pickle():
+    # non-jsonable data
+    class Data:
+        def __init__(self, value):
+            self.value = value
+
+    # without pickle, should raise error
+    @task()
+    def add(x, y):
+        return x + y.value
+
+    with pytest.raises(
+        ValueError, match="Cannot serialize type=Data. No suitable method found"
+    ):
+        with WorkGraph() as wg:
+            wg.outputs.result = add(3, Data(4)).result
+            wg.run()
+
+    # now use pickle
+    @task(use_pickle=True)
+    def add(x, y):
+        return x + y.value
+
+    with WorkGraph() as wg:
+        wg.outputs.result = add(3, Data(4)).result
+        wg.run()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -37,7 +37,7 @@ def test_decorators_args() -> None:
     )
     assert n.args_data["var_args"] is None
     assert n.args_data["var_kwargs"] == "c"
-    assert set(n.get_output_names()) == set(["result", "_outputs", "_wait"])
+    assert set(n.get_output_names()) == set(["_outputs", "_wait"])
     assert isinstance(n.inputs.c, TaskSocketNamespace)
 
 
@@ -60,7 +60,7 @@ def test_decorators_calcfunction_args() -> None:
     assert set(n.args_data["kwargs"]) == set(kwargs)
     assert n.args_data["var_args"] is None
     assert n.args_data["var_kwargs"] == "c"
-    assert set(n.get_output_names()) == set(["result", "_outputs", "_wait"])
+    assert set(n.get_output_names()) == set(["_outputs", "_wait"])
     assert isinstance(n.inputs.c, TaskSocketNamespace)
     assert set(n.inputs.metadata._get_keys()) == metadata_kwargs
 
@@ -99,9 +99,7 @@ def test_decorators_task_args(task_function):
     }
     assert n.args_data["var_args"] is None
     assert n.args_data["var_kwargs"] == "c"
-    assert set(tdata["outputs"]["sockets"].keys()) == set(
-        ["result", "_outputs", "_wait"]
-    )
+    assert set(tdata["outputs"]["sockets"].keys()) == set(["_outputs", "_wait"])
 
 
 @pytest.fixture(params=["decorator_factory", "decorator"])
@@ -139,7 +137,7 @@ def test_decorators_workfunction_args(task_workfunction) -> None:
     assert set(n.args_data["kwargs"]) == set(kwargs)
     assert n.args_data["var_args"] is None
     assert n.args_data["var_kwargs"] == "c"
-    assert set(n.get_output_names()) == set(["result", "_outputs", "_wait"])
+    assert set(n.get_output_names()) == set(["_outputs", "_wait"])
     assert set(n.inputs.metadata._get_keys()) == metadata_kwargs
 
 
@@ -185,7 +183,7 @@ def test_decorators_graph_args(task_graph_task) -> None:
     assert n.args_data["kwargs"] == ["a", "b"]
     assert n.args_data["var_args"] is None
     assert n.args_data["var_kwargs"] == "c"
-    assert set(n.get_output_names()) == set(["result", "_outputs", "_wait"])
+    assert set(n.get_output_names()) == set(["_outputs", "_wait"])
 
 
 def test_inputs_outputs_workchain() -> None:


### PR DESCRIPTION
Needs tihs PR: https://github.com/scinode/node-graph/pull/85

This PR introduces a new `use_pickle` argument to the `@task` decorator, providing a convenient fallback mechanism for handling non-AiiDA and non-JSONable data nodes.

The `use_pickle` argument, when set to `True`, enables the engine to use `couldpickle` module as a fallback serialization method. This allows users to pass/return non-JSONable data types.

#### Example

```python

class MyData:
    """A custom, non-JSONable data class."""
    def __init__(self, value):
        self.value = value

@task(use_pickle=True)
def add_data(x, y):
    return x + y.value

with WorkGraph() as wg:
    wg.outputs.result = add(3, Data(4)).result
    wg.run()
```

This change makes AiiDA more accessible for new users and rapid development. For the production-level, robust workflows, the user is still recommended to provide a dedicated AiiDA data node for the custom data type.