### PR TITLE
Fix a bug for `max_number_jobs` and allow passing it as an argument to the `@task.graph` decorator

### DIFF
--- a/docs/gallery/howto/autogen/limit_concurrent.py
+++ b/docs/gallery/howto/autogen/limit_concurrent.py
@@ -72,6 +72,7 @@ wg.run()
 # .. tip::
 #
 #     * **Workflow-Specific Limit:** The `max_number_jobs` attribute only governs child processes created by *this specific* WorkGraph instance. It does not limit other AiiDA jobs or workflows you might be running.
+#     * **Nested graph task:** To limit the number of concurrent jobs in a nested graph task, you can set the `max_number_jobs`  in the `@task.graph` decorator, e.g. `@task.graph(max_number_jobs = 2)`.
 #
 #     * **Concurrency vs. Order:** This controls **how many** jobs run, not **which ones** run first. To enforce a specific execution sequence (e.g., Task B must run after Task A), you must define dependencies between them, see :ref:`Control task execution order <task_execution_order>`
 #

--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -166,6 +166,7 @@ class TaskDecoratorCollection:
         inputs: Optional[SocketSpec | list] = None,
         outputs: Optional[SocketSpec | list] = None,
         max_depth: int = 100,
+        max_number_jobs: Optional[int] = None,
     ) -> Callable:
         """Generate a decorator that register a function as a graph task.
         Attributes:
@@ -186,6 +187,7 @@ class TaskDecoratorCollection:
                     in_spec=inputs,
                     out_spec=outputs,
                     max_depth=max_depth,
+                    max_number_jobs=max_number_jobs,
                 )
             )
             handle._callable = func

--- a/src/aiida_workgraph/engine/task_manager.py
+++ b/src/aiida_workgraph/engine/task_manager.py
@@ -16,7 +16,7 @@ MAX_NUMBER_AWAITABLES_MSG = 'The maximum number of subprocesses has been reached
 process_task_types = [
     'CALCJOB',
     'WORKCHAIN',
-    'GRAPH_TASK',
+    'GRAPH',
     'SUBGRAPH',
     'PYTHONJOB',
     'SHELLJOB',

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -24,7 +24,6 @@ class GraphTask(Task):
 
         executor = RuntimeExecutor(**self.get_executor().to_dict()).callable
         max_depth = self.spec.metadata.get('max_depth', 100)
-        max_number_jobs = self.spec.metadata.get('max_number_jobs')
         metadata = kwargs.pop('metadata', {}) if kwargs else {}
         metadata.setdefault('call_link_label', self.name)
         # Cloudpickle doesn’t restore the function’s own name in its globals after unpickling,
@@ -62,8 +61,10 @@ class GraphTask(Task):
             args=args,
             kwargs=kwargs,
             var_kwargs=var_kwargs,
-            max_number_jobs=max_number_jobs,
         )
+        # Set the maximum number of concurrent jobs
+        max_number_jobs = self.spec.metadata.get('max_number_jobs')
+        wg.max_number_jobs = max_number_jobs
         wg.parent_uuid = engine_process.node.uuid
         inputs = wg.to_engine_inputs(metadata=metadata)
         if self.action == 'PAUSE':

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -24,6 +24,7 @@ class GraphTask(Task):
 
         executor = RuntimeExecutor(**self.get_executor().to_dict()).callable
         max_depth = self.spec.metadata.get('max_depth', 100)
+        max_number_jobs = self.spec.metadata.get('max_number_jobs')
         metadata = kwargs.pop('metadata', {}) if kwargs else {}
         metadata.setdefault('call_link_label', self.name)
         # Cloudpickle doesn’t restore the function’s own name in its globals after unpickling,
@@ -61,6 +62,7 @@ class GraphTask(Task):
             args=args,
             kwargs=kwargs,
             var_kwargs=var_kwargs,
+            max_number_jobs=max_number_jobs,
         )
         wg.parent_uuid = engine_process.node.uuid
         inputs = wg.to_engine_inputs(metadata=metadata)
@@ -87,10 +89,11 @@ def _build_graph_task_nodespec(
     in_spec: Optional[SocketSpec] = None,
     out_spec: Optional[SocketSpec] = None,
     max_depth: int = 100,
+    max_number_jobs: int = 1000000,
     catalog: str = 'Others',
 ) -> NodeSpec:
     # defaults for max depth
-    metadata = {'max_depth': max_depth}
+    metadata = {'max_depth': max_depth, 'max_number_jobs': max_number_jobs}
     # We use Process as the process class here, so that the task inherits the metadata
     # inputs from the base Process class, such as 'call_link_label'.
     # While the actual process class will be the WorkGraphEngine,

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -64,7 +64,8 @@ class GraphTask(Task):
         )
         # Set the maximum number of concurrent jobs
         max_number_jobs = self.spec.metadata.get('max_number_jobs')
-        wg.max_number_jobs = max_number_jobs
+        if max_number_jobs is not None:
+            wg.max_number_jobs = max_number_jobs
         wg.parent_uuid = engine_process.node.uuid
         inputs = wg.to_engine_inputs(metadata=metadata)
         if self.action == 'PAUSE':


### PR DESCRIPTION
- Fix the bug reported #728 where graph tasks launched are unaffected by `max_number_jobs` configuration in the partent graph task. 

- Also added the functionality to pass `max_number_jobs` as decorator keywords, which can be useful to limiting the number of concurrent tasks launched by a nested graph task. 