### PR TITLE
♻️ `engine`: use enums for task state and action

### DIFF
--- a/src/aiida_workgraph/engine/task_actions.py
+++ b/src/aiida_workgraph/engine/task_actions.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import Callable, Dict
+from typing import Callable
 
 from typing_extensions import assert_never
 
-from aiida_workgraph.enums import TaskAction, TaskState
+from aiida_workgraph.enums import TaskAction, TaskActionMessage, TaskState
 
 
 class TaskActionManager:
@@ -21,15 +21,14 @@ class TaskActionManager:
         self.logger = logger
         self.process = process
 
-    def apply_task_actions(self, msg: Dict) -> None:
+    def apply_task_actions(self, msg: TaskActionMessage) -> None:
         """
         Apply task actions to the workgraph based on user or external messages.
 
-        :param msg: { "action": <str>, "tasks": <List[str]> }
         :raises ValueError: if the message carries an unknown task action.
         """
         action = TaskAction(msg['action'].upper())
-        tasks: list[str] = msg['tasks']
+        tasks = msg['tasks']
         self.process.report(f'Action: {action}. Tasks: {tasks}')
 
         # Each action maps to a callable that takes a single task name.

--- a/src/aiida_workgraph/engine/task_actions.py
+++ b/src/aiida_workgraph/engine/task_actions.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
-from typing import Dict
+from typing import Callable, Dict
+
+from typing_extensions import assert_never
+
+from aiida_workgraph.enums import TaskAction, TaskState
 
 
 class TaskActionManager:
@@ -20,31 +24,35 @@ class TaskActionManager:
     def apply_task_actions(self, msg: Dict) -> None:
         """
         Apply task actions to the workgraph based on user or external messages.
+
         :param msg: { "action": <str>, "tasks": <List[str]> }
+        :raises ValueError: if the message carries an unknown task action.
         """
-        action = msg['action'].upper()
-        tasks = msg['tasks']
+        action = TaskAction(msg['action'].upper())
+        tasks: list[str] = msg['tasks']
         self.process.report(f'Action: {action}. Tasks: {tasks}')
 
-        if action == 'RESET':
-            for name in tasks:
-                self.state_manager.reset_task(name)
-        elif action == 'PAUSE':
-            for name in tasks:
-                self.pause_task(name)
-        elif action == 'PLAY':
-            for name in tasks:
-                self.play_task(name)
-        elif action == 'SKIP':
-            for name in tasks:
-                self.skip_task(name)
-        elif action == 'KILL':
-            for name in tasks:
-                self.kill_task(name)
+        # Each action maps to a callable that takes a single task name.
+        handler: Callable[[str], None]
+        match action:
+            case TaskAction.RESET:
+                handler = self.state_manager.reset_task
+            case TaskAction.PAUSE:
+                handler = self.pause_task
+            case TaskAction.PLAY:
+                handler = self.play_task
+            case TaskAction.SKIP:
+                handler = self.skip_task
+            case TaskAction.KILL:
+                handler = self.kill_task
+            case _:
+                assert_never(action)
+        for name in tasks:
+            handler(name)
 
     def pause_task(self, name: str) -> None:
         """Mark the task to be paused."""
-        self.state_manager.set_task_runtime_info(name, 'action', 'PAUSE')
+        self.state_manager.set_task_runtime_info(name, 'action', TaskAction.PAUSE)
         self.process.report(f'Task {name} action: PAUSE.')
 
     def play_task(self, name: str) -> None:
@@ -54,7 +62,7 @@ class TaskActionManager:
 
     def skip_task(self, name: str) -> None:
         """Force a task to be SKIPPED."""
-        self.state_manager.set_task_runtime_info(name, 'state', 'SKIPPED')
+        self.state_manager.set_task_runtime_info(name, 'state', TaskState.SKIPPED)
         self.process.report(f'Task {name} action: SKIP.')
 
     def kill_task(self, name: str) -> None:

--- a/src/aiida_workgraph/engine/task_manager.py
+++ b/src/aiida_workgraph/engine/task_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 from aiida_workgraph.socket import TaskSocketNamespace
 from aiida_workgraph.utils import get_nested_dict
 from aiida.engine.processes.exit_code import ExitCode
@@ -49,8 +50,9 @@ class TaskManager:
         """Get task from the context."""
         task = self.process.wg.tasks[name]
         task.set_input_resolver(self.get_socket_value)
-        action = self.state_manager.get_task_runtime_info(name, 'action').upper()
-        task.action = action
+        # The action stored on the node is always a canonical TaskAction value (or
+        # '' for none), so no case normalisation is needed on read.
+        task.action = self.state_manager.get_task_runtime_info(name, 'action')
         # update task results
         # namespace socket does not have a value, but _value
         for socket in task.outputs:
@@ -67,7 +69,7 @@ class TaskManager:
             if task.name in BUILTIN_TASKS:
                 # skip built-in nodes, they are not executed
                 continue
-            if self.state_manager.get_task_runtime_info(task.name, 'action').upper() == 'RESET':
+            if self.state_manager.get_task_runtime_info(task.name, 'action') == TaskAction.RESET:
                 self.state_manager.reset_task(task.name)
             self.state_manager.update_task_state(task.name)
 
@@ -79,17 +81,17 @@ class TaskManager:
         not_finished_tasks = []
         for task in self.process.wg.tasks:
             # if the task is in mapped state, we need to check its children (mapped tasks)
-            if self.state_manager.get_task_runtime_info(task.name, 'state') in ['MAPPED']:
+            if self.state_manager.get_task_runtime_info(task.name, 'state') == TaskState.MAPPED:
                 self.state_manager.update_template_task_state(task.name)
-            elif self.state_manager.get_task_runtime_info(task.name, 'state') in [
-                'RUNNING',
-                'CREATED',
-                'PLANNED',
-                'READY',
-            ]:
+            elif self.state_manager.get_task_runtime_info(task.name, 'state') in {
+                TaskState.RUNNING,
+                TaskState.CREATED,
+                TaskState.PLANNED,
+                TaskState.READY,
+            }:
                 not_finished_tasks.append(task.name)
                 is_finished = False
