### PR TITLE
Fix SchemaSource for calcfunction/workfunction

### DIFF
--- a/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
+++ b/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
@@ -19,12 +19,8 @@ Interoperate with ``aiida-core`` components
 #    If you’re unfamiliar with them, please refer to the official documentation on `Calculations <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/calculations/index.html>`_ and `Workflows <https://aiida.readthedocs.io/projects/aiida-core/en/stable/topics/workflows/index.html>`_.
 
 import typing as t
-
 from aiida import load_profile, orm
-from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
-from aiida.engine import calcfunction, workfunction
-from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
-
+from aiida.engine import calcfunction
 from aiida_workgraph import namespace, task
 
 load_profile()
@@ -38,21 +34,37 @@ load_profile()
 #
 # In the following example, we combine all four ``aiida-core`` processes in a single ``WorkGraph``, connecting their inputs and outputs as needed.
 #
+# Calcfunction and workfunction
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Let's first define a ``calcfunction`` and ``workfunction``
+from aiida import orm
 
 
 @calcfunction
-def add(x, y):
-    return x + y
-
-
-@workfunction
-def add_more(x, y, z):
-    sum_x_y = add(x, y)
-    return add(sum_x_y, z)
+def add_multiply(x, y):
+    return {'sum': orm.Int(x + y), 'product': orm.Int(x * y)}
 
 
 # %%
+# To use ``aiida-core`` components in a ``WorkGraph``, we can simply cast them as tasks using the ``task`` decorator functionally (``task(<aiida-core-component>)``).
+
+add_multiply_task = task(outputs=namespace(sum=int, product=int))(add_multiply)
+
+# %%
+# One can also use the decorator syntax directly
+
+
+@task.calcfunction(outputs=namespace(sum=int, product=int))
+def add_multiply_task(x, y):
+    return {'sum': orm.Int(x + y), 'product': orm.Int(x * y)}
+
+
+# %%
+# The same syntax applies to `workfunction`.
+
+
+# %%
+#
 # .. important::
 #
 #    The ``task`` decorator accepts the same arguments when used functionally.
@@ -62,34 +74,62 @@ def add_more(x, y, z):
 #      - When the AiiDA process provides a single output (e.g., ``return x``), the socket name defaults to ``result``. You may override it (e.g., ``task(outputs=["my_sum"])(add)(...)``) for clearer graph labels, understanding the provenance graph will still record ``result``.
 #      - When the process returns a dictionary (e.g., ``return {"x": x, "y": y}``), you must assign output socket names explicitly if you want to reference individual entries. See :doc:`../../gallery/howto/autogen/annotate_inputs_outputs` for more on namespaces and dynamic sockets.
 #
+# CalcJob and WorkChain
+# ^^^^^^^^^^^^^^^^^^^^^^^
+# Similarly, ``CalcJob`` and ``WorkChain`` can also be cast as tasks using the ``task`` decorator.
+
+from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
+from aiida.calculations.arithmetic.add import ArithmeticAddCalculation
+
+
+ArithmeticAddTask = task(ArithmeticAddCalculation)
+MultiplyAddTask = task(MultiplyAddWorkChain)
 
 
 # %%
-# To use ``aiida-core`` components in a ``WorkGraph``, we can simply cast them as tasks using the ``task`` decorator functionally (``task(<aiida-core-component>)``).
-# Task functional components can then be called functionally with their respective inputs, linking outputs to inputs as needed.
+# .. important::
+#
+#    For ``WorkChain`` and ``CalcJob``, inputs and outputs are determined by the AiiDA process definition and cannot be overridden by passing the `inputs` or `outputs` arguments to the ``task`` decorator.
+#
+
+# %%
+# Task components can then be called functionally with their respective inputs, linking outputs to inputs as needed.
+
+
+def add(x, y):
+    return x + y
+
+
+def add_more(x, y, z):
+    sum_x_y = add(x, y)
+    return add(sum_x_y, z)
+
+
+AddTask = task(add)
+AddMoreTask = task(add_more)
 
 
 @task.graph
 def AiiDAComponentsWorkflow():
