### PR TITLE
Fix dynamic inputs of calcfunction/workfunction

### DIFF
--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -121,4 +121,6 @@ def _build_aiida_function_nodespec(
     )
     # the outputs of calcfunctions/workfunctions are always dynamic
     spec = replace(spec, outputs=replace(spec.outputs, meta=replace(spec.outputs.meta, dynamic=True)))
+    if obj.spec().inputs.dynamic:
+        spec = replace(spec, inputs=replace(spec.inputs, meta=replace(spec.inputs.meta, dynamic=True)))
     return spec

--- a/tests/test_calcfunction.py
+++ b/tests/test_calcfunction.py
@@ -23,6 +23,12 @@ def test_dynamic_inputs() -> None:
 
     wg = WorkGraph('test_dynamic_inputs')
     wg.add_task(add, name='add1', x=orm.Int(1), y=orm.Int(2))
+    # the top-level inputs are dynamic
+    assert wg.tasks.add1.inputs._metadata.dynamic is True
+    # the kwargs inputs are dynamic
+    assert wg.tasks.add1.inputs.kwargs._metadata.dynamic is True
     assert wg.tasks.add1.inputs.kwargs._link_limit == 1e6
     wg.run()
     assert wg.tasks.add1.outputs.result.value == 3
+    # the outputs are dynamic as well
+    assert wg.tasks.add1.outputs._metadata.dynamic is True


### PR DESCRIPTION
When one uses a keyword argument in calcfunction/workfunction, the top-level input socket should be dynamic.

```python
def test(x, **kwargs):
    pass
```