-            elif self.state_manager.get_task_runtime_info(task.name, 'state') == 'FAILED':
+            elif self.state_manager.get_task_runtime_info(task.name, 'state') == TaskState.FAILED:
                 failed_tasks.append(task.name)
         if is_finished and len(failed_tasks) > 0:
             message = f'WorkGraph finished, but tasks: {failed_tasks} failed. Thus all their child tasks are skipped.'
@@ -110,14 +112,14 @@ class TaskManager:
             # update task state
             if (
                 self.state_manager.get_task_runtime_info(task.name, 'state')
-                in [
-                    'CREATED',
-                    'RUNNING',
-                    'FINISHED',
-                    'FAILED',
-                    'SKIPPED',
-                    'MAPPED',
-                ]
+                in {
+                    TaskState.CREATED,
+                    TaskState.RUNNING,
+                    TaskState.FINISHED,
+                    TaskState.FAILED,
+                    TaskState.SKIPPED,
+                    TaskState.MAPPED,
+                }
                 or task.name in self.ctx._executed_tasks
             ):
                 continue
@@ -137,7 +139,10 @@ class TaskManager:
                 self.process.report(MAX_NUMBER_AWAITABLES_MSG.format(self.process.wg.max_number_jobs, name))
                 return False
         # skip if the task is already executed or if the task is in a skippped state
-        if name in self.ctx._executed_tasks or self.state_manager.get_task_runtime_info(name, 'state') in ['SKIPPED']:
+        if (
+            name in self.ctx._executed_tasks
+            or self.state_manager.get_task_runtime_info(name, 'state') == TaskState.SKIPPED
+        ):
             return False
         return True
 
@@ -195,7 +200,7 @@ class TaskManager:
                 )
             else:
                 self.process.report(f'Unknown task type {task_type}')
-                self.state_manager.set_task_runtime_info(name, 'state', 'FAILED')
+                self.state_manager.set_task_runtime_info(name, 'state', TaskState.FAILED)
 
     def execute_function_task(self, task, continue_workgraph=None, args=None, kwargs=None, var_kwargs=None):
         """Execute a CalcFunction or WorkFunction task."""
@@ -227,7 +232,7 @@ class TaskManager:
             # update the parent task state of mappped tasks
             if self.process.wg.tasks[task.name].map_data:
                 parent_task_name = self.process.wg.tasks[task.name].map_data['parent']
-                if self.process.node.get_task_state(parent_task_name) == 'PLANNED':
+                if self.process.node.get_task_state(parent_task_name) == TaskState.PLANNED:
                     self.process.node.set_task_state(parent_task_name, state)
             self.awaitable_manager.to_context(**{task.name: process})
         except Exception as e:
@@ -246,10 +251,10 @@ class TaskManager:
             # check the conditions of the while task
             should_run = self.should_run_while_task(name)
             if not should_run:
-                self.state_manager.set_task_runtime_info(name, 'state', 'FINISHED')
+                self.state_manager.set_task_runtime_info(name, 'state', TaskState.FINISHED)
                 self.state_manager.set_tasks_state(
                     [child.name for child in self.process.wg.tasks[name].children],
-                    'SKIPPED',
+                    TaskState.SKIPPED,
                 )
                 self.state_manager.update_parent_task_state(name)
                 self.process.report(
@@ -257,7 +262,7 @@ class TaskManager:
                 )
             else:
                 execution_count = self.state_manager.get_task_runtime_info(name, 'execution_count')
-                self.state_manager.set_task_runtime_info(name, 'state', 'RUNNING')
+                self.state_manager.set_task_runtime_info(name, 'state', TaskState.RUNNING)
                 self.state_manager.set_task_runtime_info(name, 'execution_count', execution_count + 1)
         self.continue_workgraph()
 
@@ -269,9 +274,9 @@ class TaskManager:
         else:
             should_run = self.should_run_if_task(name)
             if should_run:
-                self.state_manager.set_task_runtime_info(name, 'state', 'RUNNING')
+                self.state_manager.set_task_runtime_info(name, 'state', TaskState.RUNNING)
             else:
-                self.state_manager.set_tasks_state([child.name for child in task.children], 'SKIPPED')
+                self.state_manager.set_tasks_state([child.name for child in task.children], TaskState.SKIPPED)
                 self.state_manager.update_zone_task_state(name)
         self.continue_workgraph()
 
@@ -281,7 +286,7 @@ class TaskManager:
         if self.state_manager.are_childen_finished(name)[0]:
             self.state_manager.update_zone_task_state(name)
         else:
-            self.state_manager.set_task_runtime_info(name, 'state', 'RUNNING')
+            self.state_manager.set_task_runtime_info(name, 'state', TaskState.RUNNING)
         self.continue_workgraph()
 
     def execute_map_task(self, task, kwargs):
@@ -295,7 +300,7 @@ class TaskManager:
         if self.state_manager.are_childen_finished(name)[0]:
             self.state_manager.update_zone_task_state(name)
         else:
-            self.state_manager.set_task_runtime_info(name, 'state', 'RUNNING')
+            self.state_manager.set_task_runtime_info(name, 'state', TaskState.RUNNING)
             item_task = [child for child in task.children if child.identifier == 'workgraph.map_item'][0]
             source = kwargs['source']
             map_info['prefix'] = list(source.keys())
@@ -307,7 +312,7 @@ class TaskManager:
         self.state_manager.set_task_runtime_info(name, 'map_info', map_info)
         # gather task finishes immediately
         gather_task = task.gather_item_task
-        self.state_manager.set_task_runtime_info(gather_task.name, 'state', 'FINISHED')
+        self.state_manager.set_task_runtime_info(gather_task.name, 'state', TaskState.FINISHED)
 
         self.continue_workgraph()
 
@@ -470,7 +475,7 @@ class TaskManager:
         child_tasks = self.get_all_children(zone_task.name)
         for child_task in child_tasks:
             # since the child task is mapped, it should be skipped
-            self.state_manager.set_task_runtime_info(child_task, 'state', 'MAPPED')
+            self.state_manager.set_task_runtime_info(child_task, 'state', TaskState.MAPPED)
             task = self.copy_task(child_task, prefix)
             new_tasks[child_task] = task
             links = self.process.wg.tasks[child_task].inputs._all_links
@@ -485,7 +490,7 @@ class TaskManager:
         new_name = f'{prefix}_{item_task.name}'
         self.ctx._task_results[new_name]['key'] = prefix
         self.ctx._task_results[new_name]['value'] = value
