### PR TITLE
[Docs] Update how-to sections w.r.t recent developments

### DIFF
--- a/docs/gallery/advanced/autogen/context.py
+++ b/docs/gallery/advanced/autogen/context.py
@@ -1,12 +1,10 @@
 """
-=====================
-Using the ``Context``
-=====================
+=========================================
+Use AiiDA context variables in WorkGraphs
+=========================================
 """
 
 # %%
-# Introduction
-# ============
 # In AiiDA workflows (both, traditional ``WorkChain`` s, as well as the ``WorkGraph``), the **Context** (typically
 # represented by ``ctx``), is an internal container that can hold data shared between different tasks.
 # It's particularly useful for more complex workflows.
@@ -14,29 +12,32 @@ Using the ``Context``
 # %%
 # When to use
 # -----------
+#
 # 1. Many-to-many relationships where direct linking becomes unwieldy
 # 2. Conditional workflows where links depend on runtime conditions
 # 3. Graph builders that need to expose selective internal state
 
-#
 # %%
-# Passing data to the context
-# ---------------------------
-#
-# There are three ways to set data in the **Context**:
-# - Setting the ``ctx`` attribute of the WorkGraph directly
-# - Using the ``update_ctx`` method of the WorkGraph
-# - Using the ``workgraph.set_context`` task
-#
-# So let's have a look how to use each of them:
-
-#%%
+# Setup
+# -----
 
 from aiida_workgraph import WorkGraph, task
 from aiida import load_profile
 from aiida.orm import Int
 
 load_profile()
+
+# %%
+# Passing data to the context
+# ---------------------------
+#
+# There are three ways to set data in the **Context**:
+#
+# - Setting the ``ctx`` attribute of the WorkGraph directly
+# - Using the ``update_ctx`` method of the WorkGraph
+# - Using the ``workgraph.set_context`` task
+#
+# Let's have a look how to use each of them:
 
 wg1 = WorkGraph(name="context_1")
 
@@ -64,7 +65,7 @@ wg3.add_task(
     "workgraph.set_context", name="set_ctx1", key="sum", value=add1.outputs.result
 )
 
-#%%
+# %%
 # Nested context keys
 # -------------------
 # To organize the context data in a hierarchical structure, the keys may contain dots ``.``` that create nesting
@@ -87,13 +88,13 @@ wg.update_ctx({"sum.add2": add2.outputs.result})
 
 print(wg.ctx.sum)
 
-#%%
+# %%
 # Use data from the context
 # -------------------------
 #
 # Also for accessing data from the context, there are different approaches:
 
-#%%
+# %%
 #
 # 1. One can use elements from the ``wg.ctx.x``, directly, e.g., as inputs for other tasks
 #
@@ -109,6 +110,7 @@ wg3.add_task("workgraph.get_context", name="get_ctx1", key="sum.add1")
 
 wg.show()
 wg.to_html()
+
 
 #
 # 2. One can export the data from context to the graph builder outputs.
@@ -137,6 +139,7 @@ final_task = wg_main.add_task(add, x=builder_task.outputs.result, y=100)
 # when using explicit context tasks instead of direct context access.
 #
 # .. note::
+#
 #    Context tasks make data flow visible in the GUI, which is helpful for
 #    debugging and understanding workflow execution. Use them when you want
 #    explicit visibility of context operations.
@@ -187,5 +190,7 @@ from aiida_workgraph.utils import generate_node_graph
 generate_node_graph(wg.pk)
 
 # %%
-# .. note:: If you pass data from one task to another task through the context, you may need to use ``wait`` to wait for
-# the data to be ready. See :doc:`waiting_on`.
+# .. note::
+#
+#    If you pass data from one task to another task through the context, you may need to use ``wait`` to wait for
+#    the data to be ready. See :doc:`/howto/autogen/control_task_execution_order`.

