### PR TITLE
Add `max_depth` to graph task

### DIFF
--- a/docs/gallery/howto/autogen/control-flow.py
+++ b/docs/gallery/howto/autogen/control-flow.py
@@ -21,6 +21,10 @@ Control flow in WorkGraph
 # For this, we need to encapsulate the control flow logic using ``@task.graph``.
 
 from aiida_workgraph import task
+from aiida import load_profile
+
+
+load_profile()
 
 
 @task
@@ -108,7 +112,10 @@ def WhileLoop(n, m):
     return WhileLoop(n=n, m=m)
 
 
-WhileLoop.build(n=4, m=0).to_html()
+wg = WhileLoop.build(n=4, m=0)
+
+wg.to_html()
+
 
 # %%
 #
@@ -118,6 +125,41 @@ WhileLoop.build(n=4, m=0).to_html()
 # .. tip::
 #
 #    If you are using the AiiDA GUI, you can visualize each recursive layer by following down the ``WhileLoop`` tasks.
+#
+# Run the graph:
+
+wg.run()
+print(wg.outputs.result.value)
+
+# sphinx_gallery_start_ignore
+assert wg.outputs.result.value == 4
+# sphinx_gallery_end_ignore
+
+
+# %%
+# Limiting recursion with ``max_depth``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Recursive graphs have a built-in safeguard: a maximum recursion depth. By default this is
+# ``100`` nested calls. If the limit is reached, the engine reports a message and raises
+# ``RecursionError``. Deep recursion is generally discouraged—prefer batching the iteration
+# inside a single task where feasible.
+#
+# You can **raise** the limit if you know your workflow needs more layers:
+#
+# .. code:: python
+#
+#    @task.graph(max_depth=200)
+#    def WhileLoop(n, m):
+#        ...
+#
+# You can also **lower** it deliberately to cap the maximum number of iterations. This is a
+# practical safety brake against runaway or unexpectedly long recursions:
+#
+# .. note::
+#
+#    The reported “call depth” is an *approximation* based on the AiiDA process tree, not the exact same call depth as the recursive call.
+#
 
 # %%
 # Summary

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -135,12 +135,10 @@ class TaskDecoratorCollection:
     @nonfunctional_usage
     def decorator_task(
         identifier: Optional[str] = None,
-        task_type: str = "Normal",
         inputs: Optional[SocketSpec | list] = None,
         outputs: Optional[SocketSpec | list] = None,
         error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
         catalog: str = "Others",
-        store_provenance: bool = True,
     ) -> Callable:
         """Generate a decorator that register a function as a task.
 
@@ -182,7 +180,7 @@ class TaskDecoratorCollection:
         identifier: Optional[str] = None,
         inputs: Optional[SocketSpec | list] = None,
         outputs: Optional[SocketSpec | list] = None,
-        catalog: str = "Others",
+        max_depth: int = 100,
     ) -> Callable:
         """Generate a decorator that register a function as a graph task.
         Attributes:
