### PR TITLE
👌 Validate task names as AiiDA link labels on `build`

### DIFF
--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -215,8 +215,15 @@ class TaskHandle(BaseHandle):
         outputs = super().__call__(*args, **kwargs)
         # if "metadata.call_link_label" is set, use it as the name of the task
         if outputs._task.inputs.metadata.call_link_label.value is not None:
+            from aiida_workgraph.utils import _validate_task_name
+
             graph = outputs._graph
-            outputs._task.name = outputs._task.inputs.metadata.call_link_label.value
+            new_name = outputs._task.inputs.metadata.call_link_label.value
+            # `call_link_label` overrides the (already validated) function-derived name, so it
+            # must be validated too; otherwise an invalid override slips past `add_task` and
+            # only fails silently inside the engine at run time (see issue #784).
+            _validate_task_name(new_name, source='call_link_label')
+            outputs._task.name = new_name
             # update the names of tasks and links collections in the graph
             graph.tasks._items = {task.name: task for task in graph.tasks._items.values()}
             graph.links._items = {link.name: link for link in graph.links._items.values()}

--- a/src/aiida_workgraph/utils/__init__.py
+++ b/src/aiida_workgraph/utils/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional, Union, Callable, List
+from typing import Any, Dict, Literal, Optional, TypeAlias, Union, Callable, List
 from aiida.engine.processes import Process
 from aiida import orm
 from aiida.common.exceptions import NotExistent
 from aiida.engine.runners import Runner
+from aiida.common.links import validate_link_label
 from aiida_workgraph.config import task_types
 from aiida.engine import CalcJob, WorkChain
 from aiida_pythonjob import PythonJob
@@ -20,6 +21,63 @@ from aiida_workgraph.orm.utils import deserialize_safe
 from copy import deepcopy
 
 LOGGER = logging.getLogger(__name__)
+
+
+# A task name is set through three mechanisms; each gets the fix hint for *that* mechanism,
+# looked up by ``source`` rather than branched on (see ``_validate_task_name``):
+#
+# * ``'explicit_name'``: an explicit ``name=`` passed to :meth:`WorkGraph.add_task`. Only the
+#   low-level API can set it, so the hint may safely point at ``WorkGraph.add_task``.
+# * ``'derived_name'``: a name derived from the callable when no explicit name is given. This
+#   is the usual high-level case (a task called inside ``@task.graph``, which never touches
+#   ``add_task`` itself) and also low-level ``add_task(callable)`` without a ``name=``. The
+#   only fix common to both is to rename the callable, so the hint must not mention ``name=``
+#   (wrong for the high-level user) nor ``call_link_label`` (wrong for the low-level one).
+# * ``'call_link_label'``: the ``metadata={'call_link_label': ...}`` override applied in
+#   :meth:`TaskHandle.__call__`, which renames the task *after* ``add_task`` ran (high-level).
+TaskNameSource: TypeAlias = Literal['explicit_name', 'derived_name', 'call_link_label']
+
+_TASK_NAME_FIX_HINTS: dict[TaskNameSource, str] = {
+    'explicit_name': (
+        'How to fix: pass a valid `name=...` to `WorkGraph.add_task`, or omit it and rename '
+        'the function/callable the task is built from.'
+    ),
+    'derived_name': (
+        'How to fix: rename the function/callable the task is built from so its name is a valid link label.'
+    ),
+    'call_link_label': (
+        "How to fix: choose a valid `call_link_label` (e.g. `metadata={'call_link_label': '<name>'}`), or "
+        'omit it and rename the function/callable the task is built from.'
+    ),
+}
+
+
+def _validate_task_name(name: str, *, source: TaskNameSource) -> None:
+    """Validate that a task name can be used as an AiiDA provenance link label.
+
+    A task's name becomes the ``call_link_label`` of the process it launches, so it has to
+    satisfy AiiDA's link-label rules: a valid Python identifier, containing only letters,
+    digits and underscores, that does not start or end with an underscore. This is stricter
+    than ``node_graph``'s own name check, and it is enforced at build time so that an invalid
+    name fails fast instead of silently producing no output when the task runs.
+
+    :param name: the task name to validate.
+    :param source: which mechanism set the name; selects the API-appropriate fix hint in the
+        error message (see :data:`_TASK_NAME_FIX_HINTS`).
+    :raises ValueError: if ``name`` cannot be used as a link label, with guidance on how to
+        fix it.
+    """
+    try:
+        validate_link_label(name)
+    except ValueError as exc:
+        msg = (
+            f"Invalid task name '{name}': {exc}.\n"
+            'A task name is used as the AiiDA provenance link label of the process it '
+            'launches, so it must be a valid Python identifier containing only letters, '
+            f'digits and underscores, and may not start or end with an underscore.\n'
+            f'{_TASK_NAME_FIX_HINTS[source]}'
+        )
+        raise ValueError(msg) from exc
 
 
 def inspect_aiida_component_type(executor: Callable) -> str:

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -583,6 +583,21 @@ class WorkGraph(node_graph.Graph):
         elif callable(identifier) and not isinstance(identifier, (TaskSpec, TaskHandle, Task)):
             identifier = build_task_from_callable(identifier)
         node = self.tasks._new(identifier, name, **kwargs)
