### PR TITLE
Use `is_metadata` for AiiDA process

### DIFF
--- a/docs/gallery/advanced/autogen/context_manager.py
+++ b/docs/gallery/advanced/autogen/context_manager.py
@@ -241,7 +241,9 @@ def generate_random_number(minimum, maximum):
 
 
 def generate_add_multiply_workgraph():
-    with WorkGraph(inputs=spec.namespace(x=Any, y=Any, z=Any)) as wg:
+    with WorkGraph(
+        inputs=spec.namespace(x=Any, y=Any, z=Any), outputs=spec.namespace(result=Any)
+    ) as wg:
         the_sum = add(
             x=wg.inputs.x,
             y=wg.inputs.y,
@@ -257,7 +259,9 @@ def generate_add_multiply_workgraph():
 
 
 with WorkGraph(
-    "AddMultiplyComposed", inputs=spec.namespace(min=Any, max=Any, x=Any, y=Any)
+    "AddMultiplyComposed",
+    inputs=spec.namespace(min=Any, max=Any, x=Any, y=Any),
+    outputs=spec.namespace(result=Any),
 ) as wg:
     random_number = generate_random_number(
         minimum=wg.inputs.min,
@@ -653,10 +657,15 @@ print(f"  Product: {wg2.outputs.product.value}")
 # ----------------
 #
 # Let's now pick up the previous workgraph and extend it by a second addition, leveraging the results of the previous work.
+from node_graph.socket_spec import add_spec_field, SocketSpec
 
 with WorkGraph.load(wg2.pk) as wg3:
     wg3.name = "AddMultiplyContinued"
     wg3.add_input("workgraph.any", name="z")  # introduce a new input socket
+    # also need to update the inputs spec
+    wg3._inputs = add_spec_field(
+        wg3._inputs, "z", SocketSpec(identifier="workgraph.any")
+    )
     wg3.restart()
     new_sum = add(
         x=wg3.tasks.multiply.outputs.result,

--- a/docs/gallery/howto/autogen/remote_job.py
+++ b/docs/gallery/howto/autogen/remote_job.py
@@ -80,6 +80,8 @@ metadata = {
 #
 #    Uncomment the ``custom_scheduler_commands`` line to modify it for your environment.
 
+from typing import Annotated
+
 
 @task
 def multiply(x, y):
@@ -87,7 +89,9 @@ def multiply(x, y):
 
 
 @task.graph
-def RemoteAddLocalMultiply(x: int, y: int, computer: str, metadata: dict) -> int:
+def RemoteAddLocalMultiply(
+    x: int, y: int, computer: str, metadata: Annotated[dict, add.inputs.metadata]
+) -> int:
     the_sum = add(x=x, y=y, computer=computer, metadata=metadata).result
     return multiply(x=the_sum, y=4)  # this will run locally
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "scipy",
-    "node-graph>=0.3.8",
+    "node-graph>=0.3.9",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",
     "aiida-shell~=0.8",
-    "aiida-pythonjob>=0.4.0",
+    "aiida-pythonjob>=0.4.1",
     "jsonschema",
 ]
 

--- a/src/aiida_workgraph/socket_spec.py
+++ b/src/aiida_workgraph/socket_spec.py
@@ -62,6 +62,7 @@ class SpecInferAPI(BaseSpecInferAPI):
                 fields=fields,
                 meta=SocketSpecMeta(
                     required=required_here,
+                    is_metadata=getattr(port, "is_metadata", False),
                     call_role=("kwargs" if role == "input" else None),
                 ),
             )
@@ -82,6 +83,7 @@ class SpecInferAPI(BaseSpecInferAPI):
             identifier=ident,
             meta=SocketSpecMeta(
                 required=required_here,
+                is_metadata=getattr(port, "is_metadata", False),
                 call_role=("kwargs" if role == "input" else None),
             ),
         )

--- a/src/aiida_workgraph/tasks/subgraph_task.py
+++ b/src/aiida_workgraph/tasks/subgraph_task.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec
 from aiida_workgraph.task import SpecTask
 
@@ -74,21 +73,6 @@ def _build_subgraph_task_nodespec(
     name: str | None = None,
 ) -> NodeSpec:
     from node_graph.executor import SafeExecutor
-    from aiida_workgraph.orm.mapping import type_mapping
-
-    # mirror IO from the child graph
-    if graph._inputs is None:
-        in_spec = SocketSpec.from_namespace(
-            graph.graph_inputs.inputs, type_mapping=type_mapping
-        )
-    else:
-        in_spec = graph._inputs
-    if graph._outputs is None:
-        out_spec = SocketSpec.from_namespace(
-            graph.graph_outputs.inputs, type_mapping=type_mapping
-        )
-    else:
-        out_spec = graph._outputs
 
     meta = {
         "node_type": "SubGraph",
@@ -96,8 +80,8 @@ def _build_subgraph_task_nodespec(
 
     return NodeSpec(
         identifier=name or graph.name,
-        inputs=in_spec,
-        outputs=out_spec,
+        inputs=graph._inputs,
+        outputs=graph._outputs,
         executor=SafeExecutor.from_graph(graph),
         base_class=SubGraphTask,
         metadata=meta,

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -44,9 +44,10 @@ def test_task_update_ctx(decorated_add: Callable) -> None:
     wg = WorkGraph(name="test_node_set_ctx")
     add1 = wg.add_task(decorated_add, "add1", x=Float(2).store(), y=Float(3).store())
     with pytest.raises(
-        AttributeError, match="TaskSocketNamespace: add1.outputs has no attribute"
+        AttributeError,
+        match="TaskSocketNamespace: 'add1.outputs' has no sub-socket 'abc'",
     ):
-        wg.update_ctx({"sum": add1.outputs.resul})
+        wg.update_ctx({"sum": add1.outputs.abc})
     wg.update_ctx({"sum": add1.outputs.result})
     add2 = wg.add_task(decorated_add, "add2", x=add1.outputs[0], y=wg.ctx.sum)
     wg.run()

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -1,28 +1,30 @@
-from aiida_workgraph import WorkGraph
+from aiida_workgraph import WorkGraph, namespace
 from typing import Callable
 from aiida import orm
 
 
-def test_inputs_outptus(wg_task: WorkGraph) -> None:
+def test_inputs_outptus() -> None:
     """Test the inputs and outputs of the WorkGraph."""
     wg = WorkGraph(name="test_inputs_outptus")
-    wg_task.inputs = {"x": 1, "y": 2}
-    wg_task.outputs.diff = wg_task.tasks.sumdiff1.outputs.diff
-    wg_task.outputs.sum = wg_task.tasks.sumdiff2.outputs.sum
-    task1 = wg.add_task(wg_task, name="add1")
-    assert len(task1.inputs) == 3
-    assert len(task1.outputs) == 4
-    assert "x" in task1.inputs
-    assert "y" in task1.inputs
-    assert "sum" in task1.outputs
+    sub_wg = WorkGraph(
+        name="sub_wg",
+        inputs=namespace(x=int, y=int),
+        outputs=namespace(sum=int, diff=int),
+    )
+    sub_wg_task = wg.add_task(sub_wg, name="sub_wg")
+    assert len(sub_wg_task.inputs) == 3
+    assert len(sub_wg_task.outputs) == 4
+    assert "x" in sub_wg_task.inputs
+    assert "y" in sub_wg_task.inputs
+    assert "sum" in sub_wg_task.outputs
 
 
 def test_inputs_outptus_auto_generate(wg_task: WorkGraph) -> None:
     """Test the inputs and outputs of the WorkGraph."""
     wg = WorkGraph(name="test_inputs_outptus")
     # this will generate the group inputs and outputs automatically
-    wg_task.generate_inputs()
-    wg_task.generate_outputs()
+    wg_task.expose_inputs()
+    wg_task.expose_outputs()
     task1 = wg.add_task(wg_task, name="add1")
     ninput = 0
     for sub_task in wg_task.tasks:

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -77,6 +77,13 @@ def test_save_load(wg_task, decorated_add):
         wg2.tasks.add2.get_executor().callable == wg.tasks.add2.get_executor().callable
     )
     assert wg.tasks.add2.inputs.metadata._value == wg2.tasks.add2.inputs.metadata._value
+    # metadata is also loaded
+    assert (
+        wg2.tasks.add2.inputs.metadata.options.resources.value[
+            "num_mpiprocs_per_machine"
+        ]
+        == 2
+    )
     # TODO, the following code is not working
     # wg2.save()
     # assert wg2.tasks.add1.executor == decorated_add

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -276,7 +276,9 @@ def test_calling_workgraph_in_context_manager():
     def add(x, y):
         return x + y
 
-    with WorkGraph(inputs=spec.namespace(x=Any, y=Any)) as wg1:
+    with WorkGraph(
+        inputs=spec.namespace(x=Any, y=Any), outputs=spec.namespace(sum=Any)
+    ) as wg1:
         add_outputs = add(x=wg1.inputs.x, y=wg1.inputs.y)  # add
         add1_outputs = add(x=add_outputs.result, y=1)
         wg1.outputs.sum = add1_outputs.result


### PR DESCRIPTION
Read `is_metadata` from AiiDA process' spec, and do not serialize the sockets which are labeled with `is_metadata`.

Base on these PRs: 
https://github.com/scinode/node-graph/pull/98
https://github.com/aiidateam/aiida-pythonjob/pull/47