### PR TITLE
Support loading of a WorkGraph via its uuid

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -392,22 +392,23 @@ class WorkGraph(node_graph.NodeGraph):
         return nt
 
     @classmethod
-    def load(cls, pk: int | aiida.orm.ProcessNode) -> Optional['WorkGraph']:
+    def load(cls, pk: int | str | aiida.orm.ProcessNode) -> Optional['WorkGraph']:
         """
         Load WorkGraph from the process node with the given primary key.
 
         Args:
-            pk (int): The primary key of the process node.
+            pk (int, str, orm.ProcessNode): The primary key or uuid of the process node,
+                or the process node itself.
         """
         from aiida_workgraph.orm.workgraph import WorkGraphNode
         from aiida_workgraph.utils import load_workgraph_data
 
-        if isinstance(pk, int):
+        if isinstance(pk, (int, str)):
             process = aiida.orm.load_node(pk)
         elif isinstance(pk, aiida.orm.ProcessNode):
             process = pk
         else:
-            raise ValueError(f'Invalid pk type: {type(pk)}, requires int or ProcessNode.')
+            raise ValueError(f'Invalid pk type: {type(pk)}, requires int, str or ProcessNode.')
         if not isinstance(process, WorkGraphNode):
             raise ValueError(f'Process {pk} is not a WorkGraph')
         wgdata = load_workgraph_data(process)

--- a/tests/test_workgraph.py
+++ b/tests/test_workgraph.py
@@ -89,6 +89,7 @@ def test_save_load(wg_task, decorated_add):
     assert wg.process.process_state.value.upper() == 'CREATED'
     assert wg.process.process_label == 'WorkGraph<test_save_load>'
     assert wg.process.label == 'test_save_load'
+
     wg2 = WorkGraph.load(wg.process.pk)
     assert len(wg.tasks) == len(wg2.tasks)
     # the executor of the decorated task is pickled,
@@ -104,6 +105,17 @@ def test_save_load(wg_task, decorated_add):
     # wg2.save()
     # assert wg2.tasks.add1.executor == decorated_add
     # remove the extra, will raise an error
+
+    # Check that it also works for the uuid
+    wg3 = WorkGraph.load(wg.process.uuid)
+    assert len(wg.tasks) == len(wg3.tasks)
+
+    assert wg3.tasks.add1.get_executor().callable == UnavailableExecutor
+
+    assert wg3.tasks.add2.get_executor().callable == wg.tasks.add2.get_executor().callable
+    assert wg.tasks.add2.inputs.metadata._value == wg3.tasks.add2.inputs.metadata._value
+
+    assert wg3.tasks.add2.inputs.metadata.options.resources.value['num_mpiprocs_per_machine'] == 2
 
 
 def test_load_failure(create_process_node):


### PR DESCRIPTION
@superstar54 As discussed


I was just wondering whether we should rename the input argument `pk` as this is not fully consistent now. Nonetheless, it was already inconsistent before as a `ProcessNode` could also be provided for the `pk` argument. Something more general could be `identifier`. However, this would be backwards incompatible in case someone explicitly specifies the keyword. 

Let me not what you think @superstar54. I don't have a strong opinion at the moment, so happy to adjust it