--- a/docs/gallery/advanced/autogen/context.py
+++ b/docs/gallery/advanced/autogen/context.py
@@ -70,7 +70,7 @@ wg3.add_task(
 # -------------------
 # To organize the context data in a hierarchical structure, the keys may contain dots ``.``` that create nesting
 # Here is an example, to group the results of multipl add tasks to `ctx.sum`:
-#
+
 wg = WorkGraph(name="ctx_nested")
 add1 = wg.add_task(add, "add1", x=1, y=2)
 add2 = wg.add_task(add, "add2", x=3, y=4)
@@ -112,9 +112,6 @@ wg.show()
 wg.to_html()
 
 
-#
-# 2. One can export the data from context to the graph builder outputs.
-#
 @task.graph()
 def internal_add(x, y):
     outputs1 = add(x=x, y=y)

--- a/docs/gallery/advanced/autogen/context_manager.py
+++ b/docs/gallery/advanced/autogen/context_manager.py
@@ -297,6 +297,9 @@ wg.to_html()
 # ----------------
 #
 # Before we describe the control flow constructs, we need to understand the use of the workflow context.
+# The details on AiiDA's context variables can be found in the :doc:`/advanced/autogen/context` advanced section.
+# Here we describe how the context is treated by the ``WorkGraph``.
+#
 # ``WorkGraph`` doesn't track context variables (``wg.ctx``) for automatic dependency resolution because they could introduce cyclical dependencies between tasks.
 # As such, when defining dynamic branching in a workflow (as is done in the following sections), we must explicitly do the following:
 #

--- a/docs/gallery/howto/autogen/annotate_inputs_outputs.py
+++ b/docs/gallery/howto/autogen/annotate_inputs_outputs.py
@@ -18,12 +18,6 @@ Use annotations to control data provenance
 #
 # This guide will walk you through the various ways to annotate your tasks.
 
-# %%
-# Initial setup
-# =============
-#
-# First, let's set up the AiiDA environment.
-
 import typing as t
 from aiida import load_profile
 from aiida_workgraph import task
@@ -34,13 +28,13 @@ load_profile()
 
 # %%
 # Data creation
-# =============
+# -------------
 #
 # Data creation is controlled at the ``Calculation`` level.
 # In AiiDA, a ``Calculation`` is a process that performs a computation and creates new data nodes.
 #
 # Static namespaces for outputs
-# -----------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Let's define two tasks that perform the same calculation but have different output annotations.
 #
@@ -96,7 +90,7 @@ generate_node_graph(wg.pk)
 # As the provenance graph shows, ``add_multiply1`` has a single output node (``result``), while ``add_multiply2`` has two separate output nodes (``sum`` and ``product``), as defined in its namespace.
 #
 # Static namespaces for inputs
-# ----------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Similarly, we can annotate inputs to unpack a dictionary into distinct data nodes.
 # We use Python's standard ``typing.Annotated`` to attach the `aiida-workgraph` namespace metadata to the input type.
@@ -138,7 +132,7 @@ generate_node_graph(wg.pk)
 # We can see that even though we passed the inputs as a single dictionary, they were serialized as two separate ``Int`` nodes, ``x`` and ``y``, before being passed to the task.
 #
 # Dynamic namespaces
-# ------------------
+# ~~~~~~~~~~~~~~~~~~
 #
 # Sometimes, the number and names of outputs are not known until the task runs.
 # Dynamic namespaces are designed for this scenario.
@@ -177,7 +171,7 @@ generate_node_graph(wg.pk)
 # The ``dynamic(typing.Any)`` specification instructs the workgraph to treat each value in the returned dictionary as a separate output node of any type.
 #
 # Nested namespaces
-# -----------------
+# ~~~~~~~~~~~~~~~~~
 #
 # Namespaces can be nested to represent complex, structured data.
 # Let's define a task that returns a nested dictionary.
@@ -244,7 +238,7 @@ print(get_process_summary(wg.tasks[-1].pk))
 # The output shows a dictionary with dynamic keys (``data_0``, ``data_1``, etc.), where each value is itself a dictionary with a fixed ``square`` and ``cube`` structure, as specified by ``dynamic(namespace(...))``.
 #
 # Data linkage
-# ============
+# ------------
 #
 # Data linkage tracks the flow of data between tasks.
 # At the workflow level, a `task.graph` can define its own inputs and outputs, providing a clean interface to a complex chain of tasks.
@@ -322,7 +316,7 @@ wg.to_html()
 
 # %%
 # Conclusion
-# ==========
+# ----------
 #
 # You now know how to annotate task and graph inputs and outputs in `aiida-workgraph`.
 # By leveraging static (``namespace``), dynamic (``dynamic``), and nested namespaces, you can precisely control data serialization and create transparent data lineages.

--- a/docs/gallery/howto/autogen/annotate_inputs_outputs.py
+++ b/docs/gallery/howto/autogen/annotate_inputs_outputs.py
@@ -1,25 +1,30 @@
 """
-=================================
-Annotate inputs and outputs
-=================================
-
-In ``aiida-workgraph``, a critical feature is tracking task inputs and outputs to ensure data provenance and reproducibility.
-To achieve this, task functions must be annotated with input and output specifications.
-This tells the WorkGraph how to handle, serialize, and store data as individual AiiDA nodes.
-
-This process addresses two key aspects of provenance:
-
-- **Data creation**: How should data be created and stored? For example, if a task returns a nested dictionary, should it be stored as a single entity or unpacked into separate nodes?
-- **Data lineage**: Where does the data come from? How does it flow between tasks in the workflow?
-
-This guide will walk you through the various ways to annotate your tasks.
-
+Use annotations to control data provenance
+==========================================
 """
+
+# %%
+# Introduction
+# ------------
+#
+# In ``aiida-workgraph``, a critical feature is tracking task inputs and outputs to ensure data provenance and reproducibility.
+# To achieve this, task functions must be annotated with input and output specifications.
+# This tells the WorkGraph how to handle, serialize, and store data as individual AiiDA nodes.
+#
+# This process addresses two key aspects of provenance:
+#
+# - **Data creation**: How should data be created and stored? For example, if a task returns a nested dictionary, should it be stored as a single entity or unpacked into separate nodes?
+# - **Data lineage**: Where does the data come from? How does it flow between tasks in the workflow?
+#
+# This guide will walk you through the various ways to annotate your tasks.
+
 # %%
 # Initial setup
-# =====================
+# =============
+#
 # First, let's set up the AiiDA environment.
 
+import typing as t
 from aiida import load_profile
 from aiida_workgraph import task
 from aiida_workgraph.utils import generate_node_graph, get_process_summary
@@ -29,36 +34,44 @@ load_profile()
 
 # %%
 # Data creation
-# ==============
-# Data creation is controlled at the `Calculation` level.
-# In AiiDA, a `Calculation` is a process that performs a computation and creates new data nodes.
+# =============
+#
+# Data creation is controlled at the ``Calculation`` level.
+# In AiiDA, a ``Calculation`` is a process that performs a computation and creates new data nodes.
 #
 # Static namespaces for outputs
 # -----------------------------
+#
 # Let's define two tasks that perform the same calculation but have different output annotations.
 #
-# The first task, `add_multiply1`, has no output specification.
-# Consequently, the returned dictionary will be stored as a single AiiDA `Dict` node.
-# The second task, `add_multiply2`, uses an output namespace to specify that each key-value pair in the dictionary should be stored as a separate AiiDA node.
+# The first task, ``add_multiply1``, has no output specification.
+# Consequently, the returned dictionary will be stored as a single AiiDA ``Dict`` node.
+# The second task, ``add_multiply2``, uses an output namespace to specify that each key-value pair in the dictionary should be stored as a separate AiiDA node.
 
 # Import the `namespace` module for specifications
-from aiida_workgraph import namespace as ns
+from aiida_workgraph import namespace
 
 
-@task()
+@task
 def add_multiply1(x, y):
-    """Returns a dictionary, which will be stored as a single Dict node."""
+    """Return a dictionary, which will be stored as a single Dict node."""
     return {"sum": x + y, "product": x * y}
 
 
-@task(outputs=ns(sum=int, product=int))
-def add_multiply2(x, y):
-    """Returns a dictionary, but its elements are stored as separate Int nodes."""
+@task
+def add_multiply2(
+    x: int,
+    y: int,
+) -> t.Annotated[
+    dict,
+    namespace(sum=int, product=int),
+]:
+    """Return a dictionary, but its elements are stored as separate Int nodes."""
     return {"sum": x + y, "product": x * y}
 
 
-@task.graph()
-def add_multiply_graph(x, y):
+@task.graph
+def add_multiply_graph(x: int, y: int):
     """A graph to run both versions of the add_multiply task."""
     add_multiply1(x=x, y=y)
     add_multiply2(x=x, y=y)
@@ -68,33 +81,50 @@ wg = add_multiply_graph.build_graph(x=1, y=2)
 wg.run()
 
 # %%
+#
+# .. note::
+#
+#    In ``add_multiply2``, we also annotated the input types (``x: int, y: int``).
+#    This adds a layer of validaton to ensure only integers are passed to the task.
+#    This feature is experimental - its API and behavior may change in future releases.
+#
 # Let's visualize the data provenance of our executed workflow:
 
 generate_node_graph(wg.pk)
 
 # %%
-# As the provenance graph shows, `add_multiply1` has a single output node (`result`), while `add_multiply2` has two separate output nodes (`sum` and `product`), as defined in its namespace.
+# As the provenance graph shows, ``add_multiply1`` has a single output node (``result``), while ``add_multiply2`` has two separate output nodes (``sum`` and ``product``), as defined in its namespace.
 #
 # Static namespaces for inputs
-# -----------------------------
+# ----------------------------
+#
 # Similarly, we can annotate inputs to unpack a dictionary into distinct data nodes.
-# We use Python's standard `typing.Annotated` to attach the `aiida-workgraph` namespace metadata to the input type.
-
-from typing import Annotated
+# We use Python's standard ``typing.Annotated`` to attach the `aiida-workgraph` namespace metadata to the input type.
 
 
-@task(outputs=ns(sum=int, product=int))
-def add_multiply3(data: Annotated[dict, ns(x=int, y=int)]):
-    """Takes a dictionary as input but treats 'x' and 'y' as separate nodes."""
+@task
+def add_multiply3(
+    data: t.Annotated[
+        dict,
+        namespace(x=int, y=int),
+    ],
+) -> t.Annotated[
+    dict,
+    namespace(sum=int, product=int),
+]:
+    """Take a dictionary as input but treat 'x' and 'y' as separate nodes."""
     return {"sum": data["x"] + data["y"], "product": data["x"] * data["y"]}
 
 
-@task.graph()
-def add_multiply_graph_inputs(x, y):
-    add_multiply3(data={"x": x, "y": y})
+@task.graph
+def add_multiply_graph_inputs(x: int, y: int):
+    return add_multiply3(data={"x": x, "y": y})
 
 
 wg = add_multiply_graph_inputs.build_graph(x=1, y=2)
+wg.to_html()
+
+# %%
 wg.run()
 
 
@@ -105,27 +135,32 @@ generate_node_graph(wg.pk)
 
 
 # %%
-# We can see that even though we passed the inputs as a single dictionary, they were serialized as two separate `Int` nodes, `x` and `y`, before being passed to the task.
+# We can see that even though we passed the inputs as a single dictionary, they were serialized as two separate ``Int`` nodes, ``x`` and ``y``, before being passed to the task.
 #
 # Dynamic namespaces
-# --------------------
+# ------------------
+#
 # Sometimes, the number and names of outputs are not known until the task runs.
 # Dynamic namespaces are designed for this scenario.
 #
 # This is particularly useful for tasks that generate a variable number of outputs based on their inputs.
 
-from aiida_workgraph import dynamic as dyn
-from typing import Any
+from aiida_workgraph import dynamic
 
 
-@task(outputs=dyn(Any))
-def generate_square_numbers(n):
+@task
+def generate_square_numbers(
+    n: int,
+) -> t.Annotated[
+    dict,
+    dynamic(t.Any),
+]:
     """Generate a dict of square numbers. The number of outputs depends on 'n'."""
     return {f"square_{i}": i**2 for i in range(n)}
 
 
-@task.graph()
-def generate_square_numbers_graph(n):
+@task.graph
+def generate_square_numbers_graph(n: int):
     generate_square_numbers(n=n)
 
 
@@ -138,23 +173,30 @@ wg.run()
 generate_node_graph(wg.pk)
 
 # %%
-# The graph shows that the `generate_square_numbers` task has multiple output nodes, one for each entry in the dynamically generated dictionary.
-# The `dyn(Any)` specification instructs the workgraph to treat each value in the returned dictionary as a separate output node of any type.
+# The graph shows that the ``generate_square_numbers`` task has multiple output nodes, one for each entry in the dynamically generated dictionary.
+# The ``dynamic(typing.Any)`` specification instructs the workgraph to treat each value in the returned dictionary as a separate output node of any type.
 #
 # Nested namespaces
 # -----------------
+#
 # Namespaces can be nested to represent complex, structured data.
 # Let's define a task that returns a nested dictionary.
 
 
-@task(outputs=ns(sum=int, nested=ns(diff=int, product=int)))
-def nested_dict_task(x, y):
+@task
+def nested_dict_task(
+    x: int,
+    y: int,
+) -> t.Annotated[
+    dict,
+    namespace(sum=int, nested=namespace(diff=int, product=int)),
+]:
     """Returns a nested dictionary with a corresponding nested namespace."""
     return {"sum": x + y, "nested": {"diff": x - y, "product": x * y}}
 
 
-@task.graph()
-def nested_dict_graph(x, y):
+@task.graph
+def nested_dict_graph(x: int, y: int):
     nested_dict_task(x=x, y=y)
 
 
@@ -168,19 +210,24 @@ wg.run()
 print(get_process_summary(wg.tasks[-1].pk))
 
 # %%
-# The summary confirms that the output is correctly structured with a top-level `sum` and a nested `nested` dictionary, just as defined in the namespace.
+# The summary confirms that the output is correctly structured with a top-level ``sum`` and a nested ``nested`` dictionary, just as defined in the namespace.
 #
 # We can also combine dynamic and nested namespaces.
 
 
-@task(outputs=dyn(ns(square=Any, cube=Any)))
-def generate_dynamic_nested_dict(n):
+@task
+def generate_dynamic_nested_dict(
+    n: int,
+) -> t.Annotated[
+    dict,
+    dynamic(namespace(square=int, cube=int)),
+]:
     """Generate a nested dict of square and cube numbers from 0 to n."""
     return {f"data_{i}": {"square": i**2, "cube": i**3} for i in range(n)}
 
 
-@task.graph()
-def generate_dynamic_nested_dict_graph(n):
+@task.graph
+def generate_dynamic_nested_dict_graph(n: int):
     generate_dynamic_nested_dict(n=n)
 
 
@@ -194,10 +241,10 @@ print(get_process_summary(wg.tasks[-1].pk))
 
 
 # %%
-# The output shows a dictionary with dynamic keys (`data_0`, `data_1`, etc.), where each value is itself a dictionary with a fixed `square` and `cube` structure, as specified by `dyn(ns(...))`.
+# The output shows a dictionary with dynamic keys (``data_0``, ``data_1``, etc.), where each value is itself a dictionary with a fixed ``square`` and ``cube`` structure, as specified by ``dynamic(namespace(...))``.
 #
 # Data linkage
-# =============
+# ============
 #
 # Data linkage tracks the flow of data between tasks.
 # At the workflow level, a `task.graph` can define its own inputs and outputs, providing a clean interface to a complex chain of tasks.
@@ -207,25 +254,38 @@ print(get_process_summary(wg.tasks[-1].pk))
 # This is a powerful feature for building complex, modular, and self-consistent workflows.
 
 
-@task(outputs=ns(sum=int, product=int))
-def add_multiply(data: Annotated[dict, ns(x=int, y=int)]):
+@task
+def add_multiply(
+    data: t.Annotated[
+        dict,
+        namespace(x=int, y=int),
+    ],
+) -> t.Annotated[
+    dict,
+    namespace(sum=int, product=int),
+]:
     """A reusable task with well-defined I/O specifications."""
     return {"sum": data["x"] + data["y"], "product": data["x"] * data["y"]}
 
 
-@task.graph(
-    outputs=ns(
+@task.graph
+def add_multiply_graph_final(
+    n: int,
+    data: t.Annotated[
+        dict,
+        namespace(
+            add_multiply1=add_multiply.inputs,
+            add_multiply2=add_multiply.inputs,
+        ),
+    ],
+) -> t.Annotated[
+    dict,
+    namespace(
         square=generate_square_numbers.outputs,
         add_multiply1=add_multiply.outputs,
         add_multiply2=add_multiply.outputs,
-    )
-)
-def add_multiply_graph_final(
-    n,
-    data: Annotated[
-        dict, ns(add_multiply1=add_multiply.inputs, add_multiply2=add_multiply.inputs)
-    ],
-):
+    ),
+]:
     """A complex graph demonstrating I/O reuse and data linkage."""
     square_numbers = generate_square_numbers(n)
 
@@ -250,14 +310,14 @@ wg.to_html()
 # %%
 # In the example above:
 #
-# - **Graph outputs:** The `outputs` argument in the `@task.graph` decorator defines the *shape* of the final result.
-#   We reuse `generate_square_numbers.outputs` and `add_multiply_task.outputs` to ensure the graph's output signature is consistent with the tasks it contains.
+# - **Graph outputs:** The ``outputs`` argument in the ``@task.graph`` decorator defines the *shape* of the final result.
+#   We reuse ``generate_square_numbers.outputs`` and ``add_multiply_task.outputs`` to ensure the graph's output signature is consistent with the tasks it contains.
 #
-# - **Graph inputs:** The `data` input is annotated with a nested namespace that reuses `add_multiply_task.inputs`.
-#   This allows `aiida-workgraph` to validate the complex input dictionary and create the correct data links.
+# - **Graph inputs:** The ``data`` input is annotated with a nested namespace that reuses ``add_multiply_task.inputs``.
+#   This allows ``aiida-workgraph`` to validate the complex input dictionary and create the correct data links.
 #
 # In the GUI representation of the WorkGraph, you will see how the nested inputs are correctly wired.
-# For instance, there is a direct link from the graph input socket `data.add_multiply1.data.x` to the task input socket `add_multiply_task_1.data.x`, guaranteeing perfect data lineage.
+# For instance, there is a direct link from the graph input socket ``data.add_multiply1.data.x`` to the task input socket ``add_multiply_task_1.data.x``, guaranteeing perfect data lineage.
 
 
 # %%
@@ -265,13 +325,13 @@ wg.to_html()
 # ==========
 #
 # You now know how to annotate task and graph inputs and outputs in `aiida-workgraph`.
-# By leveraging static (`ns`), dynamic (`dyn`), and nested namespaces, you can precisely control data serialization and create transparent data lineages.
+# By leveraging static (``namespace``), dynamic (``dynamic``), and nested namespaces, you can precisely control data serialization and create transparent data lineages.
 #
 # The key takeaways are:
 #
-# - Annotate task `outputs` to unpack results into individual AiiDA nodes.
-# - Use `typing.Annotated` to specify input structures.
-# - Employ `dyn` for tasks with a variable number of outputs.
-# - Reuse `.inputs` and `.outputs` specifications at the graph level to build modular and robust workflows.
+# - Annotate task ``outputs`` to unpack results into individual AiiDA nodes.
+# - Use ``typing.Annotated`` to specify input structures.
+# - Employ ``dynamic`` for tasks with a variable number of outputs.
+# - Reuse ``.inputs`` and ``.outputs`` specifications at the graph level to build modular and robust workflows.
 #
 # These tools are fundamental to building reproducible and verifiable scientific workflows with complete data provenance.

--- a/docs/gallery/howto/autogen/control_task_execution_order.py
+++ b/docs/gallery/howto/autogen/control_task_execution_order.py
@@ -1,147 +1,109 @@
 """
-=================================
 Control task execution order
-=================================
-
-In ``aiida-workgraph``, a task typically runs as soon as its inputs are available.
-However, you sometimes need to control the execution order more precisely, forcing
-a task to wait for another unrelated task to complete. This is useful when a task
-relies on data that is not passed directly as an input but is, for instance,
-updated in a shared context.
-
-This tutorial demonstrates two powerful features for managing these dependencies:
-
-* The wait operators: ``>>`` and ``<<``
-* Task grouping with ``Zone``
-
-.. note::
-
-   For dependencies between different WorkGraphs, use the ``monitor`` task.
-   Please refer to the :doc:`monitor <./monitor>` HowTo for more details.
-
+============================
 """
-# %%
-# Initial setup
-# =====================
-# First, let's set up the environment and adjust the AiiDA log level to ``REPORT`` so we can observe the execution order of the tasks.
 
+# %%
+# Introduction
+# ------------
+# In `aiida-workgraph`, a task typically runs as soon as its inputs are available.
+# However, you sometimes need to control the execution order more precisely, forcing
+# a task to wait for another unrelated task to complete. This is useful when a task
+# relies on data that is not passed directly as an input but is, for instance,
+# updated in a shared context.
+#
+# .. note::
+#
+#    For dependencies between different WorkGraphs, use the ``monitor`` task.
+#    Please refer to the :doc:`monitor <./monitor>` HowTo for more details.
+
+
+# %%
+# Setup
+# -----
+
+# sphinx_gallery_start_ignore
 from aiida_workgraph.utils.logging import set_aiida_loglevel
-from aiida_workgraph import task, WorkGraph, Zone
-from aiida import load_profile
 
 set_aiida_loglevel("REPORT")
+# sphinx_gallery_end_ignore
+
+from aiida import load_profile
+from aiida_workgraph import group, task
 
 load_profile()
 
 
 # %%
-# Explicit dependencies with wait operators (``>>`` and ``<<``)
-# ==========================================================
+# Dependency operators ``>>`` and ``<<``
+# --------------------------------------
 #
 # The simplest way to create an explicit dependency is with the ``>>`` and ``<<``
 # operators. They let you enforce that one task must finish before another begins,
 # even if there's no data link between them.
 #
-# * ``task_A >> task_B`` means **"task B waits for task A"**.
-# * ``task_B << task_A`` equivalent to ``task_A >> task_B``.
+# * ``task_A >> task_B`` means **"task A, THEN task B"**.
+# * ``task_B << task_A`` means **"task B WAITS ON task A"** - equivalent to ``task_A >> task_B``.
 #
 # .. note::
 #
-#    These operators can be used to create a chain of dependencies, where each task
+#    These operators can be used to create a chain of dependencies.
 #
 #    .. code-block:: python
 #
-#       # task_B waits for task_A; task_C waits for task_B
+#       # task_A THEN task_B THEN task_C
 #       task_A >> task_B >> task_C
 #
 #    For many dependencies, the ``group`` utility can be used:
 #
 #    .. code-block:: python
 #
-#       from aiida_workgraph.collection import group
-#       group(task_B, task_A) >> task_C
+#       from aiida_workgraph import group
 #
-# Example
-# -------
+#       # tasks A AND B (in parallel), THEN task C
+#       group(task_A, task_B) >> task_C
+
+
+# %%
+# Simple example
+# --------------
+#
 # Let's define a workflow where an ``add`` task must wait for two ``multiply``
 # tasks to finish first.
 
 
-@task()
+@task
 def add(x, y):
     return x + y
 
 
-@task()
+@task
 def multiply(x, y):
     return x * y
 
 
-@task.graph()
+# %%
+# Next, we define a WorkGraph in which a group of ``multiply`` tasks run in parallel,
+# then (``>>``) an ``add`` task executes, returning its result.
+
+
+@task.graph
 def wait_graph(x, y):
-    add1_outputs = add(x=x, y=1)
-    multiply1_outputs = multiply(x=y, y=2)
-    multiply2_outputs = multiply(x=y, y=3)
-
-    # Make the 'add_task' wait for both 'multiply' tasks to complete
-    multiply1_outputs >> add1_outputs
-    multiply2_outputs >> add1_outputs
-
-    return add1_outputs.result
+    return (
+        group(
+            multiply(x=y, y=2),
+            multiply(x=y, y=3),
+        )
+        >> add(x=x, y=1).result  # `add` waits for both `multiply` tasks to complete
+    )
 
 
-# Build and run the WorkGraph
 wg = wait_graph.build_graph(x=1, y=2)
 wg.run()
 
 # %%
 # By checking the ``REPORT`` logs from AiiDA, you will see that both ``multiply``
-# tasks complete before the ``add`` task begins, just as we specified.
-
-
-# %%
-# Grouping dependencies with ``Zone``
-# ===================================
-#
-# For more complex scenarios, you can group a set of tasks into a **Zone**.
-# A ``Zone`` acts as a single unit for dependency management, governed by two rules:
-#
-# 1. **Entry Condition**: A ``Zone`` (and all tasks within it) will only start
-#    after *all* tasks with links pointing *into* the ``Zone`` are finished.
-# 2. **Exit Condition**: Any task that needs an output from *any* task inside the
-#    ``Zone`` must wait for the entire `Zone` to complete.
-#
-# Example
-# -------
-# Here, we'll create a workflow where ``task3`` depends on ``task1``, but because
-# ``task1`` is inside a ``Zone``, ``task3`` must wait for the whole group
-# (``task1`` and ``task2``) to finish.
-
-# Create a WorkGraph
-with WorkGraph("zone_example") as wg:
-    task0_outputs = add(x=1, y=1)
-
-    # This Zone will only start after task1 is finished,
-    # because task3 depends on its result.
-    with Zone() as zone1:
-        task1_outputs = add(x=1, y=1)
-        task2_outputs = add(x=1, y=task0_outputs.result)
-
-    # Task 4 will wait for the entire Zone to finish,
-    # even though it only needs the result from task2.
-    task3_outputs = add(x=1, y=task1_outputs.result)
-
-# Generate an HTML file to visualize the graph
-wg.to_html()
-
-# %%
-# Run the WorkGraph
-wg.run()
-
-# %%
-# If you examine the logs, you'll see that ``task3``
-# only starts after both ``task1`` and ``task2`` are complete, demonstrating the
-# "all or nothing" behavior of a ``Zone``.
+# tasks complete before the ``add`` task begins, as specified.
 
 
 # %%
@@ -158,5 +120,6 @@ wg.run()
 # These tools give you fine-grained control over your workflows, ensuring your
 # calculations run in the correct sequence.
 
-# Reset the log level to avoid verbose output in other examples
+# sphinx_gallery_start_ignore
 set_aiida_loglevel("ERROR")
+# sphinx_gallery_end_ignore

--- a/docs/gallery/howto/autogen/control_task_execution_order.py
+++ b/docs/gallery/howto/autogen/control_task_execution_order.py
@@ -17,11 +17,6 @@ Control task execution order
 #    For dependencies between different WorkGraphs, use the ``monitor`` task.
 #    Please refer to the :doc:`monitor <./monitor>` HowTo for more details.
 
-
-# %%
-# Setup
-# -----
-
 # sphinx_gallery_start_ignore
 from aiida_workgraph.utils.logging import set_aiida_loglevel
 

--- a/docs/gallery/howto/autogen/control_task_execution_order.py
+++ b/docs/gallery/howto/autogen/control_task_execution_order.py
@@ -6,6 +6,7 @@ Control task execution order
 # %%
 # Introduction
 # ------------
+#
 # In `aiida-workgraph`, a task typically runs as soon as its inputs are available.
 # However, you sometimes need to control the execution order more precisely, forcing
 # a task to wait for another unrelated task to complete. This is useful when a task
@@ -103,7 +104,7 @@ wg.run()
 
 # %%
 # Conclusion
-# ==========
+# ----------
 #
 # You now know two effective methods to control task execution order in ``aiida-workgraph``:
 #

--- a/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
+++ b/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
@@ -19,6 +19,21 @@ Interoperate with ``aiida-core`` components
 #    If you’re unfamiliar with them, please refer to the official documentation on `Calculations <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/calculations/index.html>`_ and `Workflows <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/workflows/index.html>`_.
 
 # %%
+# Setup
+# -----
+
+import typing as t
+
+from aiida import load_profile, orm
+from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+from aiida.engine import calcfunction, workfunction
+from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
+
+from aiida_workgraph import namespace, task
+
+load_profile()
+
+# %%
 # Use ``aiida-core`` components in a ``WorkGraph``
 # ------------------------------------------------
 #
@@ -26,24 +41,8 @@ Interoperate with ``aiida-core`` components
 # This means that any ``aiida-core`` component can be cast as a task and used within a ``WorkGraph``.
 #
 # In the following example, we combine all four ``aiida-core`` processes in a single ``WorkGraph``, connecting their inputs and outputs as needed.
-
-# %%
-# We start by loading the AiiDA profile and importing the necessary components:
-
-from aiida import load_profile, orm
-
-load_profile()
-
-# %%
-from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
-from aiida.engine import calcfunction, workfunction
-from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
-
-from aiida_workgraph import task, spec
-from typing import Any
-
-# %%
-# Next, let's define a ``calcfunction`` and ``workfunction``
+#
+# Let's first define a ``calcfunction`` and ``workfunction``
 
 
 @calcfunction
@@ -178,7 +177,7 @@ def multiply(x, y):
 
 
 @task.graph
-def IntegratedAddMultiply() -> spec.namespace(sum=Any, product=Any):
+def IntegratedAddMultiply() -> t.Annotated[dict, namespace(sum=int, product=int)]:
     the_sum = add(1, 2).result
     the_product = multiply(the_sum, 3).result
     return {"sum": the_sum, "product": the_product}

--- a/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
+++ b/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
@@ -18,10 +18,6 @@ Interoperate with ``aiida-core`` components
 #    This guide assumes prior knowledge of ``aiida-core`` components.
 #    If you’re unfamiliar with them, please refer to the official documentation on `Calculations <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/calculations/index.html>`_ and `Workflows <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/workflows/index.html>`_.
 
-# %%
-# Setup
-# -----
-
 import typing as t
 
 from aiida import load_profile, orm

--- a/docs/gallery/howto/autogen/monitor.py
+++ b/docs/gallery/howto/autogen/monitor.py
@@ -60,7 +60,7 @@ def add(x, y):
 
 @task.graph
 def TimeMonitor(time, x, y):
-    monitor_time(time) >> (the_sum := add(x, y).result)  # wait THEN (>>) add
+    monitor_time(time) >> (the_sum := add(x, y).result)  # wait, THEN (>>) add
     return the_sum
 
 
@@ -122,22 +122,18 @@ def FileMonitor(x, y, z):
     )
 
     # While above is running, monitor for the file
