### PR TITLE
Update task and link names when using `call_link_label`

### DIFF
--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -331,7 +331,12 @@ class TaskHandle(BaseHandle):
         outputs = super().__call__(*args, **kwargs)
         # if "metadata.call_link_label" is set, use it as the name of the task
         if outputs._node.inputs.metadata.call_link_label.value is not None:
+            graph = outputs._graph
             outputs._node.name = outputs._node.inputs.metadata.call_link_label.value
+            # update the names of tasks and links collections in the graph
+            graph.tasks._items = {node.name: node for node in graph.tasks._items.values()}
+            graph.links._items = {link.name: link for link in graph.links._items.values()}
+
         return outputs
 
     def run(self, /, *args, **kwargs):

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -24,6 +24,8 @@ class GraphTask(SpecTask):
 
         executor = RuntimeExecutor(**self.get_executor().to_dict()).callable
         max_depth = self.get_metadata()['spec_schema'].get('metadata', {}).get('max_depth', 100)
+        metadata = kwargs.pop('metadata', {}) if kwargs else {}
+        metadata.setdefault('call_link_label', self.name)
         # Cloudpickle doesn’t restore the function’s own name in its globals after unpickling,
         # so any recursive calls would raise NameError. As a temporary workaround, we re-insert
         # the decorated function into its globals under its original name.
@@ -61,7 +63,7 @@ class GraphTask(SpecTask):
             var_kwargs=var_kwargs,
         )
         wg.parent_uuid = engine_process.node.uuid
-        inputs = wg.to_engine_inputs(metadata={'call_link_label': self.name})
+        inputs = wg.to_engine_inputs(metadata=metadata)
         if self.action == 'PAUSE':
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -301,11 +301,13 @@ def test_call_link_label_as_name() -> None:
     AddTask = task()(ArithmeticAddCalculation)
     MultiplyAddTask = task()(MultiplyAddWorkChain)
 
-    with WorkGraph('test_call_link_label_as_name'):
+    with WorkGraph('test_call_link_label_as_name') as wg:
         sum1 = add(1, 2, metadata={'call_link_label': 'my_add'})
         assert sum1._node.name == 'my_add'
-        sum2 = add_calcfunction(3, 4, metadata={'call_link_label': 'my_add_calc'})
+        sum2 = add_calcfunction(3, sum1.result, metadata={'call_link_label': 'my_add_calc'})
         assert sum2._node.name == 'my_add_calc'
+        # the link name should also be updated
+        assert 'my_add.result -> my_add_calc.y' in wg.links
         sum3 = AddTask(x=5, y=6, metadata={'call_link_label': 'my_add_calcjob'})
         assert sum3._node.name == 'my_add_calcjob'
         sum4 = MultiplyAddTask(x=1, y=2, z=3, metadata={'call_link_label': 'my_multiply_add'})


### PR DESCRIPTION
Fix #702 

Update the names in the link and task collections after changing the name of the task.