### PR TITLE
Validate required inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "scipy",
-    "node-graph>=0.3.9",
+    "node-graph>=0.3.10",
     "node-graph-widget>=0.0.5",
     "aiida-core~=2.6",
     "cloudpickle",

--- a/src/aiida_workgraph/socket_spec.py
+++ b/src/aiida_workgraph/socket_spec.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from typing import Any, Tuple
 from node_graph.socket_spec import (
     SocketSpecMeta,
+    SocketSpecSelect,
     SocketSpec,
     BaseSocketSpecAPI,
     BaseSpecInferAPI,
@@ -12,6 +13,19 @@ from aiida.engine import Process
 from aiida.engine.processes.process_spec import ProcessSpec
 from plumpy.ports import Port, PortNamespace
 from .socket import TaskSocketNamespace
+
+
+__all__ = [
+    "SocketSpecAPI",
+    "SpecInferAPI",
+    "socket",
+    "namespace",
+    "dynamic",
+    "validate_socket_data",
+    "infer_specs_from_callable",
+    "from_aiida_process",
+    "SocketSpecSelect",
+]
 
 
 class SocketSpecAPI(BaseSocketSpecAPI):
@@ -133,7 +147,6 @@ class SpecInferAPI(BaseSpecInferAPI):
 socket = SocketSpecAPI.socket
 namespace = SocketSpecAPI.namespace
 dynamic = SocketSpecAPI.dynamic
-expose = SocketSpecAPI.expose
 validate_socket_data = SocketSpecAPI.validate_socket_data
 infer_specs_from_callable = SpecInferAPI.infer_specs_from_callable
 from_aiida_process = SpecInferAPI.from_aiida_process

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -108,7 +108,16 @@ class WorkGraph(node_graph.NodeGraph):
                 continue
             missing_inputs.extend(self.find_missing_inputs(task.inputs))
         if missing_inputs:
-            raise ValueError(f"Missing required inputs: {missing_inputs}")
+            bullets = "\n".join(f"  • {p}" for p in sorted(missing_inputs))
+            raise ValueError(
+                "Missing required inputs:\n"
+                f"{bullets}\n\n"
+                "How to fix:\n"
+                "  1) Provide these values (at build time or by linking from upstream task outputs).\n"
+                "  2) If some are intentionally unused, exclude them from the namespace at the call site, e.g.:\n"
+                '     Annotated[dict, some_task.inputs, SocketSpecSelect(exclude=["pw.structure", ...])]\n\n'
+                "Note: exclude paths are relative to the task's input namespace (e.g. 'pw.structure')."
+            )
 
     def find_missing_inputs(self, socket: BaseSocket) -> List[str]:
         """Check if all required inputs are provided."""

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -16,6 +16,7 @@ from .registry import RegistryHub, registry_hub
 from node_graph.analysis import NodeGraphAnalysis
 from node_graph.config import BUILTIN_NODES
 from node_graph.collection import NodeCollection
+from node_graph.socket import BaseSocket, NodeSocketNamespace
 from aiida_workgraph.orm.mapping import type_mapping
 from aiida_workgraph.socket_spec import SocketSpecAPI
 from node_graph.error_handler import ErrorHandlerSpec
@@ -96,10 +97,43 @@ class WorkGraph(node_graph.NodeGraph):
         return inputs
 
     def check_before_run(self) -> bool:
+        self.check_required_inputs()
+        self.check_modified_tasks()
+
+    def check_required_inputs(self) -> None:
+        """Check if all required inputs are provided."""
+        missing_inputs = self.find_missing_inputs(self.inputs)
+        for task in self.tasks:
+            if task.name in BUILTIN_NODES:
+                continue
+            missing_inputs.extend(self.find_missing_inputs(task.inputs))
+        if missing_inputs:
+            raise ValueError(f"Missing required inputs: {missing_inputs}")
+
+    def find_missing_inputs(self, socket: BaseSocket) -> List[str]:
+        """Check if all required inputs are provided."""
+        missing_inputs = []
+        for sub_socket in socket:
+            if isinstance(sub_socket, NodeSocketNamespace):
+                missing_inputs.extend(self.find_missing_inputs(sub_socket))
+            else:
+                if (
+                    sub_socket._metadata.required
+                    and sub_socket.value is None
+                    and len(sub_socket._links) == 0
+                ):
+                    missing_inputs.append(
+                        f"{sub_socket._node.name}.{sub_socket._scoped_name}"
+                    )
+        return missing_inputs
+
+    def check_modified_tasks(self) -> None:
+        """Check if there are modified tasks compared to the existing process.
+        If there are modified tasks, reset them and their descendants to be re-run.
+        """
         existing_process = self._load_existing_process()
         if existing_process:
             diffs = self.analyzer.compare_graphs(existing_process, self)
-            print("diffs:", diffs)
             self.reset_tasks(diffs["modified_nodes"])
 
     def run(

--- a/tests/test_group_inputs_outputs.py
+++ b/tests/test_group_inputs_outputs.py
@@ -34,7 +34,7 @@ def test_load_from_db():
     from aiida_workgraph.tasks.builtins import GraphLevelTask
 
     wg = WorkGraph("test_load_from_db", inputs=spec.namespace(x=Any, y=Any, z=Any))
-    wg.inputs = {"x": 1, "y": 2}
+    wg.inputs = {"x": 1, "y": 2, "z": 1}
     wg.save()
     wg2 = WorkGraph.load(wg.pk)
     wg2.restart()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,6 +17,6 @@ def test_validate_required_inputs():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Missing required inputs: ['graph_inputs.b.y', 'add1.y']"),
+        match=re.escape("Missing required inputs:"),
     ):
         my_graph.run(a=1, b={"x": 1})

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,22 @@
+from aiida_workgraph import task, namespace
+from typing import Annotated
+import pytest
+import re
+
+
+@task
+def add(x, y):
+    return x + y
+
+
+def test_validate_required_inputs():
+    @task.graph()
+    def my_graph(a, b: Annotated[dict, namespace(x=int, y=int)]):
+        add(a, b["x"])
+        add(a)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Missing required inputs: ['graph_inputs.b.y', 'add1.y']"),
+    ):
+        my_graph.run(a=1, b={"x": 1})

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -60,7 +60,13 @@ def test_save_load(wg_task, decorated_add):
             },
         }
     }
-    wg.add_task(ArithmeticAddCalculation, name="add2", x=4, metadata=metadata)
+    wg.add_task(
+        ArithmeticAddCalculation,
+        name="add2",
+        x=4,
+        y=wg.tasks.add1.outputs.result,
+        metadata=metadata,
+    )
     wg.name = "test_save_load"
     wg.save()
     assert wg.process.process_state.value.upper() == "CREATED"


### PR DESCRIPTION
- Validate the inputs for graph-level inputs and all tasks
- One special case for `ShellJob` Task, in AiiDA `ShellJob` process, the `code` input is required, however, this `code` input can be built on-the-fly during execution of the `ShellJob` task from the `command` input, so we mark it as `required=False`.