### PR TITLE
Refactor to use minimal db

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,9 @@ classifiers = [
 keywords = ["aiida", "workflows"]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy~=1.21",
+    "numpy",
     "scipy",
-    "ase",
-    "node-graph @ git+https://github.com/superstar54/node-graph.git@minimal_db_refactor",
+    "node-graph @ git+https://github.com/superstar54/node-graph.git@main",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy~=1.21",
     "scipy",
     "ase",
-    "node-graph>=0.3.7",
+    "node-graph @ git+https://github.com/superstar54/node-graph.git@minimal_db_refactor",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/executors/test.py
+++ b/src/aiida_workgraph/executors/test.py
@@ -4,17 +4,17 @@ from aiida_workgraph import task
 from aiida_workgraph.socket_spec import namespace
 
 
-@task.calcfunction
+@task
 def add(x: Int = 0, y: Int = 0, t: Int = 1) -> Int:
     """Add node."""
-    time.sleep(t.value)
+    time.sleep(t)
     return x + y
 
 
-@task.calcfunction
+@task
 def sum_diff(x: Int = 0, y: Int = 0, t: Int = 1) -> namespace(sum=Int, diff=Int):
     """Add node."""
-    time.sleep(t.value)
+    time.sleep(t)
     return {"sum": x + y, "diff": x - y}
 
 

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -70,23 +70,16 @@ def build_callable_nodespec(
         func_out = merge_specs(func_out, add_outputs)
 
     # 4) metadata: keep a record of each contribution
-    inputs_keys = []
-    if proc_in:
-        inputs_keys.extend(proc_in.fields.keys())
-    if add_inputs:
-        inputs_keys.extend(add_inputs.fields.keys())
-    inputs_keys = list(set(inputs_keys))
-    outputs_keys = []
-    if proc_out:
-        outputs_keys.extend(proc_out.fields.keys())
-    if add_outputs:
-        outputs_keys.extend(add_outputs.fields.keys())
-    outputs_keys = list(set(outputs_keys))
-
     meta = {
         "node_type": node_type,
-        "non_function_inputs": inputs_keys,
-        "non_function_outputs": outputs_keys,
+        "non_function_inputs": list(
+            set((proc_in and proc_in.fields.keys()) or [])
+            | set((add_inputs and add_inputs.fields.keys()) or [])
+        ),
+        "non_function_outputs": list(
+            set((proc_out and proc_out.fields.keys()) or [])
+            | set((add_outputs and add_outputs.fields.keys()) or [])
+        ),
     }
 
     return NodeSpec(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from aiida_workgraph import task, WorkGraph
-from aiida.orm import Int, StructureData
+from aiida.orm import Int
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from typing import Callable, Any, Union
 from aiida.orm import WorkflowNode
@@ -235,15 +235,6 @@ def decorated_namespace_sum_diff() -> Callable:
         }
 
     return sum_diff
-
-
-@pytest.fixture
-def structure_si() -> StructureData:
-    from ase.build import bulk
-
-    si = bulk("Si")
-    structure_si = StructureData(ase=si)
-    return structure_si
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def fixture_code(fixture_localhost):
 
 
 @pytest.fixture
-def wg_calcfunction() -> WorkGraph:
+def wg_task() -> WorkGraph:
     """A workgraph with calcfunction."""
 
     wg = WorkGraph(name="test_debug_math")

--- a/tests/test_calcfunction.py
+++ b/tests/test_calcfunction.py
@@ -2,9 +2,9 @@ from aiida_workgraph import WorkGraph, task
 from aiida import orm
 
 
-def test_run(wg_calcfunction: WorkGraph) -> None:
+def test_run(wg_task: WorkGraph) -> None:
     """Run simple calcfunction."""
-    wg = wg_calcfunction
+    wg = wg_task
     wg.name = "test_run_calcfunction"
     wg.run()
     print("state: ", wg.state)

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -3,7 +3,7 @@ from aiida import orm
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 
 
-def test_error_handlers(add_code, capsys):
+def test_error_handlers(add_code):
     """Test error handlers."""
 
     def handle_negative_sum(task: Task):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -9,7 +9,7 @@ from aiida_workgraph import WorkGraph, task
 from aiida_workgraph.tasks.monitors import monitor_time
 
 
-def test_monitor_decorator(capsys):
+def test_monitor_decorator():
     wg = WorkGraph(name="test_monitor_decorator")
     wg.add_task(
         monitor_time,
@@ -17,13 +17,12 @@ def test_monitor_decorator(capsys):
         time=datetime.datetime.now() + datetime.timedelta(seconds=5),
     )
     wg.run()
-    captured = capsys.readouterr()
-    report = captured.out
+    report = get_workchain_report(wg.process, "REPORT")
     assert "Waiting for child processes: time_monitor1" in report
     assert wg.process.is_finished_ok is True
 
 
-def test_monitor_timeout_and_interval(capsys):
+def test_monitor_timeout_and_interval():
     with WorkGraph() as wg:
         monitor_time(
             time=datetime.datetime.now() + datetime.timedelta(seconds=20),
@@ -31,13 +30,12 @@ def test_monitor_timeout_and_interval(capsys):
             timeout=5,
         )
         wg.run()
-        captured = capsys.readouterr()
-        report = captured.out
+        report = get_workchain_report(wg.process, "REPORT")
         assert "Timeout reached for monitor" in report
         assert wg.process.is_finished_ok is False
 
 
-def test_builtin_time_monitor_entrypoint(decorated_add, capsys):
+def test_builtin_time_monitor_entrypoint(decorated_add):
     """Test the time monitor task."""
     wg = WorkGraph(name="test_time_monitor")
     monitor1 = wg.add_task(
@@ -45,16 +43,10 @@ def test_builtin_time_monitor_entrypoint(decorated_add, capsys):
         "monitor1",
         time=datetime.datetime.now() + datetime.timedelta(seconds=5),
     )
-    add1 = wg.add_task(decorated_add, "add1", x=1, y=2)
-    add1.waiting_on.add(monitor1)
-    wg.run()
-    captured = capsys.readouterr()
-    report = captured.out
-    assert "Waiting for child processes: monitor1" in report
-    assert add1.outputs.result.value == 3
+    assert monitor1.get_executor().callable == monitor_time
 
 
-def test_builtin_file_monitor_entrypoint(decorated_add, tmp_path, capsys):
+def test_builtin_file_monitor_entrypoint(decorated_add, tmp_path):
     """Test the file monitor task."""
 
     @task.awaitable()
@@ -73,8 +65,7 @@ def test_builtin_file_monitor_entrypoint(decorated_add, tmp_path, capsys):
     add1 = wg.add_task(decorated_add, "add1", x=1, y=2)
     add1.waiting_on.add(monitor1)
     wg.run()
-    captured = capsys.readouterr()
-    report = captured.out
+    report = get_workchain_report(wg.process, "REPORT")
     assert "Waiting for child processes: monitor1" in report
     assert add1.outputs.result.value == 3
 
@@ -101,7 +92,7 @@ def test_builtin_task_monitor_entrypoint(decorated_add):
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_builtin_task_monitor_entrypoint_timeout(decorated_add, capsys):
+def test_builtin_task_monitor_entrypoint_timeout(decorated_add):
     """Test the monitor task with a timeout."""
     wg = WorkGraph(name="test_monitor_timeout")
     monitor1 = wg.add_task(
@@ -113,15 +104,14 @@ def test_builtin_task_monitor_entrypoint_timeout(decorated_add, capsys):
     add1 = wg.add_task(decorated_add, "add1", x=1, y=2)
     monitor1 >> add1
     wg.run()
-    captured = capsys.readouterr()
-    report = captured.out
+    report = get_workchain_report(wg.process, "REPORT")
     assert "Timeout reached for monitor function" in report
     assert monitor1.state == "FAILED"
     assert add1.state == "SKIPPED"
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_task_monitor_kill(decorated_add, capsys):
+def test_task_monitor_kill(decorated_add):
     """Test killing a monitor task."""
     wg = WorkGraph(name="test_monitor_kill")
     monitor1 = wg.add_task(

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -9,32 +9,27 @@ def test_to_dict():
     """Test the to_dict method.
     PythonJobTask override the `to_dict` method to serialize the raw
     data to AiiDA data."""
-    from ase import Atoms
-    from ase.build import bulk
     from aiida import orm
 
     @task.pythonjob()
-    def make_supercell(atoms: Atoms, dim: int = 2) -> Atoms:
-        """Scale the structure by the given scales."""
-        return atoms * (dim, dim, dim)
+    def repeat_data(data: list, dim: int = 2) -> list:
+        return data * dim
 
-    atoms = bulk("Si")
-    wg = WorkGraph("test_PythonJob_retrieve_files")
+    wg = WorkGraph("test_to_dict")
     # atoms will be converted to AtomsData automatically
     wg.add_task(
-        make_supercell,
-        atoms=atoms,
+        repeat_data,
+        data=[1, 2, 3],
         dim=2,
-        name="make_supercell_1",
     )
-    data = wg.tasks.make_supercell_1.to_dict()
+    data = wg.tasks.repeat_data.to_dict()
     assert not isinstance(
-        data["inputs"]["atoms"],
+        data["inputs"]["data"],
         orm.Data,
     )
-    data = wg.tasks.make_supercell_1.to_dict(should_serialize=True)
+    data = wg.tasks.repeat_data.to_dict(should_serialize=True)
     assert isinstance(
-        data["inputs"]["atoms"],
+        data["inputs"]["data"],
         orm.Data,
     )
 

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -3,13 +3,13 @@ from typing import Callable
 from aiida import orm
 
 
-def test_inputs_outptus(wg_calcfunction: WorkGraph) -> None:
+def test_inputs_outptus(wg_task: WorkGraph) -> None:
     """Test the inputs and outputs of the WorkGraph."""
     wg = WorkGraph(name="test_inputs_outptus")
-    wg_calcfunction.inputs = {"x": 1, "y": 2}
-    wg_calcfunction.outputs.diff = wg_calcfunction.tasks.sumdiff1.outputs.diff
-    wg_calcfunction.outputs.sum = wg_calcfunction.tasks.sumdiff2.outputs.sum
-    task1 = wg.add_task(wg_calcfunction, name="add1")
+    wg_task.inputs = {"x": 1, "y": 2}
+    wg_task.outputs.diff = wg_task.tasks.sumdiff1.outputs.diff
+    wg_task.outputs.sum = wg_task.tasks.sumdiff2.outputs.sum
+    task1 = wg.add_task(wg_task, name="add1")
     assert len(task1.inputs) == 3
     assert len(task1.outputs) == 4
     assert "x" in task1.inputs
@@ -17,19 +17,19 @@ def test_inputs_outptus(wg_calcfunction: WorkGraph) -> None:
     assert "sum" in task1.outputs
 
 
-def test_inputs_outptus_auto_generate(wg_calcfunction: WorkGraph) -> None:
+def test_inputs_outptus_auto_generate(wg_task: WorkGraph) -> None:
     """Test the inputs and outputs of the WorkGraph."""
     wg = WorkGraph(name="test_inputs_outptus")
     # this will generate the group inputs and outputs automatically
-    wg_calcfunction.generate_inputs()
-    wg_calcfunction.generate_outputs()
-    task1 = wg.add_task(wg_calcfunction, name="add1")
+    wg_task.generate_inputs()
+    wg_task.generate_outputs()
+    task1 = wg.add_task(wg_task, name="add1")
     ninput = 0
-    for sub_task in wg_calcfunction.tasks:
+    for sub_task in wg_task.tasks:
         # remove _wait, but add the namespace
         ninput += len(sub_task.inputs) - 1 + 1
     noutput = 0
-    for sub_task in wg_calcfunction.tasks:
+    for sub_task in wg_task.tasks:
         noutput += len(sub_task.outputs) - 2 + 1
     assert len(task1.inputs) == 3
     assert len(task1.outputs) == 4

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,24 +6,6 @@ from aiida_workgraph import socket_spec as spec
 from typing import Any
 
 
-def test_normal_task(decorated_add) -> None:
-    """Test a normal task."""
-
-    @task(outputs=["sum", "diff"])
-    def sum_diff(x, y):
-        return x + y, x - y
-
-    wg = WorkGraph("test_normal_task")
-    task1 = wg.add_task(sum_diff, name="sum_diff", x=2, y=3)
-    task2 = wg.add_task(
-        decorated_add, name="add", x=task1.outputs.sum, y=task1.outputs["diff"]
-    )
-    wg.run()
-    print("node: ", task2.outputs.result)
-    wg.update()
-    assert task2.outputs.result.value == 4
-
-
 def test_task_collection(decorated_add: Callable) -> None:
     """Test the TaskCollection class.
     Since waiting_on and children are TaskCollection instances, we test the waiting_on."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -29,7 +29,7 @@ def test_task_collection(decorated_add: Callable) -> None:
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_task_wait(decorated_add: Callable, capsys) -> None:
+def test_task_wait(decorated_add: Callable) -> None:
     """Run a WorkGraph with a task that waits on other tasks."""
 
     wg = WorkGraph(name="test_task_wait")

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -117,7 +117,7 @@ def test_organize_nested_inputs():
 
 
 @pytest.mark.usefixtures("started_daemon_client")
-def test_reset_message(wg_calcjob, capsys):
+def test_reset_message(wg_calcjob):
     """Modify a node and save the workgraph.
     This will add a message to the workgraph_queue extra field."""
     from aiida.cmdline.utils.common import get_workchain_report

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -26,7 +26,7 @@ def test_add_task():
     assert len(wg.links) == 1
 
 
-def test_show_state(wg_calcfunction):
+def test_show_state(wg_task):
     from io import StringIO
     import sys
 
@@ -34,8 +34,8 @@ def test_show_state(wg_calcfunction):
     captured_output = StringIO()
     sys.stdout = captured_output
     # Call the method
-    wg_calcfunction.name = "test_show_state"
-    wg_calcfunction.show()
+    wg_task.name = "test_show_state"
+    wg_task.show()
     # Reset stdout
     sys.stdout = sys.__stdout__
     # Check the output
@@ -45,12 +45,12 @@ def test_show_state(wg_calcfunction):
     assert "PLANNED" in output
 
 
-def test_save_load(wg_calcfunction, decorated_add):
+def test_save_load(wg_task, decorated_add):
     """Save the workgraph"""
     from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
     from aiida_workgraph.executors.builtins import UnavailableExecutor
 
-    wg = wg_calcfunction
+    wg = wg_task
     wg.add_task(decorated_add, name="add1", x=2, y=3)
     metadata = {
         "options": {
@@ -134,11 +134,11 @@ def test_reset_message(wg_calcjob, capsys):
     assert "Action: RESET. Tasks: ['add1']" in report
 
 
-def test_restart_and_reset(wg_calcfunction):
+def test_restart_and_reset(wg_task):
     """Restart from a finished workgraph.
     Load the workgraph, modify the task, and restart the workgraph.
     Only the modified node and its child tasks will be rerun."""
-    wg = wg_calcfunction
+    wg = wg_task
     wg.outputs.diff = wg.tasks.sumdiff1.outputs.diff
     wg.outputs.sum = wg.tasks.sumdiff2.outputs.sum
     wg.add_task(

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1,7 +1,7 @@
 from aiida_workgraph import WorkGraph
 
 
-def test_zone_task(decorated_add, capsys):
+def test_zone_task(decorated_add):
     """Test the zone task."""
 
     wg = WorkGraph("test_zone")

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -1,10 +1,10 @@
 from IPython.display import IFrame
 
 
-def test_workgraph_widget(wg_calcfunction, decorated_add):
+def test_workgraph_widget(wg_task, decorated_add):
     """Save the workgraph"""
 
-    wg = wg_calcfunction
+    wg = wg_task
     wg.name = "test_workgraph_widget"
     wg.add_task(decorated_add, "add1", x=1, y=3)
     wg.tasks["sumdiff2"].waiting_on.add(wg.tasks["sumdiff2"])
@@ -23,13 +23,13 @@ def test_workgraph_widget(wg_calcfunction, decorated_add):
     data = wg._repr_mimebundle_()
 
 
-def test_workgraph_task(wg_calcfunction):
+def test_workgraph_task(wg_task):
     """Save the workgraph"""
-    wg = wg_calcfunction
+    wg = wg_task
     value = wg.tasks["sumdiff2"].to_widget_value()
     assert len(value["nodes"]) == 1
-    # all the inputs are optional, so no inputs are shown
-    assert len(value["nodes"]["sumdiff2"]["inputs"]) == 0
+    # there is a function_data input for PyFunction
+    assert len(value["nodes"]["sumdiff2"]["inputs"]) == 1
     assert len(value["links"]) == 0
     # to html
     data = wg.tasks["sumdiff2"].to_html()


### PR DESCRIPTION
- Python function tasks (pyfunction, pythonjob) do not store inputs/outputs spec in metadata.
- Bump node-graph to use the new `NodeSpce`.
  -  Non-importable executors:  embed the full spec.
  - Importable and return `BaseHandle`: store only the executor (we can rebuild from the handle).