### PR TITLE
Apply decorator build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "scipy",
-    "node-graph @ git+https://github.com/superstar54/node-graph.git@main",
+    "node-graph>=0.3.8",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -29,12 +29,14 @@ def _spec_for(
         in_spec, out_spec = from_aiida_process(obj)
         return NodeSpec(
             identifier=identifier or obj.__name__,
+            mode="decorator_build",
             catalog="AIIDA",
             inputs=in_spec,
             outputs=out_spec,
             executor=RuntimeExecutor.from_callable(obj),
             base_class=AiiDAProcessTask,
             metadata={"node_type": inspect_aiida_component_type(obj)},
+            decorator_path="aiida_workgraph.decorator.task",
         )
 
     # AiiDA process functions (calcfunction/workfunction)
@@ -155,6 +157,7 @@ class TaskDecoratorCollection:
             # allow catalog override
             spec = NodeSpec(
                 identifier=spec.identifier,
+                mode=spec.mode,
                 catalog=catalog or spec.catalog,
                 inputs=spec.inputs,
                 outputs=spec.outputs,
@@ -162,6 +165,9 @@ class TaskDecoratorCollection:
                 error_handlers=handlers,
                 metadata=spec.metadata,
                 base_class=spec.base_class,
+                base_class_path=spec.base_class_path,
+                decorator=spec.decorator,
+                decorator_path=spec.decorator_path,
                 version=spec.version,
             )
             handle = TaskHandle(spec)

--- a/src/aiida_workgraph/executors/test.py
+++ b/src/aiida_workgraph/executors/test.py
@@ -2,6 +2,9 @@ import time
 from aiida.orm import Int
 from aiida_workgraph import task
 from aiida_workgraph.socket_spec import namespace
+from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+
+ArithmeticAddTask = task(ArithmeticAddCalculation)
 
 
 @task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 from aiida_workgraph import task, WorkGraph
-from aiida.orm import Int
 from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
 from typing import Callable, Any, Union
 from aiida.orm import WorkflowNode
@@ -95,30 +94,6 @@ def wg_calcjob(add_code) -> WorkGraph:
     add1 = wg.add_task(ArithmeticAddCalculation, "add1", x=2, y=3, code=add_code)
     add2 = wg.add_task(ArithmeticAddCalculation, "add2", x=4, code=add_code)
     wg.add_link(add1.outputs.sum, add2.inputs["y"])
-    return wg
-
-
-@pytest.fixture
-def wg_workchain(add_code) -> WorkGraph:
-    """A workgraph with workchain."""
-    from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
-
-    wg = WorkGraph(name="test_debug_math")
-    int1 = wg.add_task("workgraph.load_node", "int1", pk=Int(2).store().pk)
-    int2 = wg.add_task("workgraph.load_node", "int2", pk=Int(3).store().pk)
-    code1 = wg.add_task("workgraph.load_code", "code1", pk=add_code.pk)
-    multiply_add1 = wg.add_task(MultiplyAddWorkChain, "multiply_add1", x=Int(4).store())
-    multiply_add2 = wg.add_task(
-        MultiplyAddWorkChain,
-        "multiply_add2",
-        x=Int(2).store(),
-        y=Int(3).store(),
-    )
-    wg.add_link(code1.outputs[0], multiply_add1.inputs["code"])
-    wg.add_link(int1.outputs[0], multiply_add1.inputs["y"])
-    wg.add_link(int2.outputs[0], multiply_add1.inputs["z"])
-    wg.add_link(code1.outputs[0], multiply_add2.inputs["code"])
-    wg.add_link(multiply_add1.outputs[0], multiply_add2.inputs["z"])
     return wg
 
 

--- a/tests/test_calcjob.py
+++ b/tests/test_calcjob.py
@@ -1,4 +1,3 @@
-import pytest
 from aiida_workgraph import WorkGraph, task
 
 
@@ -12,12 +11,5 @@ def test_create_task_from_calcJob(add_code) -> None:
         outputs2 = AddTask(x=outputs1.sum, y=3, code=add_code)
         wg.run()
     assert outputs2.sum.value == 8
-
-
-@pytest.mark.usefixtures("started_daemon_client")
-def test_submit(wg_calcjob: WorkGraph) -> None:
-    """Submit simple calcjob."""
-    wg = wg_calcjob
-    wg.name = "test_submit_calcjob"
-    wg.submit(wait=True)
-    assert wg.tasks.add2.outputs.sum.value == 9
+    assert outputs1._node._spec.mode == "decorator_build"
+    assert outputs1._node.get_executor().callable == ArithmeticAddCalculation

--- a/tests/test_workchain.py
+++ b/tests/test_workchain.py
@@ -1,19 +1,9 @@
-import pytest
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 from aiida_workgraph import task
 
 
-def test_workchain(wg_workchain):
-    """Submit simple calcjob."""
-    wg = wg_workchain
-    wg.name = "test_workchain"
-    wg.run()
-    # print("results: ", results[])
-    assert wg.tasks.multiply_add2.outputs.result.value == 17
-
-
 def test_build_workchain_inputs_outputs():
-    """Submit simple calcjob."""
+    """Run simple workchain."""
 
     node = task(MultiplyAddWorkChain)()._node
     inputs = MultiplyAddWorkChain.spec().inputs
@@ -21,34 +11,26 @@ def test_build_workchain_inputs_outputs():
     ninput = len(inputs.ports) + 1
     assert len(node.inputs) == ninput
     assert len(node.outputs) == 3
+    assert node._spec.mode == "decorator_build"
+    assert node._spec.decorator_path == "aiida_workgraph.decorator.task"
 
 
-@pytest.mark.usefixtures("started_daemon_client")
 def test_build_workchain(add_code):
     """Submit simple calcjob."""
     from aiida.orm import Int
     from aiida_workgraph import WorkGraph
 
     wg = WorkGraph(name="test_debug_math")
-    code1 = wg.add_task("workgraph.load_code", "code1", pk=add_code.pk)
-    multiply_add1 = wg.add_task(
+    wg.add_task(
         MultiplyAddWorkChain,
         "multiply_add1",
         x=Int(4),
         y=Int(2),
         z=Int(3),
+        code=add_code,
     )
-    multiply_add2 = wg.add_task(
-        MultiplyAddWorkChain,
-        "multiply_add2",
-        x=Int(2),
-        y=Int(3),
-    )
-    wg.add_link(code1.outputs[0], multiply_add1.inputs["code"])
-    wg.add_link(code1.outputs[0], multiply_add2.inputs["code"])
-    wg.add_link(multiply_add1.outputs[0], multiply_add2.inputs["z"])
-    wg.submit(wait=True, timeout=100)
-    assert wg.tasks.multiply_add2.outputs.result.value == 17
+    wg.run()
+    assert wg.tasks.multiply_add1.outputs.result.value == 11
     # reload wg
     wg1 = WorkGraph.load(wg.pk)
-    assert wg1.tasks.multiply_add2.outputs.result.value == 17
+    assert wg1.tasks.multiply_add1.get_executor().callable == MultiplyAddWorkChain


### PR DESCRIPTION
- Bump node-graph to 0.3.8
- Use `decorator_build` mode for CalcJob and WorkChain