@@ -193,10 +191,16 @@ class TaskDecoratorCollection:
         """
 
         def decorator(func) -> TaskHandle:
-            from aiida_workgraph.tasks.graph_task import _build_task_nodespec
+            from aiida_workgraph.tasks.graph_task import _build_graph_task_nodespec
 
             handle = TaskHandle(
-                _build_task_nodespec(func, in_spec=inputs, out_spec=outputs)
+                _build_graph_task_nodespec(
+                    func,
+                    identifier=identifier,
+                    in_spec=inputs,
+                    out_spec=outputs,
+                    max_depth=max_depth,
+                )
             )
             handle._func = func
             return handle
@@ -214,7 +218,10 @@ class TaskDecoratorCollection:
             func_decorated = calcfunction(func)
             handle = TaskHandle(
                 _build_aiida_function_nodespec(
-                    func_decorated, in_spec=inputs, out_spec=outputs
+                    func_decorated,
+                    in_spec=inputs,
+                    out_spec=outputs,
+                    error_handlers=error_handlers,
                 )
             )
             handle._func = func_decorated
@@ -233,7 +240,10 @@ class TaskDecoratorCollection:
             func_decorated = workfunction(func)
             handle = TaskHandle(
                 _build_aiida_function_nodespec(
-                    func_decorated, in_spec=inputs, out_spec=outputs
+                    func_decorated,
+                    in_spec=inputs,
+                    out_spec=outputs,
+                    error_handlers=error_handlers,
                 )
             )
             handle._func = func_decorated
@@ -268,6 +278,7 @@ class TaskDecoratorCollection:
     def awaitable(
         inputs: Optional[SocketSpec | list] = None,
         outputs: Optional[SocketSpec | list] = None,
+        error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
     ) -> Callable:
         def decorator(func) -> TaskHandle:
             from aiida_workgraph.tasks.awaitable_tasks import (
@@ -276,7 +287,10 @@ class TaskDecoratorCollection:
 
             handle = TaskHandle(
                 _build_awaitable_function_nodespec(
-                    func, in_spec=inputs, out_spec=outputs
+                    func,
+                    in_spec=inputs,
+                    out_spec=outputs,
+                    error_handlers=error_handlers,
                 )
             )
             handle._func = func
@@ -289,6 +303,7 @@ class TaskDecoratorCollection:
     def monitor(
         inputs: Optional[SocketSpec | list] = None,
         outputs: Optional[SocketSpec | list] = None,
+        error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
     ) -> Callable:
         def decorator(func) -> TaskHandle:
             from aiida_workgraph.tasks.awaitable_tasks import (
@@ -296,7 +311,12 @@ class TaskDecoratorCollection:
             )
 
             handle = TaskHandle(
-                _build_monitor_function_nodespec(func, in_spec=inputs, out_spec=outputs)
+                _build_monitor_function_nodespec(
+                    func,
+                    in_spec=inputs,
+                    out_spec=outputs,
+                    error_handlers=error_handlers,
+                )
             )
             handle._func = func
             return handle

--- a/src/aiida_workgraph/executors/test.py
+++ b/src/aiida_workgraph/executors/test.py
@@ -24,3 +24,13 @@ def sum_diff(x: Int = 0, y: Int = 0, t: Int = 1) -> namespace(sum=Int, diff=Int)
 @task.pythonjob()
 def add_pythonjob(x: int, y: int) -> int:
     return x + y
+
+
+@task.graph
+def Fibonacci(n, a=0, b=1):
+    """Fibonacci sequence."""
+    if n == 0:
+        return a
+    if n == 1:
+        return b
+    return Fibonacci(n=n - 1, a=b, b=add(x=a, y=b).result)

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -1,10 +1,11 @@
 from aiida_workgraph.task import SpecTask
 from aiida.engine import Process
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict
 from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec
 from .function_task import build_callable_nodespec
 from node_graph.executor import RuntimeExecutor
+from node_graph.error_handler import ErrorHandlerSpec
 
 
 class AiiDAFunctionTask(SpecTask):
@@ -87,6 +88,7 @@ def _build_aiida_function_nodespec(
     identifier: Optional[str] = None,
     in_spec: Optional[SocketSpec] = None,
     out_spec: Optional[SocketSpec] = None,
+    error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
 ) -> NodeSpec:
     from aiida_workgraph.utils import inspect_aiida_component_type
 
@@ -98,4 +100,5 @@ def _build_aiida_function_nodespec(
         process_cls=Process,
         in_spec=in_spec,
         out_spec=out_spec,
+        error_handlers=error_handlers,
     )

--- a/src/aiida_workgraph/tasks/awaitable_tasks.py
+++ b/src/aiida_workgraph/tasks/awaitable_tasks.py
@@ -1,11 +1,12 @@
 import asyncio
 from aiida_workgraph.task import SpecTask
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, Dict
 from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec
 from .function_task import build_callable_nodespec
 from aiida_workgraph.socket_spec import namespace
 from node_graph.executor import RuntimeExecutor
+from node_graph.error_handler import ErrorHandlerSpec
 
 
 class AwaitableFunctionTask(SpecTask):
@@ -73,6 +74,7 @@ def _build_awaitable_function_nodespec(
     identifier: Optional[str] = None,
     in_spec: Optional[SocketSpec] = None,
     out_spec: Optional[SocketSpec] = None,
+    error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
 ) -> NodeSpec:
 
     return build_callable_nodespec(
@@ -83,6 +85,7 @@ def _build_awaitable_function_nodespec(
         process_cls=None,
         in_spec=in_spec,
         out_spec=out_spec,
+        error_handlers=error_handlers,
     )
 
 
@@ -91,6 +94,7 @@ def _build_monitor_function_nodespec(
     identifier: Optional[str] = None,
     in_spec: Optional[SocketSpec] = None,
     out_spec: Optional[SocketSpec] = None,
+    error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
 ) -> NodeSpec:
     # defaults for interval/timeout — set on the NAMESPACE (keys = field names)
     add_in = namespace(
@@ -109,4 +113,5 @@ def _build_monitor_function_nodespec(
         out_spec=out_spec,
         add_inputs=add_in,
         add_outputs=add_out,
+        error_handlers=error_handlers,
     )

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -39,6 +39,7 @@ def build_callable_nodespec(
     add_inputs: Optional[SocketSpec | List[str]] = None,
     add_outputs: Optional[SocketSpec | List[str]] = None,
     error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
+    metadata: Optional[dict] = None,
 ) -> NodeSpec:
     """
     - infers function I/O