+        # A task name becomes the AiiDA `call_link_label` of the process it launches, so it
+        # must be a valid link label. Validate the resolved name (which may have been derived
+        # from the function name) here at build time; otherwise an invalid name only fails
+        # inside the engine at run time, where the error is swallowed (see issue #784). The
+        # fix hint differs depending on whether the user passed `name=` or it was derived.
+        from aiida_workgraph.utils import _validate_task_name
+
+        try:
+            _validate_task_name(node.name, source='explicit_name' if name is not None else 'derived_name')
+        except ValueError:
+            # Roll back the partially-added task so the workgraph is not left in an
+            # inconsistent state, then re-raise the actionable error.
+            if node.name in self.tasks:
+                del self.tasks[node.name]
+            raise
         self._version += 1
         return node
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,4 @@
-from aiida_workgraph import task, namespace
+from aiida_workgraph import task, namespace, WorkGraph
 from typing import Annotated
 import pytest
 import re
@@ -20,3 +20,65 @@ def test_validate_required_inputs():
         match=re.escape('Missing required inputs:'),
     ):
         my_graph.run(a=1, b={'x': 1})
+
+
+@pytest.mark.parametrize(
+    'name, reason',
+    [
+        pytest.param('_hidden', 'cannot start with an underscore', id='leading-underscore'),
+        pytest.param('hidden_', 'cannot end with an underscore', id='trailing-underscore'),
+        pytest.param('2nd', 'not a valid python identifier', id='non-identifier'),
+    ],
+)
+def test_invalid_task_name_raises_at_build_time(name, reason):
+    """An explicit, invalid ``name=`` to the low-level ``add_task`` is rejected at build time.
+
+    Regression test for https://github.com/aiidateam/aiida-workgraph/issues/784: such names
+    previously passed the (weaker) node_graph name check and only failed at run time inside
+    the engine, where the failure was swallowed.
+    """
+    wg = WorkGraph()
+    with pytest.raises(ValueError, match=re.escape(f"Invalid task name '{name}'")) as excinfo:
+        wg.add_task(add, name=name)
+    message = str(excinfo.value)
+    assert reason in message
+    # the fix hint is the one for the low-level API, not the call_link_label one
+    assert 'WorkGraph.add_task' in message
+
+
+def test_invalid_derived_task_name_raises_at_build_time():
+    """The issue #784 example: an invalid name derived from the function name (never passed
+    explicitly), built through the high-level ``@task.graph`` API, must also be caught at
+    build time. This path still resolves the name inside ``add_task``.
+    """
+
+    @task
+    def _hidden() -> dict:
+        return {'ran': True}
+
+    @task.graph
+    def top():
+        _hidden()
+
+    with pytest.raises(ValueError, match=re.escape("Invalid task name '_hidden'")) as excinfo:
+        top.build()
+    message = str(excinfo.value)
+    # the name was derived, so the fix is to rename the callable; the user never called
+    # `add_task` here, so the message must not tell them to use it
+    assert 'rename the function/callable' in message
+    assert 'WorkGraph.add_task' not in message
+
+
+def test_invalid_call_link_label_raises_at_build_time():
+    """An invalid name set via ``metadata={'call_link_label': ...}`` must be rejected too.
+
+    This is the documented way to give a task an explicit name in the high-level API. The
+    override is applied in ``TaskHandle.__call__`` *after* ``add_task`` validated the derived
+    name, so it needs its own check; without it the invalid label slips through and only
+    fails silently at run time (issue #784). The user-facing fix hint here is the
+    ``call_link_label`` one, not the low-level ``name=`` one.
+    """
+    with pytest.raises(ValueError, match=re.escape("Invalid task name '_sum'")) as excinfo:
+        with WorkGraph():
+            add(1, 2, metadata={'call_link_label': '_sum'})
+    assert 'call_link_label' in str(excinfo.value)


### PR DESCRIPTION
A task name becomes the process's `call_link_label`, so it has to be a valid link label.

**Alternatives considered:** auto-fixing the name (prepend `fn_`, strip underscores, ...) would hand the user a name they never wrote, which is then what shows up in their provenance and `wg.tasks.<name>` lookups, and no transform is obviously right anyway (stripping collides `_a`/`a`, prefixing is arbitrary). Such a name is almost always an oversight, so failing fast with a fix hint beats persisting a renamed node, and anyone who does want a custom name still sets one explicitly via `name=` or `call_link_label`.

Closes #784.