### PR TITLE
Pin RMQ in CI to `3.8.14-management` instead of `latest`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:latest
+        image: rabbitmq:3.8.14-management
         ports:
         - 5672:5672
 


### PR DESCRIPTION
CI failure appeared on #781