@@ -70,17 +71,20 @@ def build_callable_nodespec(
         func_out = merge_specs(func_out, add_outputs)
 
     # 4) metadata: keep a record of each contribution
-    meta = {
-        "node_type": node_type,
-        "non_function_inputs": list(
-            set((proc_in and proc_in.fields.keys()) or [])
-            | set((add_inputs and add_inputs.fields.keys()) or [])
-        ),
-        "non_function_outputs": list(
-            set((proc_out and proc_out.fields.keys()) or [])
-            | set((add_outputs and add_outputs.fields.keys()) or [])
-        ),
-    }
+    metadata = metadata or {}
+    metadata.update(
+        {
+            "node_type": node_type,
+            "non_function_inputs": list(
+                set((proc_in and proc_in.fields.keys()) or [])
+                | set((add_inputs and add_inputs.fields.keys()) or [])
+            ),
+            "non_function_outputs": list(
+                set((proc_out and proc_out.fields.keys()) or [])
+                | set((add_outputs and add_outputs.fields.keys()) or [])
+            ),
+        }
+    )
 
     return NodeSpec(
         identifier=identifier or obj.__name__,
@@ -90,5 +94,5 @@ def build_callable_nodespec(
         executor=RuntimeExecutor.from_callable(obj),
         error_handlers=error_handlers,
         base_class=base_class,
-        metadata=meta,
+        metadata=metadata,
     )

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -39,7 +39,7 @@ class GraphTask(SpecTask):
         depth = call_depth_from_node(engine_process.node)
         if depth >= max_depth:
             if depth >= max_depth:
-                raise RecursionError(
+                msg = (
                     f"Graph task '{self.name}' exceeded the recursion safeguard.\n"
                     f"- Current AiiDA process call depth (approx.): {depth}\n"
                     f"- Allowed maximum          :                  {max_depth}\n"
@@ -51,6 +51,8 @@ class GraphTask(SpecTask):
                     f"you can explicitly set a higher limit in your decorator, e.g.:\n"
                     f"    @task.graph(max_depth=200)\n"
                 )
+                engine_process.report(msg)
+                raise RecursionError(msg)
         wg = materialize_graph(
             executor,
             self._spec.inputs,

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -15,22 +15,42 @@ class GraphTask(SpecTask):
     catalog = "builtins"
 
     def execute(self, engine_process, args=None, kwargs=None, var_kwargs=None):
-        from aiida_workgraph.utils import create_and_pause_process
+        from aiida_workgraph.utils import create_and_pause_process, call_depth_from_node
         from aiida_workgraph.engine.workgraph import WorkGraphEngine
         from aiida_workgraph import task, WorkGraph
         from node_graph.utils.graph import materialize_graph
-        from node_graph.node_spec import BaseHandle
+        from aiida_workgraph.task import TaskHandle
 
         executor = RuntimeExecutor(**self.get_executor().to_dict()).callable
+        max_depth = (
+            self.get_metadata()["spec_schema"].get("metadata", {}).get("max_depth", 100)
+        )
         # Cloudpickle doesn’t restore the function’s own name in its globals after unpickling,
         # so any recursive calls would raise NameError. As a temporary workaround, we re-insert
         # the decorated function into its globals under its original name.
         # Downside: this mutates the module globals at runtime, if another symbol with the same name exists,
         # we may introduce hard-to-trace bugs or collisions.
-        if isinstance(executor, BaseHandle) and hasattr(executor, "_func"):
+        if isinstance(executor, TaskHandle) and hasattr(executor, "_func"):
             executor = executor._func
         if executor.__name__ not in executor.__globals__:
-            executor.__globals__[executor.__name__] = task.graph()(executor)
+            executor.__globals__[executor.__name__] = task.graph(max_depth=max_depth)(
+                executor
+            )
+        depth = call_depth_from_node(engine_process.node)
+        if depth >= max_depth:
+            if depth >= max_depth:
+                raise RecursionError(
+                    f"Graph task '{self.name}' exceeded the recursion safeguard.\n"
+                    f"- Current AiiDA process call depth (approx.): {depth}\n"
+                    f"- Allowed maximum          :                  {max_depth}\n"
+                    f"- Process UUID:                               {engine_process.node.uuid}\n\n"
+                    f"Deeply nested process calls (>100) are generally discouraged. "
+                    f"Prefer wrapping iterative logic inside a single task instead of "
+                    f"recursively spawning new graph tasks.\n\n"
+                    f"However, if you are confident that recursion is the right design, "
+                    f"you can explicitly set a higher limit in your decorator, e.g.:\n"
+                    f"    @task.graph(max_depth=200)\n"
+                )
         wg = materialize_graph(
             executor,
             self._spec.inputs,
@@ -61,12 +81,15 @@ class GraphTask(SpecTask):
         return process, state
 
 
-def _build_task_nodespec(
+def _build_graph_task_nodespec(
     obj: Callable,
     identifier: Optional[str] = None,
     in_spec: Optional[SocketSpec] = None,
     out_spec: Optional[SocketSpec] = None,
+    max_depth: int = 100,
 ) -> NodeSpec:
+    # defaults for max depth
+    metadata = {"max_depth": max_depth}
 
     return build_callable_nodespec(
         obj=obj,
@@ -76,4 +99,5 @@ def _build_task_nodespec(
         process_cls=None,
         in_spec=in_spec,
         out_spec=out_spec,
+        metadata=metadata,
     )

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -639,3 +639,12 @@ def get_process_summary(node: orm.ProcessNode | int, data: str = ["outputs"]) ->
         )
         result += f"\n{format_nested_links(nodes_output.nested(), headers=['Outputs', 'PK', 'Type'])}"
     return result
+
+
+def call_depth_from_node(node: str | int | orm.Node) -> int:
+    node = orm.load_node(node) if not isinstance(node, orm.Node) else node
+    depth = 0
+    while getattr(node, "caller", None) is not None:
+        depth += 1
+        node = node.caller
+    return depth

--- a/tests/test_while.py
+++ b/tests/test_while.py
@@ -6,6 +6,11 @@ def add(x, y):
     return x + y
 
 
+@task.graph(max_depth=2)
+def dump_graph():
+    return dump_graph()
+
+
 @task.graph()
 def sum_to_n(n, total, N):
     if n >= N:
@@ -22,6 +27,14 @@ def test_graph_task():
         wg.outputs.result = outputs.result
         wg.run()
         assert wg.outputs.result.value == 10
+
+
+def test_max_depth():
+    """Test the max_depth parameter of the graph task decorator."""
+
+    wg = dump_graph.build()
+    wg.run()
+    assert wg.process.exit_status == 302
 
 
 def test_while_instruction(decorated_add, decorated_multiply, decorated_smaller_than):


### PR DESCRIPTION
Recursive graphs have a built-in safeguard: a maximum recursion depth. By default, this is 100 nested calls. If the limit is reached, the engine reports a message and raises ``RecursionError``. Deep recursion is generally discouraged, and it is preferred to batch the iteration inside a single task where feasible.

Users can **raise** the limit if they know their workflow needs more layers:
```python
@task.graph(max_depth=200)
def WhileLoop(n, m):
```
The reported “call depth” is an *approximation* based on the AiiDA process tree, not the exact same call depth as the recursive call.