-        self.state_manager.set_task_runtime_info(new_name, 'state', 'FINISHED')
+        self.state_manager.set_task_runtime_info(new_name, 'state', TaskState.FINISHED)
 
     def copy_task(self, name: str, prefix: str) -> 'Task':
         import uuid
@@ -500,7 +505,7 @@ class TaskManager:
         task_data['uuid'] = str(uuid.uuid4())
         # Reset runtime states
         self.ctx._task_results[new_name] = {}
-        self.state_manager.set_task_runtime_info(new_name, 'state', 'PLANNED')
+        self.state_manager.set_task_runtime_info(new_name, 'state', TaskState.PLANNED)
         self.state_manager.set_task_runtime_info(new_name, 'action', '')
         # Insert new_data in ctx._tasks
         task = self.process.wg.add_task_from_dict(task_data)

--- a/src/aiida_workgraph/engine/task_manager.py
+++ b/src/aiida_workgraph/engine/task_manager.py
@@ -50,8 +50,6 @@ class TaskManager:
         """Get task from the context."""
         task = self.process.wg.tasks[name]
         task.set_input_resolver(self.get_socket_value)
-        # The action stored on the node is always a canonical TaskAction value (or
-        # '' for none), so no case normalisation is needed on read.
         task.action = self.state_manager.get_task_runtime_info(name, 'action')
         # update task results
         # namespace socket does not have a value, but _value

--- a/src/aiida_workgraph/engine/task_state.py
+++ b/src/aiida_workgraph/engine/task_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Tuple, List, Any
+from typing_extensions import assert_never
 from aiida.orm.utils.serialize import serialize
 from aiida_workgraph.orm.utils import deserialize_safe
 from aiida.orm import ProcessNode, Data
@@ -59,7 +60,7 @@ class TaskStateManager:
             case 'map_info':
                 self.process.node.set_task_map_info(name, value)
             case _:
-                raise ValueError(f'Invalid key: {key}')
+                assert_never(key)
 
     def set_tasks_state(self, tasks: List[str], value: str) -> None:
         """

--- a/src/aiida_workgraph/engine/task_state.py
+++ b/src/aiida_workgraph/engine/task_state.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple, List, Any
 from aiida.orm.utils.serialize import serialize
 from aiida_workgraph.orm.utils import deserialize_safe
 from aiida.orm import ProcessNode, Data
+from aiida_workgraph.enums import TERMINAL_TASK_STATES, RuntimeInfoKey, TaskState
 from node_graph.socket import BaseSocket, TaskSocketNamespace
 
 
@@ -25,39 +26,40 @@ class TaskStateManager:
         self.process = process
         self.awaitable_manager = awaitable_manager
 
-    def get_task_runtime_info(self, name: str, key: str) -> Any:
+    def get_task_runtime_info(self, name: str, key: RuntimeInfoKey) -> Any:
         """Fetch a task runtime property (e.g. process, state, action)."""
-        if key == 'process':
-            value = self.process.node.get_task_process(name)
-            return deserialize_safe(value) if value else None
-        elif key == 'state':
-            return self.process.node.get_task_state(name)
-        elif key == 'action':
-            return self.process.node.get_task_action(name)
-        elif key == 'execution_count':
-            return self.process.node.get_task_execution_count(name)
-        else:
-            raise ValueError(f'Invalid key: {key}')
-        return None
+        match key:
+            case 'process':
+                value = self.process.node.get_task_process(name)
+                return deserialize_safe(value) if value else None
+            case 'state':
+                return self.process.node.get_task_state(name)
+            case 'action':
+                return self.process.node.get_task_action(name)
+            case 'execution_count':
+                return self.process.node.get_task_execution_count(name)
+            case _:
+                raise ValueError(f'Invalid key: {key}')
 
-    def set_task_runtime_info(self, name: str, key: str, value: Any) -> None:
+    def set_task_runtime_info(self, name: str, key: RuntimeInfoKey, value: Any) -> None:
         """Set a task runtime property (e.g. process, state, action).
         All the runtime info are store into the process node, which allow us
         access this info outside the engine
         """
-        if key == 'process':
-            serialized = serialize(value)
-            self.process.node.set_task_process(name, serialized)
-        elif key == 'state':
-            self.process.node.set_task_state(name, value)
-        elif key == 'action':
-            self.process.node.set_task_action(name, value)
-        elif key == 'execution_count':
-            self.process.node.set_task_execution_count(name, value)
-        elif key == 'map_info':
-            self.process.node.set_task_map_info(name, value)
-        else:
-            raise ValueError(f'Invalid key: {key}')
+        match key:
+            case 'process':
+                serialized = serialize(value)
+                self.process.node.set_task_process(name, serialized)
+            case 'state':
+                self.process.node.set_task_state(name, value)
+            case 'action':
+                self.process.node.set_task_action(name, value)
+            case 'execution_count':
+                self.process.node.set_task_execution_count(name, value)
+            case 'map_info':
+                self.process.node.set_task_map_info(name, value)
+            case _:
+                raise ValueError(f'Invalid key: {key}')
 
     def set_tasks_state(self, tasks: List[str], value: str) -> None:
         """
@@ -84,7 +86,7 @@ class TaskStateManager:
                     self.set_task_runtime_info(task.name, 'state', state)
 
                     self.ctx._task_results[name] = resolve_node_link_managers(node.outputs)
-                    self.set_task_runtime_info(task.name, 'state', 'FINISHED')
+                    self.set_task_runtime_info(task.name, 'state', TaskState.FINISHED)
                     self.update_meta_tasks(name)
                     self.process.report(f'Task: {name}, type: {task.task_type}, finished.')
                     self.apply_socket_spec_extras_to_aiida_node(name, node)
@@ -98,7 +100,7 @@ class TaskStateManager:
                     output_name for output_name in task.outputs._get_keys() if output_name not in ['_wait', '_outputs']
                 ][0]
                 self.ctx._task_results[name] = {output_name: node}
-                self.set_task_runtime_info(task.name, 'state', 'FINISHED')
+                self.set_task_runtime_info(task.name, 'state', TaskState.FINISHED)
                 self.update_meta_tasks(name)
                 self.process.report(f'Task: {name} finished.')
         else:
