### PR TITLE
🐛 Fix `@task.graph` failing under `from __future__ import annotations`

### DIFF
--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import contextlib
+import typing
 from typing import Callable, List, Optional, Type, Dict, TYPE_CHECKING
 from aiida_workgraph.socket_spec import (
     from_aiida_process,
@@ -11,6 +13,26 @@ from node_graph.error_handler import ErrorHandlerSpec, normalize_error_handlers
 
 if TYPE_CHECKING:
     from node_graph import Node
+
+
+def _resolve_string_annotations(obj: Callable) -> None:
+    """Resolve PEP 563 stringized annotations on ``obj`` in place.
+
+    cloudpickle drops names that appear only inside stringized annotations, so a
+    pickled task callable can no longer resolve its hints when the engine re-infers
+    its signature (issue #783). Resolving eagerly here, while the defining module is
+    still importable, keeps the callable self-describing across the pickle round-trip.
+
+    A ``NameError`` means a name is not resolvable yet (e.g. a forward reference);
+    that is valid under PEP 563, so leave the annotation as a string and let the
+    usual lazy resolution handle it. Other errors are genuine annotation bugs and
+    are allowed to surface.
+    """
+    annotations = getattr(obj, '__annotations__', None)
+    if not annotations or not any(isinstance(value, str) for value in annotations.values()):
+        return
+    with contextlib.suppress(NameError):
+        obj.__annotations__ = typing.get_type_hints(obj, include_extras=True)
 
 
 def build_callable_TaskSpec(
@@ -40,6 +62,9 @@ def build_callable_TaskSpec(
 
     in_spec = validate_socket_data(in_spec)
     out_spec = validate_socket_data(out_spec)
+
+    # Keep the pickled callable self-describing under PEP 563 (issue #783).
+    _resolve_string_annotations(obj)
 
     # 1) infer from the callable (keep a snapshot before augmentation)
     func_in, func_out = infer_specs_from_callable(obj, in_spec, out_spec)

--- a/src/aiida_workgraph/tasks/function_task.py
+++ b/src/aiida_workgraph/tasks/function_task.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-import contextlib
-import typing
 from typing import Callable, List, Optional, Type, Dict, TYPE_CHECKING
 from aiida_workgraph.socket_spec import (
     from_aiida_process,
@@ -13,26 +11,6 @@ from node_graph.error_handler import ErrorHandlerSpec, normalize_error_handlers
 
 if TYPE_CHECKING:
     from node_graph import Node
-
-
-def _resolve_string_annotations(obj: Callable) -> None:
-    """Resolve PEP 563 stringized annotations on ``obj`` in place.
-
-    cloudpickle drops names that appear only inside stringized annotations, so a
-    pickled task callable can no longer resolve its hints when the engine re-infers
-    its signature (issue #783). Resolving eagerly here, while the defining module is
-    still importable, keeps the callable self-describing across the pickle round-trip.
-
-    A ``NameError`` means a name is not resolvable yet (e.g. a forward reference);
-    that is valid under PEP 563, so leave the annotation as a string and let the
-    usual lazy resolution handle it. Other errors are genuine annotation bugs and
-    are allowed to surface.
-    """
-    annotations = getattr(obj, '__annotations__', None)
-    if not annotations or not any(isinstance(value, str) for value in annotations.values()):
-        return
-    with contextlib.suppress(NameError):
-        obj.__annotations__ = typing.get_type_hints(obj, include_extras=True)
 
 
 def build_callable_TaskSpec(
@@ -62,9 +40,6 @@ def build_callable_TaskSpec(
 
     in_spec = validate_socket_data(in_spec)
     out_spec = validate_socket_data(out_spec)
-
-    # Keep the pickled callable self-describing under PEP 563 (issue #783).
-    _resolve_string_annotations(obj)
 
     # 1) infer from the callable (keep a snapshot before augmentation)
     func_in, func_out = infer_specs_from_callable(obj, in_spec, out_spec)

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -18,7 +18,7 @@ class GraphTask(Task):
     def execute(self, engine_process, args=None, kwargs=None, var_kwargs=None):
         from aiida_workgraph.utils import create_and_pause_process, call_depth_from_node
         from aiida_workgraph.engine.workgraph import WorkGraphEngine
-        from aiida_workgraph import task, WorkGraph
+        from aiida_workgraph import WorkGraph
         from node_graph.utils.graph import materialize_graph
         from aiida_workgraph.task import TaskHandle
 
@@ -27,14 +27,18 @@ class GraphTask(Task):
         metadata = kwargs.pop('metadata', {}) if kwargs else {}
         metadata.setdefault('call_link_label', self.name)
         # Cloudpickle doesn’t restore the function’s own name in its globals after unpickling,
-        # so any recursive calls would raise NameError. As a temporary workaround, we re-insert
-        # the decorated function into its globals under its original name.
+        # so any recursive calls would raise NameError. We re-insert a task handle into its
+        # globals under its original name. We reuse the spec built at decoration time rather
+        # than re-decorating the function: re-decoration would re-infer the signature, which
+        # fails under PEP 563 once cloudpickle has dropped the names used only in stringized
+        # annotations (issue #783).
         # Downside: this mutates the module globals at runtime, if another symbol with the same name exists,
         # we may introduce hard-to-trace bugs or collisions.
         if isinstance(executor, TaskHandle) and hasattr(executor, '_callable'):
             executor = executor._callable
-        # We override the executor's globals to include the decorated function for recursion
-        executor.__globals__[executor.__name__] = task.graph(max_depth=max_depth)(executor)
+        recursion_handle = TaskHandle(self.spec)
+        recursion_handle._callable = executor
+        executor.__globals__[executor.__name__] = recursion_handle
         depth = call_depth_from_node(engine_process.node)
         if depth >= max_depth:
             if depth >= max_depth:

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,0 +1,43 @@
+"""Regression test for #783: dynamic-namespace tasks under PEP 563.
+
+The module-level ``from __future__ import annotations`` is what makes annotations
+strings, the condition that breaks run-time signature re-inference of pickled task
+callables.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from aiida_workgraph import dynamic, namespace, task
+
+
+def test_dynamic_namespace_graph_task_runs_under_future_annotations():
+    """A dynamic-namespace ``@task.graph`` must run under PEP 563.
+
+    The engine re-infers the graph task's signature from the unpickled callable;
+    under PEP 563 cloudpickle drops the annotation's names, which used to raise
+    ``NameError: name 'Annotated' is not defined`` mid-run (#783).
+    """
+
+    @task
+    def source() -> Annotated[dict, namespace(data=dynamic(int))]:
+        return {'data': {'k1': 1, 'k2': 2, 'k3': 3}}
+
+    @task
+    def total(data: Annotated[dict, dynamic(int)]) -> int:
+        return sum(data.values())
+
+    @task.graph
+    def fan(data: Annotated[dict, dynamic(int)]) -> int:
+        return total(data=data).result
+
+    @task.graph
+    def top() -> int:
+        return fan(data=source().data).result
+
+    wg = top.build()
+    wg.run()
+
+    assert wg.state == 'FINISHED'
+    assert wg.outputs.result.value == 6


### PR DESCRIPTION
`@task.graph` with a dynamic-namespace signature fails at run time under `from __future__ import annotations`: `NameError: name 'Annotated' is not defined`, and the task fails mid-run.

Under PEP 563 the annotation is just a string that `get_type_hints` resolves lazily against the function's globals, but cloudpickle drops names used only inside stringized annotations from the unpickled callable. `GraphTask.execute` re-decorated that callable just to register a recursion handle, which re-inferred the signature and tripped over the missing `Annotated`. The fix builds the handle from the existing `self.spec` instead, so nothing re-infers the signature at run time. Includes a regression test.

MWE provided in the corresponding issue raised by @elinscott.