### PR TITLE
Use `call_link_label` to set task name

### DIFF
--- a/docs/gallery/howto/autogen/remote_job.py
+++ b/docs/gallery/howto/autogen/remote_job.py
@@ -59,6 +59,7 @@ print('\nResult: ', wg.outputs.result.value)
 # * **Outputs:** In addition to your function's return value (available as ``.result`` by default), the task provides comprehensive outputs, such as ``remote_folder`` (a reference to the job's directory on the remote computer).
 
 # %%
+# .. _pythonjob_metadata:
 # Prepare Python environment on remote computer
 # ---------------------------------------------
 #
@@ -90,8 +91,8 @@ def multiply(x, y):
 
 
 @task.graph
-def RemoteAddLocalMultiply(x: int, y: int, computer: str, metadata: Annotated[dict, add.inputs.metadata]) -> int:
-    the_sum = add(x=x, y=y, computer=computer, metadata=metadata).result
+def RemoteAddLocalMultiply(x: int, y: int, computer: str, add_metadata: Annotated[dict, add.inputs.metadata]) -> int:
+    the_sum = add(x=x, y=y, computer=computer, metadata=add_metadata).result
     return multiply(x=the_sum, y=4)  # this will run locally
 
 
@@ -99,7 +100,7 @@ wg = RemoteAddLocalMultiply.build(
     x=2,
     y=3,
     computer='localhost',
-    metadata=metadata,
+    add_metadata=metadata,
 )
 wg.run()
 

--- a/docs/gallery/howto/autogen/set_task_metadata.py
+++ b/docs/gallery/howto/autogen/set_task_metadata.py
@@ -1,0 +1,94 @@
+"""
+Set task metadata
+=================
+
+By default, tasks are named after their function or process class name.
+When a workflow becomes complex, or when the same task is used multiple times, giving tasks custom names and descriptions can greatly improve clarity.
+
+This example shows how to set three useful metadata fields on tasks:
+
+- ``call_link_label``: the **task name** in the WorkGraph, and the **link label** shown in the provenance visualization.
+- ``label``: the **process label** stored on the AiiDA process.
+- ``description``: a **human friendly description** stored on the AiiDA process.
+
+We also show how to query the provenance by these fields.
+
+.. note::
+
+   For ``CalcJob`` and ``PythonJob`` tasks there are more metadata options.
+   Please refer to the section on :ref:`PythonJob metadata <pythonjob_metadata>` and the `CalcJob options <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/calculations/usage.html#options>`_ for more details.
+
+"""
+# %%
+# Here's an example:
+
+from aiida import load_profile
+from aiida_workgraph import task
+
+load_profile()
+
+
+@task
+def add(x, y):
+    return x + y
+
+
+@task
+def multiply(x, y):
+    return x * y
+
+
+@task.graph()
+def add_and_multiply(x, y, z):
+    sum_result = add(
+        x,
+        y,
+        metadata={
+            'call_link_label': 'my_add',
+            'label': 'AdditionStep',
+            'description': 'Compute x + y and store it as an intermediate result.',
+        },
+    ).result
+
+    product_result = multiply(
+        sum_result,
+        z,
+        metadata={
+            'call_link_label': 'my_multiply',
+            'label': 'MultiplicationStep',
+            'description': 'Multiply the sum by z to produce the final result.',
+        },
+    ).result
+
+    return product_result
+
+
+# Build and visualize the graph
+wg = add_and_multiply.build(x=1, y=2, z=3)
+wg.to_html()
+
+# %%
+# As you can see in the visualization, the task are now labeled "my_add" and "my_multiply" instead of the default function names.
+#
+# Run the workflow:
+
+wg.run()
+
+
+# %%
+# Query provenance by label or description
+# ----------------------------------------
+# You can later find these processes by their metadata.
+from aiida import orm
+
+qb = orm.QueryBuilder()
+qb.append(
+    orm.ProcessNode,
+    filters={'label': {'==': 'MultiplicationStep'}},
+    project=['uuid', 'label', 'description'],
+)
+matches = qb.all()
+
+print(f"Found {len(matches)} process node(s) labeled 'MultiplicationStep'")
+for uuid, label, description in matches:
+    print(f'- {uuid} | {label} | {description}')

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -19,6 +19,7 @@ This section contains a collection of HowTos for various topics.
    autogen/monitor
    autogen/control_task_execution_order
    autogen/limit_concurrent
+   autogen/set_task_metadata
    autogen/error_resistant
    cli
    control

--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -333,7 +333,11 @@ class TaskHandle(BaseHandle):
                 '  2) Move shared logic into a plain Python helper function and call that.'
             )
 