@@ -138,7 +140,7 @@ class TaskStateManager:
                 elif len(output_names) > 1:
                     self.process.exit_codes.OUTPUS_NOT_MATCH_RESULTS
             self.update_meta_tasks(name)
-            self.set_task_runtime_info(name, 'state', 'FINISHED')
+            self.set_task_runtime_info(name, 'state', TaskState.FINISHED)
             self.process.report(f'Task: {name} finished.')
         else:
             self.on_task_failed(name)
@@ -176,7 +178,7 @@ class TaskStateManager:
         and recursing to children. If the task is a WHILE, reset its execution_count.
         """
         self.logger.debug(f'Resetting task {name}.')
-        self.set_task_runtime_info(name, 'state', 'PLANNED')
+        self.set_task_runtime_info(name, 'state', TaskState.PLANNED)
         if reset_process:
             self.set_task_runtime_info(name, 'process', None)
         self.remove_executed_task(name)
@@ -217,13 +219,13 @@ class TaskStateManager:
         # If the task has a parent zone
         if parent_task:
             state = self.get_task_runtime_info(parent_task.name, 'state')
-            if state not in ['RUNNING']:
+            if state != TaskState.RUNNING:
                 parent_states[1] = False
 
         # Check input tasks from the zone connectivity
         for child_task_name in self.process.wg.connectivity['zone'][name]['input_tasks']:
             child_state = self.get_task_runtime_info(child_task_name, 'state')
-            if child_state not in ['FINISHED', 'SKIPPED', 'FAILED']:
+            if child_state not in TERMINAL_TASK_STATES:
                 parent_states[0] = False
                 break
         return all(parent_states), parent_states
@@ -233,8 +235,8 @@ class TaskStateManager:
         Mark a task as FAILED, skip its children, and run any error handlers.
         """
         task_type = self.process.wg.tasks[name].task_type
-        self.set_task_runtime_info(name, 'state', 'FAILED')
-        self.set_tasks_state(self.process.wg.connectivity['child_node'][name], 'SKIPPED')
+        self.set_task_runtime_info(name, 'state', TaskState.FAILED)
+        self.set_tasks_state(self.process.wg.connectivity['child_node'][name], TaskState.SKIPPED)
         msg = f'Task, {name}, type: {task_type}, failed.'
         process = self.get_task_runtime_info(name, 'process')
         if isinstance(process, ProcessNode):
