### PR TITLE
Fix namespace-to-namespace linking

### DIFF
--- a/docs/gallery/advanced/autogen/context_manager.py
+++ b/docs/gallery/advanced/autogen/context_manager.py
@@ -529,16 +529,15 @@ with WorkGraph('AddMap') as wg:
             y=get_value(map_zone.item.value, 'y').result,
         ).result
         map_zone.gather({'result': result})
-        wg.ctx.result = map_zone.outputs.result
-        wg.outputs.result = wg.ctx.result
+        wg.outputs.result = map_zone.outputs.result
 
 wg.run()
 
 print('\nResults:')
-for i, item in enumerate(wg.outputs.result.value.values()):
-    print(f'  Item {i}: {item}')
+for item in wg.outputs.result:
+    print(f'  {item._name}: {item.value}')
 # (1+1) + (2+2) + (3+3) = 12
-assert sum(wg.outputs.result.value.values()) == 12
+sum([socket.value.value for socket in wg.outputs.result]) == 12
 
 # %%
 # Let's inspect the task graph:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "scipy",
-  "node-graph~=0.6.2",
+  "node-graph~=0.6.3",
   "node-graph-widget>=0.0.5",
   "aiida-core~=2.7.1",
   "cloudpickle",

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict
 from aiida_workgraph.task import Task
-from aiida_workgraph import task, namespace, meta
+from aiida_workgraph import task, namespace, meta, dynamic
 from node_graph.tasks.builtins import _GraphIOSharedMixin
 from node_graph.task import ChildTaskSet
 from node_graph.socket import BaseSocket
@@ -95,7 +95,7 @@ class Map(Zone):
         task_type='MAP',
         catalog='Control',
         inputs=namespace(
-            source=SocketSpec('workgraph.any', link_limit=100000),
+            source=dynamic(Any),
         ),
         outputs=namespace(),
         base_class_path='aiida_workgraph.tasks.builtins.Map',
@@ -125,7 +125,7 @@ class Map(Zone):
         gather_item = self.gather_item_task
         for name in sockets:
             gather_item.add_input_spec('workgraph.any', name=name)
-            self.add_output_spec('workgraph.any', name=name)
+            self.add_output_spec('workgraph.namespace', name=name)
         gather_item.set_inputs(sockets)
         return gather_item.outputs
 

--- a/tests/test_pythonjob.py
+++ b/tests/test_pythonjob.py
@@ -149,8 +149,10 @@ def test_PythonJob_namespace_output_input(fixture_localhost, python_executable_p
     """Test function with namespace output and input."""
 
     # output namespace
+    add_spec = namespace(sum=Any, total=Any)
+    add_multiply_spec = namespace(add=add_spec, multiply=Any)
     out = namespace(
-        add_multiply=namespace(add=namespace(sum=Any, total=Any), multiply=Any),
+        add_multiply=add_multiply_spec,
         minus=Any,
     )
 
@@ -163,13 +165,13 @@ def test_PythonJob_namespace_output_input(fixture_localhost, python_executable_p
 
     # input namespace
     @task.pythonjob
-    def myfunc2(x, y):
+    def myfunc2(x: add_multiply_spec, y):
         add = x['add']['sum']
         multiply = x['multiply']
         return y + add + multiply
 
     @task.pythonjob
-    def myfunc3(x, y):
+    def myfunc3(x: add_spec, y):
         return x['sum'] + y
 
     wg = WorkGraph('test_namespace_outputs')

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ requires-dist = [
     { name = "jsonschema" },
     { name = "myst-nb", marker = "extra == 'docs'", specifier = "~=1.0.0" },
     { name = "nbsphinx", marker = "extra == 'docs'" },
-    { name = "node-graph", specifier = "~=0.6.2" },
+    { name = "node-graph", specifier = "~=0.6.3" },
     { name = "node-graph-widget", specifier = ">=0.0.5" },
     { name = "numpy" },
     { name = "pgtest", marker = "extra == 'tests'", specifier = "~=1.3" },
@@ -2173,7 +2173,7 @@ wheels = [
 
 [[package]]
 name = "node-graph"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2189,9 +2189,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/f3/1b604180c6802b140b59db2cf383d6c317f35ad5cf98f192560c10babe64/node_graph-0.6.2.tar.gz", hash = "sha256:0ef47647ec6a4cbde717b0329cd52e3c6465802ec313e66a983ef1a8d3980c03", size = 97840, upload-time = "2026-01-23T11:47:02.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/3a/b481e68ef50ed16f376f71d32054e06c33ca63fe2080159c93b43f8901be/node_graph-0.6.3.tar.gz", hash = "sha256:a7bbe9b4c54dfd644e6e6528111c58e72df133494fafe2bf6658e437d47d1ce9", size = 100085, upload-time = "2026-01-25T08:13:52.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/38/4efca6ce3855a1c9c2f901b906b668d77f946a788f3f4ecc463f9c8b4b16/node_graph-0.6.2-py3-none-any.whl", hash = "sha256:b85afd35f96ae0f88fdff6a808c28b8f87d1a3fe3a695ec4cf0c3c37728e4d15", size = 115265, upload-time = "2026-01-23T11:47:00.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/f5bb1c524b8f6b6437c73f43b402168f5dd112780ae9ec67e7df799ff0fa/node_graph-0.6.3-py3-none-any.whl", hash = "sha256:89ee619d4f50d5b6efbad89ad8962f378cfa6c3c8be5ca39cc4da73a88726581", size = 117415, upload-time = "2026-01-25T08:13:50.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump node-graph to `0.6.3`.
When linking two namespace sockets, recursively wiring matching child sockets