-    calcjob_sum = task(ArithmeticAddCalculation)(
+    calcjob_sum = ArithmeticAddTask(
         code=orm.load_code('add@localhost'),
         x=1,
         y=2,
     ).sum  # `ArithmeticAddCalculation` explicitly defines a 'sum' output
 
-    calcfunction_sum = task(add)(
+    calcfunction_sum = AddTask(
         x=calcjob_sum,
         y=4,
     ).result  # `calcfunction` implicitly defines a 'result' output
 
-    workchain_result = task(MultiplyAddWorkChain)(
+    workchain_result = MultiplyAddTask(
         code=orm.load_code('add@localhost'),
         x=calcfunction_sum,
         y=2,
         z=3,
     ).result  # `MultiplyAddWorkChain` explicitly defines a 'result' output
 
-    workfunction_sum = task(add_more)(
+    workfunction_sum = AddMoreTask(
         x=workchain_result,
         y=2,
         z=3,
@@ -100,12 +140,6 @@ def AiiDAComponentsWorkflow():
 
 wg = AiiDAComponentsWorkflow.build()
 wg.to_html()
-
-# %%
-# .. important::
-#
-#    For ``WorkChain`` and ``CalcJob``, inputs and outputs are determined by the AiiDA process definition and cannot be overridden by passing the `inputs` or `outputs` arguments to the ``task`` decorator.
-
 
 # %%
 # Let's run our ``aiida-core``-powered ``WorkGraph`` and examine the provenance graph:

--- a/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
+++ b/docs/gallery/howto/autogen/interoperate_with_aiida_core.py
@@ -53,6 +53,18 @@ def add_more(x, y, z):
 
 
 # %%
+# .. important::
+#
+#    The ``task`` decorator accepts the same arguments when used functionally.
+#    However, here are a few things to consider:
+#      - Input specifications are inferred from the Python signature. Declaring explicit input namespaces is not supported, because `calcfunction` and `workfunction` accept namespaced inputs only via keyword argument (e.g., ``**kwargs``): this is treated as a dynamic namespace and bypasses validation, allowing arbitrary nested AiiDA data to be provided.
+#      - Outputs are always dynamic: whatever structure the function returns becomes its provenance without validation. Defining an output specification is therefore only needed to expose output sockets that other tasks can link to.
+#      - When the AiiDA process provides a single output (e.g., ``return x``), the socket name defaults to ``result``. You may override it (e.g., ``task(outputs=["my_sum"])(add)(...)``) for clearer graph labels, understanding the provenance graph will still record ``result``.
+#      - When the process returns a dictionary (e.g., ``return {"x": x, "y": y}``), you must assign output socket names explicitly if you want to reference individual entries. See :doc:`../../gallery/howto/autogen/annotate_inputs_outputs` for more on namespaces and dynamic sockets.
+#
+
+
+# %%
 # To use ``aiida-core`` components in a ``WorkGraph``, we can simply cast them as tasks using the ``task`` decorator functionally (``task(<aiida-core-component>)``).
 # Task functional components can then be called functionally with their respective inputs, linking outputs to inputs as needed.
 
@@ -92,19 +104,7 @@ wg.to_html()
 # %%
 # .. important::
 #
-#    The ``task`` decorator accepts the same arguments when used functionally.
-#    However, here are a few things to consider:
-#
-#    - For ``WorkChain`` and ``CalcJob``, inputs and outputs are determined by the AiiDA process definition and cannot be overridden.
-#    - For ``calcfunction`` and ``workfunction``:
-#
-#      - When the AiiDA process provides a single output (e.g., ``return x``), the output socket name is implicitly set to ``result``.
-#        The user may override this by assigning a custom output socket name (e.g., ``task(outputs=["my_sum"])(add)(...)``).
-#        However, the benefits of clear graph visualization labels must be weighed against the loss of provenance consistency (the provenance graph will still show ``result``).
-#      - When the AiiDA process provides multiple outputs (e.g., ``return {"x": x, "y": y}``), it is actually necessary to assign output socket names explicitly.
-#        However, the previous point applies here as well if the user chooses to assign output socket names different from the dictionary keys of the AiiDA process.
-#
-#    For more about sockets, please refer to the :doc:`../../concept/autogen/socket_concept` concept section.
+#    For ``WorkChain`` and ``CalcJob``, inputs and outputs are determined by the AiiDA process definition and cannot be overridden by passing the `inputs` or `outputs` arguments to the ``task`` decorator.
 
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "scipy",
-  "node-graph~=0.4.2",
+  "node-graph~=0.4.3",
   "node-graph-widget>=0.0.5",
   "aiida-core~=2.7.1",
   "cloudpickle",

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -1,13 +1,13 @@
 from aiida_workgraph.task import Task
 from aiida.engine import Process
-from typing import Callable, Optional, Dict
+from typing import Callable, Optional, Dict, Any
 from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec, SchemaSource
 from .function_task import build_callable_nodespec
 from node_graph.executor import RuntimeExecutor
 from node_graph.error_handler import ErrorHandlerSpec
 from aiida_workgraph.utils import inspect_aiida_component_type
-from aiida_workgraph.socket_spec import from_aiida_process
+from aiida_workgraph.socket_spec import from_aiida_process, validate_socket_data
 
 
 class AiiDAFunctionTask(Task):
@@ -106,6 +106,11 @@ def _build_aiida_function_nodespec(
     error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
 ) -> NodeSpec:
     from aiida_workgraph.utils import inspect_aiida_component_type
+    from aiida_workgraph.socket_spec import dynamic
+    from dataclasses import replace
+
+    out_spec = validate_socket_data(out_spec) or dynamic(result=Any)
+    out_spec = replace(out_spec, meta=replace(out_spec.meta, dynamic=True))
 
     return build_callable_nodespec(
         obj=obj,

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -1,13 +1,13 @@
 from aiida_workgraph.task import Task
 from aiida.engine import Process
-from typing import Callable, Optional, Dict, Any
+from typing import Callable, Optional, Dict
 from node_graph.socket_spec import SocketSpec
 from node_graph.node_spec import NodeSpec, SchemaSource
 from .function_task import build_callable_nodespec
 from node_graph.executor import RuntimeExecutor
 from node_graph.error_handler import ErrorHandlerSpec
 from aiida_workgraph.utils import inspect_aiida_component_type
-from aiida_workgraph.socket_spec import from_aiida_process, validate_socket_data
+from aiida_workgraph.socket_spec import from_aiida_process
 
 
 class AiiDAFunctionTask(Task):
@@ -106,13 +106,9 @@ def _build_aiida_function_nodespec(
     error_handlers: Optional[Dict[str, ErrorHandlerSpec]] = None,
 ) -> NodeSpec:
     from aiida_workgraph.utils import inspect_aiida_component_type
-    from aiida_workgraph.socket_spec import dynamic
     from dataclasses import replace
 
-    out_spec = validate_socket_data(out_spec) or dynamic(result=Any)
-    out_spec = replace(out_spec, meta=replace(out_spec.meta, dynamic=True))
-
-    return build_callable_nodespec(
+    spec = build_callable_nodespec(
         obj=obj,
         node_type=inspect_aiida_component_type(obj),
         catalog=catalog,
@@ -123,3 +119,6 @@ def _build_aiida_function_nodespec(
         out_spec=out_spec,
         error_handlers=error_handlers,
     )
+    # the outputs of calcfunctions/workfunctions are always dynamic
+    spec = replace(spec, outputs=replace(spec.outputs, meta=replace(spec.outputs.meta, dynamic=True)))
+    return spec

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -86,9 +86,11 @@ def build_callable_nodespec(
             ),
         }
     )
-    # if not importable, embed schema
-    executor = RuntimeExecutor.from_callable(obj)
-    schema_source = SchemaSource.HANDLE if executor.mode == 'module' else SchemaSource.EMBEDDED
+    # We always use EMBEDDED schema for function tasks
+    # but when store the spec in the DB, we will check if the
+    # callable is a BaseHandler, and switch the schema_source to HANDLER accordingly.
+    # This avoid cyclic import.
+    schema_source = SchemaSource.EMBEDDED
 
     return NodeSpec(
         identifier=identifier or obj.__name__,
@@ -97,7 +99,7 @@ def build_callable_nodespec(
         catalog=catalog,
         inputs=func_in,
         outputs=func_out,
-        executor=executor,
+        executor=RuntimeExecutor.from_callable(obj),
         error_handlers=error_handlers,
         base_class=base_class,
         metadata=metadata,

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -5,7 +5,7 @@ from aiida_workgraph.socket_spec import (
     infer_specs_from_callable,
 )
 from node_graph.socket_spec import SocketSpec, merge_specs
-from node_graph.node_spec import NodeSpec
+from node_graph.node_spec import NodeSpec, SchemaSource
 from node_graph.executor import RuntimeExecutor
 from node_graph.error_handler import ErrorHandlerSpec, normalize_error_handlers
 
@@ -86,14 +86,18 @@ def build_callable_nodespec(
             ),
         }
     )
+    # if not importable, embed schema
+    executor = RuntimeExecutor.from_callable(obj)
+    schema_source = SchemaSource.HANDLE if executor.mode == 'module' else SchemaSource.EMBEDDED
 
     return NodeSpec(
         identifier=identifier or obj.__name__,
+        schema_source=schema_source,
         node_type=node_type,
         catalog=catalog,
         inputs=func_in,
         outputs=func_out,
-        executor=RuntimeExecutor.from_callable(obj),
+        executor=executor,
         error_handlers=error_handlers,
         base_class=base_class,
         metadata=metadata,

--- a/uv.lock
+++ b/uv.lock
@@ -210,7 +210,7 @@ requires-dist = [
     { name = "jsonschema" },
     { name = "myst-nb", marker = "extra == 'docs'", specifier = "~=1.0.0" },
     { name = "nbsphinx", marker = "extra == 'docs'" },
-    { name = "node-graph", specifier = "~=0.4.2" },
+    { name = "node-graph", specifier = "~=0.4.3" },
     { name = "node-graph-widget", specifier = ">=0.0.5" },
     { name = "numpy" },
     { name = "pgtest", marker = "extra == 'tests'", specifier = "~=1.3" },
@@ -2623,7 +2623,7 @@ wheels = [
 
 [[package]]
 name = "node-graph"
-version = "0.4.2"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
@@ -2637,9 +2637,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/c2/71601109155e1fb645b85470114844cc0ce2337de092f7fb061926bf171a/node_graph-0.4.2.tar.gz", hash = "sha256:b1bc3df18ee2d055561bcfa132a0d4ef19cf3186d74ff623fac1ab553b59707a", size = 73990, upload-time = "2025-10-19T09:57:19.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/83/eaad09397554fbcab30dc17017dba46c6e55f2a7e2010383b5d81403c76c/node_graph-0.4.3.tar.gz", hash = "sha256:9bdd067d4f1d5812d3171e8766e000102d45dd917d3503203afc20781c48e47d", size = 74031, upload-time = "2025-10-23T12:26:44.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/81/e935ca4c3f781360707752f362928ba297246a040e3ddfbd2fc1c1d73791/node_graph-0.4.2-py3-none-any.whl", hash = "sha256:eb05c6d84bb81e8df8142914aed678a932be7aa5e882f8491745cd7eabe0f1c3", size = 89073, upload-time = "2025-10-19T09:57:17.777Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/63/75d2dd631bc99fc009c0cb02f480b42cee53d6ea94f4316a94e614ca7859/node_graph-0.4.3-py3-none-any.whl", hash = "sha256:50f9197757c0e180c3905475a0561716d5e4c23377a1a16db60994e6f13c5e76", size = 89177, upload-time = "2025-10-23T12:26:42.746Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

- Fix #713 , bump node-graph to `0.4.3`
- Also set the outputs of calcfunction/workfunction as a dynamic namespace.