@@ -284,7 +286,7 @@ class TaskStateManager:
         """
         finished, _ = self.are_childen_finished(name)
         if finished:
-            self.set_task_runtime_info(name, 'state', 'FINISHED')
+            self.set_task_runtime_info(name, 'state', TaskState.FINISHED)
             self.process.report(f'Task: {name} finished.')
             self.update_parent_task_state(name)
 
@@ -307,7 +309,7 @@ class TaskStateManager:
                 for prefix, mapped_task in self.process.wg.tasks[gather_task.name].mapped_tasks.items():
                     results[prefix] = self.ctx._task_results[mapped_task.name][link.to_socket._name]
                 self.ctx._task_results[name][link.to_socket._name] = results
-            self.set_task_runtime_info(name, 'state', 'FINISHED')
+            self.set_task_runtime_info(name, 'state', TaskState.FINISHED)
             # self.update_meta_tasks(name)
             self.process.report(f'Task: {name} finished.')
             self.update_meta_tasks(name)
@@ -329,7 +331,7 @@ class TaskStateManager:
             #             results.setdefault(output._name, {})
             #             results[output._name][prefix] = self.ctx._task_results[mapped_task.name][output._name]
             # self.ctx._task_results[name] = results
-            self.set_task_runtime_info(name, 'state', 'FINISHED')
+            self.set_task_runtime_info(name, 'state', TaskState.FINISHED)
             # self.update_meta_tasks(name)
             self.process.report(f'Task: {name} finished.')
             self.update_parent_task_state(name)
@@ -340,21 +342,13 @@ class TaskStateManager:
         finished = True
         if hasattr(task, 'children'):
             for child in task.children:
-                if self.get_task_runtime_info(child.name, 'state') not in [
-                    'FINISHED',
-                    'SKIPPED',
-                    'FAILED',
-                ]:
+                if self.get_task_runtime_info(child.name, 'state') not in TERMINAL_TASK_STATES:
                     finished = False
                     break
         # check the mapped tasks
         mapped_tasks = task.mapped_tasks or {}
         for mapped_task in mapped_tasks.values():
-            if self.get_task_runtime_info(mapped_task.name, 'state') not in [
-                'FINISHED',
-                'SKIPPED',
-                'FAILED',
-            ]:
+            if self.get_task_runtime_info(mapped_task.name, 'state') not in TERMINAL_TASK_STATES:
                 finished = False
                 break
         return finished, None

--- a/src/aiida_workgraph/engine/workgraph.py
+++ b/src/aiida_workgraph/engine/workgraph.py
@@ -15,6 +15,7 @@ import kiwipy
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import override
 from aiida.orm import Node
+from aiida_workgraph.enums import TaskState
 from aiida_workgraph.orm.workgraph import WorkGraphNode
 
 from aiida.engine.processes.exit_code import ExitCode
@@ -279,7 +280,7 @@ class WorkGraphEngine(Process, metaclass=Protect):
         self.task_manager.state_manager.update_meta_tasks('graph_inputs')
         # set meta-tasks state
         for task_name in BUILTIN_TASKS:
-            self.task_manager.state_manager.set_task_runtime_info(task_name, 'state', 'FINISHED')
+            self.task_manager.state_manager.set_task_runtime_info(task_name, 'state', TaskState.FINISHED)
 
     def apply_action(self, msg: dict) -> None:
         if msg['catalog'] == 'task':
@@ -335,5 +336,5 @@ class WorkGraphEngine(Process, metaclass=Protect):
             self.out('new_data', self.ctx._new_data)
         self.report('Finalize workgraph.')
         for task in self.wg.tasks:
-            if self.task_manager.state_manager.get_task_runtime_info(task.name, 'state') == 'FAILED':
+            if self.task_manager.state_manager.get_task_runtime_info(task.name, 'state') == TaskState.FAILED:
                 return self.exit_codes.TASK_FAILED

--- a/src/aiida_workgraph/enums.py
+++ b/src/aiida_workgraph/enums.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing import Final, Literal
+from typing import Final, Literal, TypedDict
 
 __all__ = (
     'TaskState',
     'TaskAction',
     'TERMINAL_TASK_STATES',
     'RuntimeInfoKey',
+    'TaskActionMessage',
 )
 
 
@@ -59,3 +60,15 @@ class TaskAction(str, Enum):
 #: Keys addressing a task's runtime info on the process node, used as the dispatch
 #: key in ``get_task_runtime_info`` / ``set_task_runtime_info``.
 RuntimeInfoKey = Literal['process', 'state', 'action', 'execution_count', 'map_info']
+
+
+class TaskActionMessage(TypedDict):
+    """RPC payload sent to a running WorkGraph to act on its tasks.
+
+    Built by ``create_task_action`` and consumed by ``apply_task_actions``.
+    """
+
+    intent: str
+    catalog: str
+    action: str
+    tasks: list[str]

--- a/src/aiida_workgraph/enums.py
+++ b/src/aiida_workgraph/enums.py
@@ -1,0 +1,61 @@
+"""Enums used by WorkGraph."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+from typing import Final, Literal
+
+__all__ = (
+    'TaskState',
+    'TaskAction',
+    'TERMINAL_TASK_STATES',
+    'RuntimeInfoKey',
+)
+
+
+@unique
+class TaskState(str, Enum):
+    """Lifecycle state of a single task within a running WorkGraph."""
+
+    PLANNED = 'PLANNED'
+    READY = 'READY'
+    CREATED = 'CREATED'
+    RUNNING = 'RUNNING'
+    FINISHED = 'FINISHED'
+    FAILED = 'FAILED'
+    SKIPPED = 'SKIPPED'
+    MAPPED = 'MAPPED'
+
+    def __str__(self) -> str:
+        # Return the bare value ('RUNNING'), not 'TaskState.RUNNING', uniformly
+        # across Python versions so reports and logs read naturally.
+        return self.value
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the task has settled and will not transition further."""
+        return self in TERMINAL_TASK_STATES
+
+
+#: States a task does not transition out of; a task in any of these is "done" for
+#: readiness and finished checks.
+TERMINAL_TASK_STATES: Final[frozenset[TaskState]] = frozenset({TaskState.FINISHED, TaskState.SKIPPED, TaskState.FAILED})
+
+
+@unique
+class TaskAction(str, Enum):
+    """Externally-triggered action requested on a task."""
+
+    PAUSE = 'PAUSE'
+    PLAY = 'PLAY'
+    KILL = 'KILL'
+    SKIP = 'SKIP'
+    RESET = 'RESET'
+
+    def __str__(self) -> str:
+        return self.value
+
+
+#: Keys addressing a task's runtime info on the process node, used as the dispatch
+#: key in ``get_task_runtime_info`` / ``set_task_runtime_info``.
+RuntimeInfoKey = Literal['process', 'state', 'action', 'execution_count', 'map_info']

--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from node_graph.task import Task as GraphTask
 from .registry import RegistryHub, registry_hub
+from aiida_workgraph.enums import TaskState
 import aiida
 from typing import Any, Dict, Optional, Union, Callable, List, TYPE_CHECKING
 from node_graph.task_spec import BaseHandle
@@ -47,7 +48,7 @@ class Task(GraphTask):
         self.waiting_on = WaitingTaskSet(parent=self)
         self.process = process
         self.pk = pk
-        self.state = 'PLANNED'
+        self.state = TaskState.PLANNED
         self.action = ''
         self.show_socket_depth = 0
         self.parent = None
@@ -116,7 +117,7 @@ class Task(GraphTask):
 
     def reset(self) -> None:
         self.process = None
-        self.state = 'PLANNED'
+        self.state = TaskState.PLANNED
 
     def update_state(self, data: Dict[str, Any]) -> None:
         """Set the outputs of the task from a dictionary."""
@@ -158,7 +159,7 @@ class Task(GraphTask):
             result = executor(*args, **kwargs)
         else:
             result = executor(*args, **kwargs, **var_kwargs)
-        return result, 'FINISHED'
+        return result, TaskState.FINISHED
 
     def to_widget_value(self):
         from aiida_workgraph.utils import workgraph_to_short_json

--- a/src/aiida_workgraph/tasks/aiida.py
+++ b/src/aiida_workgraph/tasks/aiida.py
@@ -1,4 +1,5 @@
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 from aiida.engine import Process
 from typing import Callable, Optional, Dict
 from node_graph.socket_spec import SocketSpec
@@ -34,7 +35,7 @@ class AiiDAFunctionTask(Task):
         else:
             _, process = run_get_node(executor, **kwargs, **var_kwargs)
 
-        return process, 'FINISHED'
+        return process, TaskState.FINISHED
 
 
 class AiiDAProcessTask(Task):
@@ -72,7 +73,7 @@ class AiiDAProcessTask(Task):
 
         kwargs.setdefault('metadata', {})
         kwargs['metadata'].update({'call_link_label': self.name})
-        if self.action == 'PAUSE':
+        if self.action == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -80,11 +81,11 @@ class AiiDAProcessTask(Task):
                 kwargs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(executor, **kwargs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
 
         return process, state
 

--- a/src/aiida_workgraph/tasks/graph_task.py
+++ b/src/aiida_workgraph/tasks/graph_task.py
@@ -1,4 +1,5 @@
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 from typing import Callable, Optional
 from node_graph.socket_spec import SocketSpec
 from node_graph.task_spec import TaskSpec
@@ -72,7 +73,7 @@ class GraphTask(Task):
             wg.max_number_jobs = max_number_jobs
         wg.parent_uuid = engine_process.node.uuid
         inputs = wg.to_engine_inputs(metadata=metadata)
-        if self.action == 'PAUSE':
+        if self.action == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -80,11 +81,11 @@ class GraphTask(Task):
                 inputs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(WorkGraphEngine, **inputs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
 
         return process, state
 

--- a/src/aiida_workgraph/tasks/monitors.py
+++ b/src/aiida_workgraph/tasks/monitors.py
@@ -3,6 +3,7 @@ import typing as t
 import logging
 
 from aiida_workgraph import task
+from aiida_workgraph.enums import TERMINAL_TASK_STATES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,4 +57,4 @@ def monitor_task(task_name: str, workgraph_pk: int = None, workgraph_name: str =
     node = builder.first()[0]
     state = node.task_states.get(task_name, '')
     LOGGER.debug('Task state: %s', state)
-    return state in ['FINISHED', 'FAILED', 'SKIPPED']
+    return state in TERMINAL_TASK_STATES

--- a/src/aiida_workgraph/tasks/pythonjob_tasks.py
+++ b/src/aiida_workgraph/tasks/pythonjob_tasks.py
@@ -6,6 +6,7 @@ from aiida_workgraph.utils import create_and_pause_process
 from aiida.engine import run_get_node
 from aiida_pythonjob import pyfunction, PythonJob, PyFunction, MonitorPyFunction
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 from node_graph.socket_spec import SocketSpec, SocketSpecSelect, SocketMeta
 from node_graph.task_spec import TaskSpec
 from aiida_workgraph.socket_spec import namespace
@@ -123,7 +124,7 @@ class PythonJobTask(BaseSerializablePythonTask):
         )
 
         # If we want to pause
-        if self.action == 'PAUSE':
+        if self.action == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -131,11 +132,11 @@ class PythonJobTask(BaseSerializablePythonTask):
                 inputs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(PythonJob, **inputs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
 
         return process, state
 
@@ -168,7 +169,7 @@ class PyFunctionTask(BaseSerializablePythonTask):
                 serializers=kwargs.pop('serializers', None),
                 register_pickle_by_value=kwargs.pop('register_pickle_by_value', False),
             )
-            if self.action == 'PAUSE':
+            if self.action == TaskAction.PAUSE:
                 engine_process.report(f'Task {self.name} is created and paused.')
                 process = create_and_pause_process(
                     engine_process.runner,
@@ -176,11 +177,11 @@ class PyFunctionTask(BaseSerializablePythonTask):
                     inputs,
                     state_msg='Paused through WorkGraph',
                 )
-                state = 'CREATED'
+                state = TaskState.CREATED
                 process = process.node
             else:
                 process = engine_process.submit(PyFunction, **inputs)
-                state = 'RUNNING'
+                state = TaskState.RUNNING
 
             return process, state
         else:
@@ -200,7 +201,7 @@ class PyFunctionTask(BaseSerializablePythonTask):
             else:
                 _, process = run_get_node(func, **kwargs, **var_kwargs)
 
-            return process, 'FINISHED'
+            return process, TaskState.FINISHED
 
 
 class MonitorFunctionTask(BaseSerializablePythonTask):
@@ -230,7 +231,7 @@ class MonitorFunctionTask(BaseSerializablePythonTask):
             register_pickle_by_value=kwargs.pop('register_pickle_by_value', False),
             **kwargs,
         )
-        if self.action == 'PAUSE':
+        if self.action == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -238,11 +239,11 @@ class MonitorFunctionTask(BaseSerializablePythonTask):
                 inputs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(MonitorPyFunction, **inputs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
         return process, state
 
 

--- a/src/aiida_workgraph/tasks/shelljob_task.py
+++ b/src/aiida_workgraph/tasks/shelljob_task.py
@@ -10,6 +10,7 @@ from node_graph.executor import RuntimeExecutor
 from node_graph.socket_spec import SocketSpec, merge_specs, SocketMeta
 from aiida_workgraph.socket_spec import from_aiida_process, namespace
 from aiida_workgraph.task import Task, TaskHandle
+from aiida_workgraph.enums import TaskAction, TaskState
 from aiida import orm
 
 
@@ -89,7 +90,7 @@ class ShellJobTask(Task):
         md = kwargs.setdefault('metadata', {})
         md.setdefault('call_link_label', self.name)
 
-        if getattr(self, 'action', None) == 'PAUSE':
+        if getattr(self, 'action', None) == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -97,11 +98,11 @@ class ShellJobTask(Task):
                 kwargs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(ShellJob, **kwargs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
         return process, state
 
 

--- a/src/aiida_workgraph/tasks/subgraph_task.py
+++ b/src/aiida_workgraph/tasks/subgraph_task.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from node_graph.task_spec import TaskSpec
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ class SubGraphTask(Task):
 
         inputs = self.prepare_for_subgraph_task(kwargs)
 
-        if self.action == 'PAUSE':
+        if self.action == TaskAction.PAUSE:
             engine_process.report(f'Task {self.name} is created and paused.')
             process = create_and_pause_process(
                 engine_process.runner,
@@ -62,11 +63,11 @@ class SubGraphTask(Task):
                 inputs,
                 state_msg='Paused through WorkGraph',
             )
-            state = 'CREATED'
+            state = TaskState.CREATED
             process = process.node
         else:
             process = engine_process.submit(WorkGraphEngine, **inputs)
-            state = 'RUNNING'
+            state = TaskState.RUNNING
 
         return process, state
 

--- a/src/aiida_workgraph/utils/control.py
+++ b/src/aiida_workgraph/utils/control.py
@@ -6,32 +6,38 @@ from aiida.manage import get_manager
 from aiida import orm
 from aiida.engine.processes import control
 
+from aiida_workgraph.enums import RuntimeInfoKey, TaskAction, TaskState
+
 LOGGER = logging.getLogger(__name__)
 
 
 def create_task_action(
     pk: int,
     tasks: list,
-    action: str = 'pause',
+    action: TaskAction = TaskAction.PAUSE,
 ):
     """Send task action to Process."""
 
     controller = get_manager().get_process_controller()
-    message = {'intent': 'custom', 'catalog': 'task', 'action': action, 'tasks': tasks}
+    # Send the canonical action value as a plain string; the engine re-validates it
+    # into a TaskAction on receipt.
+    message = {'intent': 'custom', 'catalog': 'task', 'action': str(action), 'tasks': tasks}
     controller._communicator.rpc_send(pk, message)
 
 
-def get_task_runtime_info(node, name: str, key: str) -> str:
+def get_task_runtime_info(node, name: str, key: RuntimeInfoKey) -> str:
     """Get task state info from attributes."""
     from aiida_workgraph.orm.utils import deserialize_safe
 
-    if key == 'process':
-        value = deserialize_safe(node.task_processes.get(name, ''))
-    elif key == 'state':
-        value = node.task_states.get(name, '')
-    elif key == 'action':
-        value = node.task_actions.get(name, '')
-    return value
+    match key:
+        case 'process':
+            return deserialize_safe(node.task_processes.get(name, ''))
+        case 'state':
+            return node.task_states.get(name, '')
+        case 'action':
+            return node.task_actions.get(name, '')
+        case _:
+            raise ValueError(f'Invalid key: {key}')
 
 
 def pause_tasks(pk: int, tasks: list[str], timeout: int = 5):
@@ -48,9 +54,9 @@ def pause_tasks(pk: int, tasks: list[str], timeout: int = 5):
         'PAUSED',
     ]:
         for name in tasks:
-            if get_task_runtime_info(node, name, 'state') == 'PLANNED':
-                create_task_action(pk, tasks, action='pause')
-            elif get_task_runtime_info(node, name, 'state') == 'RUNNING':
+            if get_task_runtime_info(node, name, 'state') == TaskState.PLANNED:
+                create_task_action(pk, tasks, action=TaskAction.PAUSE)
+            elif get_task_runtime_info(node, name, 'state') == TaskState.RUNNING:
                 try:
                     control.pause_processes(
                         [get_task_runtime_info(node, name, 'process')],
@@ -76,8 +82,8 @@ def play_tasks(pk: int, tasks: list, timeout: int = 5):
     ]:
         for name in tasks:
             state = get_task_runtime_info(node, name, 'state')
-            if state == 'PLANNED':
-                create_task_action(pk, tasks, action='play')
+            if state == TaskState.PLANNED:
+                create_task_action(pk, tasks, action=TaskAction.PLAY)
                 break
             process = get_task_runtime_info(node, name, 'process')
             if process.is_finished:
@@ -109,17 +115,15 @@ def kill_tasks(pk: int, tasks: list, timeout: int = 5):
         for name in tasks:
             state = get_task_runtime_info(node, name, 'state')
             process = get_task_runtime_info(node, name, 'process')
-            if state == 'PLANNED':
-                create_task_action(pk, tasks, action='skip')
-            elif state in [
-                'CREATED',
-                'RUNNING',
-                'WAITING',
-                'PAUSED',
-            ]:
+            if state == TaskState.PLANNED:
+                create_task_action(pk, tasks, action=TaskAction.SKIP)
+            # A live task to kill is either CREATED or RUNNING; WAITING/PAUSED are
+            # AiiDA process states a *task* state never takes, so they were dead
+            # entries in this list.
+            elif state in {TaskState.CREATED, TaskState.RUNNING}:
                 if process is None:
                     LOGGER.warning('Task %s is not an AiiDA process.', name)
-                    create_task_action(pk, tasks, action='kill')
+                    create_task_action(pk, tasks, action=TaskAction.KILL)
                 else:
                     try:
                         control.kill_processes(
@@ -149,6 +153,6 @@ def reset_tasks(pk: int, tasks: list) -> None:
         'PAUSED',
     ]:
         for name in tasks:
-            create_task_action(pk, tasks, action='reset')
+            create_task_action(pk, tasks, action=TaskAction.RESET)
 
     return True, ''

--- a/src/aiida_workgraph/utils/control.py
+++ b/src/aiida_workgraph/utils/control.py
@@ -6,7 +6,7 @@ from aiida.manage import get_manager
 from aiida import orm
 from aiida.engine.processes import control
 
-from aiida_workgraph.enums import RuntimeInfoKey, TaskAction, TaskState
+from aiida_workgraph.enums import RuntimeInfoKey, TaskAction, TaskActionMessage, TaskState
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ def create_task_action(
     controller = get_manager().get_process_controller()
     # Send the canonical action value as a plain string; the engine re-validates it
     # into a TaskAction on receipt.
-    message = {'intent': 'custom', 'catalog': 'task', 'action': str(action), 'tasks': tasks}
+    message: TaskActionMessage = {'intent': 'custom', 'catalog': 'task', 'action': str(action), 'tasks': tasks}
     controller._communicator.rpc_send(pk, message)
 
 

--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -4,6 +4,7 @@ import logging
 import node_graph
 import aiida
 from aiida_workgraph.task import Task
+from aiida_workgraph.enums import TaskAction, TaskState
 import time
 from typing import Any, Dict, List, Optional, Union
 from .registry import RegistryHub, registry_hub
@@ -440,7 +441,7 @@ class WorkGraph(node_graph.Graph):
 
         if self.process is None:
             for name in tasks:
-                self.tasks[name].action = 'PAUSE'
+                self.tasks[name].action = TaskAction.PAUSE
         else:
             _, msg = pause_tasks(self.process.pk, tasks)
 
@@ -465,7 +466,7 @@ class WorkGraph(node_graph.Graph):
 
         if self.process is None:
             for name in tasks:
-                self.tasks[name].action = 'KILL'
+                self.tasks[name].action = TaskAction.KILL
         else:
             _, msg = kill_tasks(self.process.pk, tasks)
         return 'Send message to kill tasks.'
@@ -477,11 +478,11 @@ class WorkGraph(node_graph.Graph):
 
         if self.process is None:
             for name in tasks:
-                self.tasks[name].state = 'PLANNED'
+                self.tasks[name].state = TaskState.PLANNED
                 self.tasks[name].process = None
                 child_tasks = self.analyzer.get_all_descendants(self.tasks[name])
                 for name in child_tasks:
-                    self.tasks[name].state = 'PLANNED'
+                    self.tasks[name].state = TaskState.PLANNED
                     self.tasks[name].process = None
         else:
             _, msg = reset_tasks(self.process.pk, tasks)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,5 +1,67 @@
+import logging
 import pytest
 import time
+
+from aiida_workgraph.engine.task_actions import TaskActionManager
+from aiida_workgraph.enums import TaskAction, TaskState
+
+
+class _RecordingStateManager:
+    """Minimal stand-in for ``TaskStateManager`` that records dispatched calls.
+
+    A real one needs a live engine/process node, so the collaborator is faked to
+    keep the dispatch test fast and focused on ``apply_task_actions``.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def reset_task(self, name):
+        self.calls.append(('reset', name))
+
+    def set_task_runtime_info(self, name, key, value):
+        self.calls.append(('set', name, key, value))
+
+
+class _RecordingProcess:
+    def __init__(self):
+        self.reports = []
+
+    def report(self, message):
+        self.reports.append(message)
+
+
+def _make_action_manager():
+    state_manager = _RecordingStateManager()
+    process = _RecordingProcess()
+    manager = TaskActionManager(state_manager, logging.getLogger(__name__), process)
+    return manager, state_manager, process
+
+
+@pytest.mark.parametrize(
+    'raw_action, expected_call',
+    [
+        pytest.param('pause', ('set', 'add1', 'action', TaskAction.PAUSE), id='pause-lowercase'),
+        pytest.param('PAUSE', ('set', 'add1', 'action', TaskAction.PAUSE), id='pause-uppercase'),
+        pytest.param('PaUsE', ('set', 'add1', 'action', TaskAction.PAUSE), id='pause-mixedcase'),
+        pytest.param('reset', ('reset', 'add1'), id='reset-lowercase'),
+        pytest.param('ReSeT', ('reset', 'add1'), id='reset-mixedcase'),
+        pytest.param('skip', ('set', 'add1', 'state', TaskState.SKIPPED), id='skip-lowercase'),
+    ],
+)
+def test_apply_task_actions_is_case_insensitive(raw_action, expected_call):
+    """Whatever the case of the incoming action, it dispatches the same way."""
+    manager, state_manager, _ = _make_action_manager()
+    manager.apply_task_actions({'action': raw_action, 'tasks': ['add1']})
+    assert expected_call in state_manager.calls
+
+
+def test_apply_task_actions_raises_on_unknown_action():
+    """A typo'd action fails loudly rather than being silently swallowed."""
+    manager, state_manager, _ = _make_action_manager()
+    with pytest.raises(ValueError):
+        manager.apply_task_actions({'action': 'frobnicate', 'tasks': ['add1']})
+    assert state_manager.calls == []
 
 
 @pytest.mark.skip(reason='PAUSED state is wrong for the moment.')

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,64 @@
+"""Unit tests for the task-state and task-action enums.
+
+These cover the behaviour the engine relies on: the human-facing string form
+drops the ``TaskState.``/``TaskAction.`` prefix, only canonical values are
+accepted, and the terminal-state set matches both enum members and bare strings.
+"""
+
+import pytest
+
+from aiida_workgraph.enums import TERMINAL_TASK_STATES, TaskAction, TaskState
+
+
+@pytest.mark.parametrize('enum_cls', [TaskState, TaskAction])
+def test_str_and_format_drop_class_prefix(enum_cls):
+    """``__str__``/f-strings must yield the bare value on every supported Python
+    version, so report messages stay e.g. ``Action: RESET`` (test_workgraph)."""
+    member = next(iter(enum_cls))
+    assert str(member) == member.value
+    assert f'{member}' == member.value
+    assert '{}'.format(member) == member.value
+
+
+@pytest.mark.parametrize('enum_cls', [TaskState, TaskAction])
+@pytest.mark.parametrize(
+    'bad',
+    [
+        pytest.param('running', id='lowercased-state'),
+        pytest.param('reset', id='lowercased-action'),
+        pytest.param('nope', id='gibberish'),
+        pytest.param('', id='empty'),
+    ],
+)
+def test_construction_from_noncanonical_value_raises(enum_cls, bad):
+    """Only the canonical uppercase values are valid; a typo or wrong case fails
+    loud instead of silently never matching."""
+    with pytest.raises(ValueError):
+        enum_cls(bad)
+
+
+@pytest.mark.parametrize(
+    'state, terminal',
+    [
+        (TaskState.FINISHED, True),
+        (TaskState.SKIPPED, True),
+        (TaskState.FAILED, True),
+        (TaskState.PLANNED, False),
+        (TaskState.RUNNING, False),
+        (TaskState.CREATED, False),
+        (TaskState.READY, False),
+        (TaskState.MAPPED, False),
+    ],
+)
+def test_is_terminal(state, terminal):
+    assert state.is_terminal is terminal
+
+
+def test_terminal_set_matches_bare_strings_and_not_unset_default():
+    """The engine checks ``stored_state in TERMINAL_TASK_STATES`` where the
+    stored value is a bare string and the unset default is ``''``."""
+    assert TERMINAL_TASK_STATES == frozenset({TaskState.FINISHED, TaskState.SKIPPED, TaskState.FAILED})
+    for state in TERMINAL_TASK_STATES:
+        assert state.value in TERMINAL_TASK_STATES  # hash-equality with bare strings
+    assert '' not in TERMINAL_TASK_STATES
+    assert TaskState.PLANNED not in TERMINAL_TASK_STATES

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -17,7 +17,6 @@ def test_str_and_format_drop_class_prefix(enum_cls):
     member = next(iter(enum_cls))
     assert str(member) == member.value
     assert f'{member}' == member.value
