### PR TITLE
Fix loading process outputs

### DIFF
--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -137,7 +137,7 @@ class Task(GraphNode):
                 self.set_outputs_from_data_node(node)
 
     def set_outputs_from_process_node(self, node: aiida.orm.ProcessNode) -> None:
-        from aiida_workgraph.utils import get_nested_dict
+        from aiida_workgraph.utils import resolve_node_link_managers
 
         # if the node is finished ok, update the output sockets
         # note the task.state may not be the same as the node.process_state
@@ -145,12 +145,7 @@ class Task(GraphNode):
         # even if the node.is_finished_ok is True
         self.process = node
         if node.is_finished_ok:
-            # update the output sockets
-            for socket in self.outputs:
-                if socket._identifier == 'workgraph.namespace':
-                    socket._value = get_nested_dict(node.outputs, socket._name, default=None)
-                else:
-                    socket.value = get_nested_dict(node.outputs, socket._name, default=None)
+            self.outputs._set_socket_value(resolve_node_link_managers(node.outputs))
 
     def set_outputs_from_data_node(self, node: aiida.orm.Data) -> None:
         self.outputs[0].value = node

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -308,7 +308,7 @@ class WorkGraph(node_graph.NodeGraph):
         of the tasks that are outgoing from the process node. This includes updating the state of process nodes
         linked to the current process, and data nodes linked to the current process.
         """
-        from aiida_workgraph.utils import get_processes_latest, get_nested_dict
+        from aiida_workgraph.utils import get_processes_latest, resolve_node_link_managers
 
         if self.process is None:
             return
@@ -326,12 +326,7 @@ class WorkGraph(node_graph.NodeGraph):
             self.widget.states = states
 
         if self.process.is_finished_ok:
-            # update the output sockets
-            for socket in self.outputs:
-                if socket._identifier == 'workgraph.namespace':
-                    socket._value = get_nested_dict(self.process.outputs, socket._name, default=None)
-                else:
-                    socket.value = get_nested_dict(self.process.outputs, socket._name, default=None)
+            self.outputs._set_socket_value(resolve_node_link_managers(self.process.outputs))
 
     @property
     def pk(self) -> Optional[int]:


### PR DESCRIPTION
Fix #700 

- first,  use `resolve_node_link_managers` to get a dict representation of the node outputs
- then, set the dict as the output Socket value, and the Socket will handle dynamic/namespace automatically. 