-    # Once done (`>>` means wait on left operant), add two numbers and discard the file
-    # Finally, multiply the sum by a factor
-    (
-        monitor_file(
-            "/tmp/monitor_test.txt",
-            interval=1,
-            timeout=10,
-        )
-        >> group(
-            discard_file("/tmp/monitor_test.txt"),
-            the_sum := add(x, y).result,
-        )
-        >> (the_product := multiply(the_sum, z).result)
+    # Once done (`>>` means wait on left operant), discard the file and add two numbers
+    monitor_file(
+        "/tmp/monitor_test.txt",
+        interval=1,
+        timeout=10,
+    ) >> group(
+        discard_file("/tmp/monitor_test.txt"),
+        the_sum := add(x, y).result,
     )
 
-    return the_product
+    # Finally, multiply the sum by a factor
+    return multiply(the_sum, z).result
 
 
 wg = FileMonitor.build_graph(x=1, y=2, z=3)

--- a/docs/gallery/howto/autogen/parallel.py
+++ b/docs/gallery/howto/autogen/parallel.py
@@ -1,158 +1,137 @@
 """
-=====================
 Run tasks in parallel
 =====================
 """
 
 # %%
 # Introduction
-# ============
+# ------------
+#
 # Once you have developed a correct and functioning workflow, the next step is often to scale it up for large datasets.
 # This typically involves applying the same workflow to many independent data points.
 # In this how-to, we show how to run the workflow in parallel for each data point to improve performance and scalability.
 
 # %%
-# Setting up the AiiDA environment
-# --------------------------------
+# Setup
+# ~~~~~
+
+import typing as t
 
 from aiida import load_profile
 
-load_profile()
-
+from aiida_workgraph import WorkGraph, namespace, task, dynamic
 from aiida_workgraph.utils import generate_node_graph
-from aiida_workgraph import WorkGraph, task, spec
+
+load_profile()
 
 # %%
 # Perfectly parallelizable problem
-# ================================
+# --------------------------------
+#
 # A perfectly parallelizable problem can be broken down into smaller, independent subproblems that require no shared resources.
 # For example, consider an addition operation ``x + y`` applied element-wise to two lists: ``[x₁, ..., xₙ]`` and ``[y₁, ..., yₙ]``.
 # Each individual addition can be performed independently of the others.
 # ``WorkGraph`` automatically parallelizes task execution when there are no data dependencies between tasks (for more details on this concept, refer to `WorkGraph Engine <../../concept/autogen/engine>`_).
-# We will take advanatge of this concept and create three different show three different ways how one can parallelize the add operation over the list with ``WorkGraph``.
+#
+# We will take advantage of this concept and show three different ways of how one can parallelize the add operation over the list with ``WorkGraph``.
 #
 # .. note::
 #
-#     In practice, a simple element-wise addition like this would typically be parallelized at a lower level, such as using NumPy vectorization or multithreading.
-#     However, we use it here for illustrative purposes.
-#     The concepts demonstrated in this guide can be applied to any workflow that is perfectly parallelizable.
-
+#    In practice, a simple element-wise addition like this would typically be parallelized at a lower level, such as using NumPy vectorization or multithreading.
+#    We use it here for illustrative purposes.
+#    The concepts demonstrated in this guide can be applied to any workflow that is perfectly parallelizable.
 
 # %%
 # Conventional for-loop
-# ---------------------
+# ~~~~~~~~~~~~~~~~~~~~~
 
 
 @task
-def add(x, y):
+def add(x: int, y: int) -> int:
     return x + y
 
 
-len_list = 4
-x_list = list(range(len_list))
-y_list = list(range(len_list))
-sums = []
+@task.graph
+def ParallelAdd(
+    data: t.Annotated[dict[str, dict[str, int]], dynamic(namespace(x=int, y=int))],
+) -> t.Annotated[dict, namespace(sums=dynamic(int))]:
+    sums = {}
+    for i, list_i in enumerate(data.values()):
+        x, y = list_i.values()
+        sums[f"sum_{i}"] = add(x=x, y=y).result
+    return {"sums": sums}
 
-wg = WorkGraph("parallel_for_loop")
-for i in range(len_list):
-    add_task = wg.add_task(add, x=x_list[i], y=y_list[i])
-    sums.append(add_task.outputs.result)
 
+# %%
+# Let's run it with some sample data.
+
+data = {f"list_{i}": {"x": i, "y": i} for i in range(1, 5)}
+
+wg = ParallelAdd.build_graph(data)
 wg.run()
-print("Result:", sums)
-# (1+1) + (2+2) + (3+3) = 12
-assert sum(sum_socket.value for sum_socket in sums) == 12
+
+print("\nResults:")
+lists = list(data.values())
+for i, sum_ in enumerate(wg.outputs.sums):
+    print(f"{lists[i]['x']} + {lists[i]['y']} = {sum_.value}")
+
+# %%
+# Each addition was executed independently, yielding an AiiDA node for each result.
 
 # %%
 # Workflow view
-# ~~~~~~~~~~~~~
+# """""""""""""
+
 wg.to_html()
 
 # %%
 # Provenance graph
-# ~~~~~~~~~~~~~~~~
+# """"""""""""""""
+
 generate_node_graph(wg.pk)
 
 # %%
-# Graph builder
-# -------------
-# We continue with creating the same task for the graph builder.
-# We will perform the for loop within the graph builder task.
-#
 # .. note::
 #
-#     We pack the two lists into a dictionary to pass the data to a task, because ``aiida-core`` supports dynamically sized data structures only through dictionaries.
-#     While lists are supported to some extent, their usage is limited to primitive types.
-
-from typing import Any, Annotated
-
-
-@task.graph(outputs=spec.namespace(result=spec.dynamic(Any)))
-def parallel_add_workflow(data) -> dict:
-    result = {}
-    for i, item in enumerate(data.values()):
-        outputs = add(x=item["x"], y=item["y"])
-        result[f"sum_{i}"] = outputs.result
-    return {"result": result}
-
-
-len_list = 4
-data = {f"list_{i}": {"x": i, "y": i} for i in range(len_list)}
-
-wg = WorkGraph("parallel_graph_task")
-wg.add_task(parallel_add_workflow, data=data)
-wg.outputs.result = wg.tasks.parallel_add_workflow.outputs.result
-wg.run()
-print("Result:")
-for socket in wg.outputs.result:
-    print(socket._name, socket.value)
-# (1+1) + (2+2) + (3+3) = 12
-assert sum(wg.outputs.result._value.values()) == 12
-
-# %%
-# Workflow view
-# ~~~~~~~~~~~~~
-wg.to_html()
-
-# %%
-# Provenance graph
-# ~~~~~~~~~~~~~~~~
-generate_node_graph(wg.pk)
-
+#    Due to our explicit use of type annotation, AiiDA yields a node per input/output.
+#    For more on leveraging type annotations, refer to the :doc:`/howto/autogen/annotate_inputs_outputs` how-to section.
 
 # %%
 # Gather results
-# ==============
+# ~~~~~~~~~~~~~~
+#
 # We now extend the workflow by adding a task that sums the intermediate results.
 # This step is commonly known as a gather, aggregate, or reduce operation.
-# It is often used to automatically analyze or summarize the output of the parallel computations.
-
-
-# %%
-# Graph builder
-# -------------
+# It is often used to automatically analyze or summarize the output of parallel computations.
+#
 # We will extend it the whole workflow only by the ``aggregate_sum`` task
+
+
 @task
-def aggregate_sum(data: Annotated[dict, spec.dynamic(Any)]):
+def aggregate_sums(data: t.Annotated[dict, dynamic(int)]) -> int:
     return sum(data.values())
 
 
-@task.graph(outputs=spec.namespace(result=spec.dynamic(Any)))
-def parallel_add_workflow(data) -> dict:
-    result = {}
-    for i, item in enumerate(data.values()):
-        outputs = add(x=item["x"], y=item["y"])
-        result[f"sum_{i}"] = outputs.result
-    return {"result": result}
+@task.graph
+def ParallelAddAggregate(
+    data: t.Annotated[dict[str, dict[str, int]], dynamic(namespace(x=int, y=int))],
+) -> int:
+    sums = ParallelAdd(data=data).sums
+    return aggregate_sums(data=sums).result
 
 
-len_list = 4
-data = {f"list_{i}": {"x": i, "y": i} for i in range(len_list)}
-
-wg = WorkGraph("parallel_graph_task")
-wg.add_task(parallel_add_workflow, data=data)
-wg.add_task(aggregate_sum, data=wg.tasks.parallel_add_workflow.outputs.result)
-wg.outputs.result = wg.tasks.aggregate_sum.outputs.result
+wg = ParallelAddAggregate.build_graph(data)
 wg.run()
-print("Result:", wg.outputs.result.value)
-assert wg.outputs.result == 12
+
+print("\nResult:", wg.outputs.result.value)
+
+# (1+1) + (2+2) + (3+3) + (4+4) = 20
+assert wg.outputs.result == 20
+
+# %%
+# Conclusion
+# ----------
+#
+# In this how-to, we demonstrated how to run tasks in parallel using ``WorkGraph``.
+# We illustrated this with a simple example of element-wise addition, showcasing how to structure a perfectly parallelizable workflow.
+# We also showed how to gather the results of parallel computations using an aggregation task.

--- a/docs/gallery/howto/autogen/parallel.py
+++ b/docs/gallery/howto/autogen/parallel.py
@@ -11,15 +11,11 @@ Run tasks in parallel
 # This typically involves applying the same workflow to many independent data points.
 # In this how-to, we show how to run the workflow in parallel for each data point to improve performance and scalability.
 
-# %%
-# Setup
-# ~~~~~
-
 import typing as t
 
 from aiida import load_profile
 
-from aiida_workgraph import WorkGraph, namespace, task, dynamic
+from aiida_workgraph import namespace, task, dynamic
 from aiida_workgraph.utils import generate_node_graph
 
 load_profile()

--- a/docs/gallery/howto/autogen/remote_job.py
+++ b/docs/gallery/howto/autogen/remote_job.py
@@ -1,18 +1,17 @@
 """
-
-===============================
 Run calculations remotely
-===============================
+=========================
 
 """
 
 # %%
 # Introduction
-# ============
+# ------------
+#
 # There are three ways to run calculations remotely using AiiDA:
 #
-# - `CalcJob`: run a shell command (via dedicated AiiDA plugins to manage inputs, outputs) on a remote computer, please refer to `How to use aiida-core components inside WorkGraph <../../howto/autogen/interoperate_with_aiida_core.html>`_.
-# - `ShellJob`: run any shell command on a remote computer, please refer to the `Run shell commands as a task <../../howto/autogen/shelljob.html>`_.
+# - `CalcJob`: run a shell command (via dedicated AiiDA plugins to manage inputs, outputs) on a remote computer (see :doc:`/howto/autogen/interoperate_with_aiida_core`).
+# - `ShellJob`: run any shell command on a remote computer (see :doc:`/howto/autogen/shelljob`).
 # - `PythonJob`: run any Python function on a remote computer.
 #
 # In this tutorial, we introduce how to run `PythonJob` tasks inside a WorkGraph.
@@ -20,84 +19,93 @@ Run calculations remotely
 
 from aiida import load_profile
 
+from aiida_workgraph import task
+
 load_profile()
 
 # %%
-# PythonJob task
-# ========================
-# One can create a `PythonJob` task using the ``@task.pythonjob()`` decorator.
+# PythonJob
+# ---------
+#
+# One can create a `PythonJob` task using the ``@task.pythonjob`` decorator.
 # This allows you to define a Python function that can be executed as a job on a remote computer.
 
-from aiida_workgraph import WorkGraph, task
 
-
-# Decorator to define a pythonjob
-@task.pythonjob()
-def add(x, y):
+@task.pythonjob
+def add(x: int, y: int) -> int:
     return x + y
 
 
-with WorkGraph() as wg:
-    # Call the add task, specifying 'localhost' as the computer.
-    # Notice we pass 'computer="localhost"' even though it's not
-    # an argument to the 'add(x, y)' function directly.
-    outputs = add(x=1, y=2, computer="localhost")
-    wg.run()
+@task.graph
+def RemoteAdd(x: int, y: int, computer: str) -> int:
+    return add(x=x, y=y, computer=computer).result
 
-# Print out the result once the WorkGraph has finished executing.
-print("\nResult: ", outputs.result)
+
+wg = RemoteAdd.build_graph(x=1, y=2, computer="localhost")
+wg.run()
+
+print("\nResult: ", wg.outputs.result.value)
 
 # %%
-# Understanding Inputs and Outputs
+# Understanding inputs and outputs
 # --------------------------------
-# When you apply the ``@task.pythonjob()`` decorator, your Python function (like ``add``) transforms into an AiiDA `PythonJob` task.
+#
+# When you apply the ``@task.pythonjob`` decorator, your Python function (like ``add``) transforms into an AiiDA `PythonJob` task.
 # This task requires and produces more than just your function's direct inputs and outputs:
 #
-# * **Inputs:** Besides your function's arguments (e.g., ``x``, ``y``), the task takes additional inputs like ``computer`` to manage its execution on a remote machine.
+# * **Inputs:** In addition to your function's arguments (e.g., ``x``, ``y``), the task takes additional inputs (e.g., ``computer``) to manage its execution on a remote machine.
 #
-# * **Outputs:** Beyond your function's return value (available as ``.result`` by default), the task provides comprehensive outputs, such as ``remote_folder`` (a reference to the job's directory on the remote computer).
+# * **Outputs:** In addition to your function's return value (available as ``.result`` by default), the task provides comprehensive outputs, such as ``remote_folder`` (a reference to the job's directory on the remote computer).
 
 # %%
 # Prepare Python environment on remote computer
-# -----------------------------------------------
+# ---------------------------------------------
+#
 # `PythonJob` requires that the Python version on the remote computer matches the one used on the localhost where AiiDA is running.
 # You can use `conda` to create a virtual environment with the same Python version, then activate the environment in the `metadata` of the `PythonJob` task.
 #
 # Here's an example demonstrating how to submit a `PythonJob` and chain it with another Python function within a `WorkGraph`.
 # We'll also show how to pass custom scheduler commands via metadata, though for this example, they will be empty.
-#
 
 
-# Uncomment the 'custom_scheduler_commands' line below and modify it to suit your environment.
 metadata = {
     "options": {
-        # 'custom_scheduler_commands' : 'module load anaconda\nconda activate py3.11\n',
+        # "custom_scheduler_commands" : "module load anaconda\nconda activate py3.11\n",
         "custom_scheduler_commands": "",  # Keeping it empty for this example
     }
 }
 
+# %%
+# .. note::
+#
+#    Uncomment the ``custom_scheduler_commands`` line to modify it for your environment.
 
-# This is a normal task. It will be executed locally within the WorkGraph.
-@task()
+
+@task
 def multiply(x, y):
     return x * y
 
 
-with WorkGraph(name="test_pythonjob") as wg:
-    # We pass the metadata to ensure any custom scheduler commands are applied.
-    outputs1 = add(x=2, y=3, computer="localhost", metadata=metadata)
-    # Add another task which will run locally
-    wg.outputs.result = multiply(x=outputs1.result, y=4).result
-    wg.run()
+@task.graph
+def RemoteAddLocalMultiply(x: int, y: int, computer: str, metadata: dict) -> int:
+    the_sum = add(x=x, y=y, computer=computer, metadata=metadata).result
+    return multiply(x=the_sum, y=4)  # this will run locally
 
-# ------------------------- Print the output -------------------------
-print("\nResult {} \n\n".format(wg.outputs.result.value))
+
+wg = RemoteAddLocalMultiply.build_graph(
+    x=2,
+    y=3,
+    computer="localhost",
+    metadata=metadata,
+)
+wg.run()
+
+print("\nResult:", wg.outputs.result.value)
 
 
 # %%
 # Conclusion
-# ===========
-# In this tutorial, we demonstrated the three ways to run calculations remotely using AiiDA:
-# `CalcJob`, `ShellJob`, and `PythonJob`. We focused on `PythonJob`, showing how to
-# define and execute Python functions as remote jobs,
-# including managing the remote Python environment via custom scheduler commands.
+# ----------
+#
+# In this tutorial, we briefly discussed the three ways to run calculations remotely using AiiDA: `CalcJob`, `ShellJob`, and `PythonJob`.
+# We demonstrated how to use `PythonJob` to define and execute Python functions as remote jobs, including managing the remote Python environment via custom scheduler commands.

--- a/docs/gallery/howto/autogen/shelljob.py
+++ b/docs/gallery/howto/autogen/shelljob.py
@@ -7,41 +7,52 @@ Run shell commands as a task
 
 # %%
 # Introduction
-# ============
-# This document demonstrates how to use the built-in `shelljob` task within AiiDA-WorkGraph, which leverages the `aiida-shell <https://aiida-shell.readthedocs.io/en/latest/>`_ package, to easily execute shell commands.
+# ------------
+#
+# This document demonstrates how to use the built-in ``shelljob`` task within AiiDA-WorkGraph, which leverages the `aiida-shell <https://aiida-shell.readthedocs.io/en/latest/>`_ package, to easily execute shell commands.
 # This eliminates the need to write custom plugins or parsers for simple shell operations.
 #
-# This tutorial is based on the `docs <https://aiida-shell.readthedocs.io/en/latest/howto.html#>`_ of the ``aiida-shell``.
-#
-# Load the AiiDA profile.
+# This tutorial is based on the `docs <https://aiida-shell.readthedocs.io/en/latest/howto.html#>`_ of the `aiida-shell` package.
 
-from aiida import load_profile
+import typing as t
+
+from aiida import load_profile, orm
+from aiida_shell.data import PickledData
+
+from aiida_workgraph import dynamic, shelljob, task
+from aiida_workgraph.utils import generate_node_graph, get_or_create_code
 
 load_profile()
 
 # %%
-# Running a shell command
-# ========================
-# To execute a shell command, you can use `shelljob`.
-# Here's an example that runs the `date` command to retrieve the current date:
+# Run a shell command
+# -------------------
 #
+# To execute a shell command, you can use ``shelljob``.
+# Here's an example that runs the `date` command to retrieve the current date:
 
-from aiida_workgraph import WorkGraph, shelljob
 
-with WorkGraph(name="test_shell_date") as wg:
-    outputs = shelljob(command="date")
-    wg.run()
+@task.graph
+def ShellDate() -> t.Annotated[dict, dynamic(t.Any)]:
+    return shelljob(command="date")
 
-# Print out the result:
-print("\nResult: ", outputs.stdout.value.get_content())
 
+wg = ShellDate.build_graph()
+wg.run()
+
+print("\nResult: ", wg.outputs.stdout.value.get_content())
 
 # %%
-# Under the hood, an AiiDA ``Code`` instance ``date`` will be created on the ``localhost`` computer. In addition, it is also
-# possible to specify a different, remote computer. For the sake of this example, we create a mock remote computer (you
-# would usually have this pre-configured already, e.g., your favorite HPC resource):
+# .. note::
+#
+#    In the current version, it is required to annotate the return type of a task which returns the outputs of a ``shelljob`` with ``t.Annotated[dict, dynamic(t.Any)]``.
+#    The annotation overrides the default ``result`` socket with that of the ``shelljob``.
+#    In a future release, this will be handled via explicit exposing of the ``shelljob`` outputs.
+#
+# Under the hood, an AiiDA ``Code`` instance referencing the ``date`` shell command will be created on the ``localhost`` computer.
+# In addition, it is also possible to specify a different remote computer.
+# For the sake of this example, we create a mock remote computer (you would usually have this pre-configured already, e.g., your favorite HPC resource).
 
-from aiida import orm
 
 created, mock_remote_computer = orm.Computer.collection.get_or_create(
     label="my-remote-computer",
@@ -54,19 +65,22 @@ created, mock_remote_computer = orm.Computer.collection.get_or_create(
 if created:
     mock_remote_computer.store()
 
-# We can then specify the remote computer via the ``metadata``:
+# %%
+# We can then specify the remote computer via the ``metadata``.
 
-with WorkGraph(name="test_shell_date_remote") as wg:
-    outputs = shelljob(
+
+@task.graph
+def RemoteShellDate(computer: str) -> t.Annotated[dict, dynamic(t.Any)]:
+    return shelljob(
         command="date",
-        metadata={"computer": orm.load_computer("my-remote-computer")},
+        metadata={"computer": orm.load_computer(computer)},
     )
 
 
-#%%
-# In addition, it is possible to pass a pre-configured ``Code``. Let's again create a mock ``Code``:
+# %%
+# In addition, it is possible to pass a pre-configured ``Code``.
+# Let's again create a mock ``Code``.
 
-from aiida_workgraph.utils import get_or_create_code
 
 mock_remote_code = get_or_create_code(
     code_label="remote-date",
@@ -74,113 +88,112 @@ mock_remote_code = get_or_create_code(
     code_path="/usr/bin/date",
 )
 
-# Which we can now directly pass to the ``command`` argument of ``add_task``:
+# %%
+# We can now directly pass to the ``command`` argument of ``add_task``.
 
-with WorkGraph(name="test_shell_date_preconfigured") as wg:
-    outputs = shelljob(command=orm.load_code("remote-date@my-remote-computer"))
 
-# Note, we are not running or submitting the ``WorkGraph`` in the above two examples, as we are using mocked
-# ``Computer`` and ``Code`` entities for demonstration purposes.
+@task.graph
+def RemoteShellDateWithCode(code: str) -> t.Annotated[dict, dynamic(t.Any)]:
+    return shelljob(command=orm.load_code(code))
+
 
 # %%
-# Running a shell command with arguments
-# =======================================
-# To pass arguments to the shell command, pass them as a list of strings to the arguments keyword:
+# Command arguments
+# -----------------
 #
+# To pass arguments to the shell command, pass them as a list of strings to the arguments keyword.
 
 
-with WorkGraph(name="test_shell_date_with_arguments") as wg:
-    outputs = shelljob(command="date", arguments=["--iso-8601"])
-    wg.run()
+@task.graph
+def ShellDateWithArguments() -> t.Annotated[dict, dynamic(t.Any)]:
+    return shelljob(command="date", arguments=["--iso-8601"])
 
-# Print out the result:
-print("\nResult: ", outputs.stdout.value.get_content())
+
+wg = ShellDateWithArguments.build_graph()
+wg.run()
+
+print("\nResult: ", wg.outputs.stdout.value.get_content())
 
 # %%
-# Running a shell command with files as arguments
-# ===============================================
-# For commands that take arguments that refer to files, pass those files using the nodes keyword. The keyword takes a dictionary of SinglefileData nodes. To specify where on the command line the files should be passed, use placeholder strings in the arguments keyword.
+# File arguments
+# --------------
 #
+# For commands that take arguments referring to files, you pass those files using the nodes keyword.
+# The keyword takes a dictionary of `SinglefileData` nodes.
+# To specify where on the command line the files should be passed, use placeholder strings in the arguments keyword.
 
 
-from aiida.orm import SinglefileData
-
-with WorkGraph(name="test_shell_cat_with_file_arguments") as wg:
-    outputs = shelljob(
+@task.graph
+def ShellCatWithFileArguments() -> t.Annotated[dict, dynamic(t.Any)]:
+    return shelljob(
         command="cat",
         arguments=["{file_a}", "{file_b}"],
         nodes={
-            "file_a": SinglefileData.from_string("string a"),
-            "file_b": SinglefileData.from_string("string b"),
+            "file_a": orm.SinglefileData.from_string("string a"),
+            "file_b": orm.SinglefileData.from_string("string b"),
         },
     )
-    wg.run()
 
-    # Print out the result:
-    print("\nResult: ", outputs.stdout.value.get_content())
+
+wg = ShellCatWithFileArguments.build_graph()
+wg.run()
+
+print("\nResult: ", wg.outputs.stdout.value.get_content())
 
 # %%
-# Create a workflow
-# =================
-# We want to calculate `(x+y)*z` in two steps using the `expr` command. Each step will invole one `ShellJob`.
+# An example workflow: ``(x + y) * z``
+# ------------------------------------
 #
-# If one wanted to run this workflow in AiiDA using CalcJob and WorkChain, one would have to write plugins for `expr` command, and a WorkChain to handle the workflow. With aiida-workgraph, this can be run with the following workgraph:
-#
-
-from aiida_workgraph import WorkGraph
-from aiida.orm import Int
-from aiida_shell.data import PickledData
-from aiida import load_profile
-
-load_profile()
+# We want to calculate ``(x + y) * z`` in two steps using the ``expr`` command.
+# Each step will involve one `ShellJob`.
+# To facilitate access to the result of each step, we define a custom parser that reads the output from the `stdout` file.
 
 
 def parser(dirpath):
-    from aiida.orm import Int
+    return {"result": orm.Int((dirpath / "stdout").read_text().strip())}
 
-    return {"result": Int((dirpath / "stdout").read_text().strip())}
+
+@task.graph
+def ShellAddMultiply(x: int, y: int, z: int) -> int:
+    the_sum = shelljob(
+        command="expr",
+        arguments=["{x}", "+", "{y}"],
+        nodes={"x": x, "y": y},
+        parser=PickledData(parser),
+        parser_outputs=["result"],
+    ).result
+    the_product = shelljob(
+        command="expr",
+        arguments=["{x}", "*", "{y}"],
+        nodes={"x": the_sum, "y": z},
+        parser=PickledData(parser),
+        parser_outputs=["result"],
+    ).result
+    return the_product
 
 
 # Create a workgraph
-with WorkGraph(name="shell_add_mutiply_workflow") as wg:
-    outputs1 = shelljob(
-        command="expr",
-        arguments=["{x}", "+", "{y}"],
-        nodes={"x": Int(2), "y": Int(3)},
-        parser=PickledData(parser),
-        parser_outputs=["result"],
-    )
-    outputs2 = shelljob(
-        command="expr",
-        arguments=["{result}", "*", "{z}"],
-        nodes={"z": Int(4), "result": outputs1.result},
-        parser=PickledData(parser),
-        parser_outputs=["result"],
-    )
+wg = ShellAddMultiply.build_graph(2, 3, 4)
 wg.to_html()
 
-
 # %%
-# Submit the workgraph
-#
 
 wg.run()
-print("State of WorkGraph    : {}".format(wg.state))
-print("Result               : {}".format(outputs2.result.value))
-assert outputs2.result.value == 20
+
+print("State` of WorkGraph    : {}".format(wg.state))
+print("Result                : {}".format(wg.outputs.result.value))
+assert wg.outputs.result.value == 20
 
 
 # %%
-# Generate node graph from the AiiDA process
-#
-
-from aiida_workgraph.utils import generate_node_graph
+# Let's have a look at the provenance graph.
 
 generate_node_graph(wg.pk)
 
 # %%
 # What's Next
-# ===========
-# Overall, WorkGraph's ``ShellJob`` builds on top of ``aiida-shell`` and mirrors its functionality. So features
-# implemented in ``aiida-shell`` should also be available for the ``ShellJob``. For more examples of ``aiida-shell``, please refer to its `docs <https://aiida-shell.readthedocs.io/en/latest/howto.html#>`_.
+# -----------
 #
+# Overall, WorkGraph's `ShellJob` builds on top of ``aiida-shell`` and mirrors its functionality.
+# Features implemented in ``aiida-shell`` are also be available for the ``ShellJob``.
+# For more examples of ``aiida-shell``, please refer to its `docs <https://aiida-shell.readthedocs.io/en/latest/howto.html#>`_.

--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -2,18 +2,22 @@
 Advanced topics
 ===============
 
-The following sections provide details on the two additional modes of use of AiiDA WorkGraph:
+The following sections provide details on advanced use of AiiDA WorkGraph:
 
-* :doc:`/advanced/autogen/node_graph_programming`
-   This section covers node-graph programming, allowing users to build workflows by connecting task inputs and outputs, enabling easy modification and extension.
+* :doc:`/advanced/autogen/context`
+   This section introduces the use of the AiiDA context, which allows users to store and retrieve data within the workflow's execution context, facilitating data management and sharing between tasks.
 
 * :doc:`/advanced/autogen/context_manager`
    This section discusses the context manager paradigm, which offers explicit zones like ``If``, ``While``, and ``Map`` to build a graph that clearly shows the workflow's structure and dependencies.
+
+* :doc:`/advanced/autogen/node_graph_programming`
+   This section covers node-graph programming, allowing users to build workflows by connecting task inputs and outputs, enabling easy modification and extension.
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
    :hidden:
 
-   autogen/node_graph_programming
+   autogen/context
    autogen/context_manager
+   autogen/node_graph_programming

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -11,7 +11,6 @@ This section contains a collection of HowTos for various topics.
    autogen/annotate_inputs_outputs
    autogen/parallel
    autogen/control-flow
-   autogen/context
    autogen/shelljob
    autogen/remote_job
    autogen/combine_workgraphs


### PR DESCRIPTION
This PR updates much of the how-to sections, converting all workflows to `@task.graph` constructs, moving all other paradigms to the advanced topics.