### PR TITLE
Rolling task window

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -54,6 +54,7 @@ class WorkGraph(node_graph.NodeGraph):
         self.max_number_jobs = 1000000
         self.max_iteration = 1000000
         self._error_handlers = error_handlers or {}
+        self.extras = {}  # Initialize extras dict for custom metadata
         self.analyzer = NodeGraphAnalysis(self)
 
     @property
@@ -238,6 +239,7 @@ class WorkGraph(node_graph.NodeGraph):
                 'restart_process': self.restart_process.pk if self.restart_process else None,
                 'max_iteration': self.max_iteration,
                 'max_number_jobs': self.max_number_jobs,
+                'extras': getattr(self, 'extras', {}),  # Serialize extras dict
             }
         )
         # save error handlers
@@ -340,6 +342,7 @@ class WorkGraph(node_graph.NodeGraph):
             'max_iteration',
             'max_number_jobs',
             'connectivity',
+            'extras',  # Restore extras dict (for window_config)
         ]:
             if key in wgdata:
                 setattr(wg, key, wgdata[key])


### PR DESCRIPTION
__This works for our Sirocco use case__

Add support for topological-level-based rolling window submission,
which controls task submission based on their level in the workflow
dependency graph. This prevents overwhelming schedulers and provides
better resource management for large workflows.

Changes:

1. Add `extras` dict serialization to WorkGraph
   - Initialize `extras` dict in WorkGraph.__init__()
   - Serialize extras in to_dict() for database persistence
   - Deserialize extras in from_dict() to restore configuration
   - Enables passing custom metadata (like window_config) between
     workflow building and execution phases

2. Implement rolling window logic in TaskManager
   - Add window state tracking (min_active_level, max_allowed_level)
   - Load window configuration from WorkGraph.extras on initialization
   - Update window dynamically based on task completion
   - Gate task submission based on topological level
   - Only launcher tasks are gated; lightweight tasks always allowed (-> this is still hardcoded for sirocco)
   - Optional max_queued_jobs hard limit on concurrent tasks

__Sirocco stuff:__
Window behavior:
- window_size=0: Sequential execution (one level at a time)
- window_size=1: Levels N and N+1 can be active (default)
- window_size=N: N+1 consecutive levels can have active tasks
- Window advances automatically as lower-level tasks complete

The window configuration is provided by upstream workflow builders
via WorkGraph.extras['window_config'] with keys:
- enabled: bool - whether windowing is active
- window_size: int - number of levels in window
- max_queued_jobs: int|None - optional hard limit on concurrent jobs
- task_levels: dict - mapping of task names to topological levels