-        return super().__call__(*args, **kwargs)
+        outputs = super().__call__(*args, **kwargs)
+        # if "metadata.call_link_label" is set, use it as the name of the task
+        if outputs._node.inputs.metadata.call_link_label.value is not None:
+            outputs._node.name = outputs._node.inputs.metadata.call_link_label.value
+        return outputs
 
     def run(self, /, *args, **kwargs):
         graph = self.build(*args, **kwargs)

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -31,7 +31,6 @@ class AiiDAFunctionTask(SpecTask):
             _, process = run_get_node(executor, **kwargs)
         else:
             _, process = run_get_node(executor, **kwargs, **var_kwargs)
-        process.label = self.name
 
         return process, 'FINISHED'
 
@@ -64,7 +63,6 @@ class AiiDAProcessTask(SpecTask):
         else:
             process = engine_process.submit(executor, **kwargs)
             state = 'RUNNING'
-        process.label = self.name
 
         return process, state
 

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -43,6 +43,22 @@ def build_callable_nodespec(
 
     # 1) infer from the callable (keep a snapshot before augmentation)
     func_in, func_out = infer_specs_from_callable(obj, in_spec, out_spec)
+    # "metadata" is reserved for AiiDA process, so raise error if user tries to use it
+    if 'metadata' in func_in.fields:
+        fn = getattr(obj, '__name__', 'the task function')
+        raise ValueError(
+            "Invalid input name: 'metadata'\n"
+            "Reason: In AiiDA, 'metadata' is reserved for process-level settings "
+            '(e.g., call_link_label, description) and cannot be used as a task input.\n\n'
+            f'How to fix: Rename the argument in {fn} to something else, e.g.: task_metadata.\n\n'
+            'Example:\n'
+            '    # before\n'
+            f'    def {fn}(metadata: dict, x: int):\n'
+            '        ...\n\n'
+            '    # after\n'
+            f'    def {fn}(task_metadata: dict, x: int):\n'
+            '        ...\n'
+        )
 
     # 2) process-contributed I/O (if any)
     proc_in = proc_out = None

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -75,7 +75,6 @@ class GraphTask(SpecTask):
         else:
             process = engine_process.submit(WorkGraphEngine, **inputs)
             state = 'RUNNING'
-        process.label = self.name
 
         return process, state
 

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -4,6 +4,7 @@ from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec
 from .function_task import build_callable_nodespec
 from node_graph.executor import RuntimeExecutor
+from aiida.engine import Process
 
 
 class GraphTask(SpecTask):
@@ -88,13 +89,17 @@ def _build_graph_task_nodespec(
 ) -> NodeSpec:
     # defaults for max depth
     metadata = {'max_depth': max_depth}
+    # We use Process as the process class here, so that the task inherits the metadata
+    # inputs from the base Process class, such as 'call_link_label'.
+    # While the actual process class will be the WorkGraphEngine,
+    # which is set at runtime in the execute() method
 
     return build_callable_nodespec(
         obj=obj,
         node_type='GRAPH',
         base_class=GraphTask,
         identifier=identifier,
-        process_cls=None,
+        process_cls=Process,
         in_spec=in_spec,
         out_spec=out_spec,
         metadata=metadata,

--- a/src/aiida_workgraph/tasks/pythonjob_tasks.py
+++ b/src/aiida_workgraph/tasks/pythonjob_tasks.py
@@ -166,7 +166,6 @@ class PythonJobTask(BaseSerializablePythonTask):
             process = engine_process.submit(PythonJob, **inputs)
             state = 'RUNNING'
 
-        process.label = self.name
         return process, state
 
 
@@ -212,7 +211,6 @@ class PyFunctionTask(BaseSerializablePythonTask):
                 process = engine_process.submit(PyFunction, **inputs)
                 state = 'RUNNING'
 
-            process.label = self.name
             return process, state
         else:
             # Make sure it's process_function-decorated
@@ -231,7 +229,6 @@ class PyFunctionTask(BaseSerializablePythonTask):
             else:
                 _, process = run_get_node(func, **kwargs, **var_kwargs)
 
-            process.label = self.name
             return process, 'FINISHED'
 
 
@@ -275,7 +272,6 @@ class MonitorFunctionTask(BaseSerializablePythonTask):
         else:
             process = engine_process.submit(MonitorPyFunction, **inputs)
             state = 'RUNNING'
-        process.label = self.name
         return process, state
 
 

--- a/src/aiida_workgraph/tasks/shelljob_task.py
+++ b/src/aiida_workgraph/tasks/shelljob_task.py
@@ -97,7 +97,6 @@ class ShellJobTask(SpecTask):
         else:
             process = engine_process.submit(ShellJob, **kwargs)
             state = 'RUNNING'
-        process.label = self.name
         return process, state
 
 

--- a/src/aiida_workgraph/tasks/subgraph_task.py
+++ b/src/aiida_workgraph/tasks/subgraph_task.py
@@ -67,7 +67,6 @@ class SubGraphTask(SpecTask):
         else:
             process = engine_process.submit(WorkGraphEngine, **inputs)
             state = 'RUNNING'
-        process.label = self.name
 
         return process, state
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -170,7 +170,7 @@ def test_decorators_graph_args(task_graph_task) -> None:
     # assert task_graph_task.identifier == "add_multiply_group"
     n = task_graph_task._spec.to_node()
     assert n.args_data['args'] == []
-    assert n.args_data['kwargs'] == ['a', 'b']
+    assert n.args_data['kwargs'] == ['a', 'b', 'metadata']
     assert n.args_data['var_args'] is None
     assert n.args_data['var_kwargs'] == 'c'
     assert set(n.get_output_names()) == set(['_outputs', '_wait'])

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -91,7 +91,6 @@ def test_decorator(fixture_localhost, python_executable_path):
     assert wg.tasks.multiply1.outputs.result.value.value == 9
     # process_label and label
     assert wg.tasks.add1.node.process_label == 'PythonJob<add1>'
-    assert wg.tasks.add1.node.label == 'add1'
 
 
 def test_PythonJob_kwargs(fixture_localhost, python_executable_path):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -312,3 +312,13 @@ def test_call_link_label_as_name() -> None:
         assert sum4._node.name == 'my_multiply_add'
         sum5 = test_graph(metadata={'call_link_label': 'my_graph'})
         assert sum5._node.name == 'my_graph'
+
+
+def test_metadata_can_not_be_used_as_function_argument(decorated_add) -> None:
+    """Test that metadata can not be used as a function argument."""
+
+    with pytest.raises(ValueError, match="Invalid input name: 'metadata'"):
+
+        @task
+        def myfunc(x, y, metadata=None):
+            return x + y

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -279,3 +279,30 @@ def test_call_task_inside_task():
         wg.run()
         assert result._node.process.exit_status == 323
         assert 'Invalid nested task call.' in result._node.process.exit_message
+
+
+def test_call_link_label_as_name() -> None:
+    """Test that the call_link_label is used as the name of the task."""
+    from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+    from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
+
+    @task()
+    def add(x, y):
+        return x + y
+
+    @task.calcfunction()
+    def add_calcfunction(x, y):
+        return x + y
+
+    AddTask = task()(ArithmeticAddCalculation)
+    MultiplyAddTask = task()(MultiplyAddWorkChain)
+
+    with WorkGraph('test_call_link_label_as_name'):
+        sum1 = add(1, 2, metadata={'call_link_label': 'my_add'})
+        assert sum1._node.name == 'my_add'
+        sum2 = add_calcfunction(3, 4, metadata={'call_link_label': 'my_add_calc'})
+        assert sum2._node.name == 'my_add_calc'
+        sum3 = AddTask(x=5, y=6, metadata={'call_link_label': 'my_add_calcjob'})
+        assert sum3._node.name == 'my_add_calcjob'
+        sum4 = MultiplyAddTask(x=1, y=2, z=3, metadata={'call_link_label': 'my_multiply_add'})
+        assert sum4._node.name == 'my_multiply_add'

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -294,6 +294,10 @@ def test_call_link_label_as_name() -> None:
     def add_calcfunction(x, y):
         return x + y
 
+    @task.graph()
+    def test_graph():
+        pass
+
     AddTask = task()(ArithmeticAddCalculation)
     MultiplyAddTask = task()(MultiplyAddWorkChain)
 
@@ -306,3 +310,5 @@ def test_call_link_label_as_name() -> None:
         assert sum3._node.name == 'my_add_calcjob'
         sum4 = MultiplyAddTask(x=1, y=2, z=3, metadata={'call_link_label': 'my_multiply_add'})
         assert sum4._node.name == 'my_multiply_add'
+        sum5 = test_graph(metadata={'call_link_label': 'my_graph'})
+        assert sum5._node.name == 'my_graph'


### PR DESCRIPTION
This PR provides a way to set the name of the task. The `call_link_label` is a built-in metadata input for the AiiDA process.
In WorkGraph, `call_link_label` is set to the same as the name of the task. In verse, when the user sets the `call_link_label`, we use it as the name of the task.
```python
sum1 = add(x, y, metadata={"call_link_label": "my_add"}).result
```

Also check that `metadata` is not used as an input argument of the function, because it is reserved by AiiDA.

## Docs
Add a new section: `Set task metadata`

Here is the preview: https://aiida-workgraph--698.org.readthedocs.build/en/698/howto/autogen/set_task_metadata.html