-    assert '{}'.format(member) == member.value
 
 
 @pytest.mark.parametrize('enum_cls', [TaskState, TaskAction])


### PR DESCRIPTION
Task state and action were bare strings checked against copy-pasted `in [...]` lists. This PR adds `aiida_workgraph/enums.py` (`TaskState`/`TaskAction` as `str`-mixed enums + a `RuntimeInfoKey` `Literal`), migrates every engine call site, and unifies the terminal check into `TERMINAL_TASK_STATES` / `is_terminal`.

Behaviour-preserving: the `str` mixin keeps members equal to and JSON-serialising as the same bare strings, so persisted process-node state is byte-identical and existing string comparisons / `wg.wait(...)` keep working. It also fixes the latent action casing bug — normalise once in `apply_task_actions` (validate to `TaskAction`, dispatch via `match`), drop the scattered `.upper()`, and an unknown action now raises instead of being silently ignored.

Scope: `node.process_state` comparisons stay strings (aiida-core's domain), the dead `WAITING`/`PAUSED` are dropped from `kill_tasks`, and `enums.py` is importable but not in the top-level `__all__`. Typing follow-ups (`TaskType` enum, removing the runtime-info dispatch, `TypedDict`s, `Optional` sentinels, a node-graph sibling) will be filed as separate issues.

Closes [#789](https://github.com/aiidateam/aiida-workgraph/issues/789).