### PR TITLE
👌 `Map`: replace `z.item` with `z.value`/`z.key`

### DIFF
--- a/docs/gallery/advanced/autogen/context_manager.py
+++ b/docs/gallery/advanced/autogen/context_manager.py
@@ -489,9 +489,8 @@ wg.generate_provenance_graph()
 #   We welcome your feedback on its functionality.
 #   **ctx** does not work inside a ``Map`` zone yet.
 #
-# The ``Map`` context manager works similarly to Python's built-in ``map`` function.
-# By accessing the ``item`` member of the ``Map`` context, we can pass each individual element (e.g. a dictionary entry) to tasks.
-# This creates a new task behind the scenes for each element.
+# A ``Map`` zone runs the tasks inside it once for each entry of a dynamic namespace (a dict), not for each element of a sequence.
+# Use ``map_zone.value`` for the entry's value and ``map_zone.key`` for its key; a separate set of tasks is created behind the scenes for each entry.
 
 # %%
 # Running tasks in parallel
@@ -525,8 +524,8 @@ from aiida_workgraph import Map
 with WorkGraph('AddMap') as wg:
     with Map(data) as map_zone:
         result = add(
-            x=get_value(map_zone.item.value, 'x').result,
-            y=get_value(map_zone.item.value, 'y').result,
+            x=get_value(map_zone.value, 'x').result,
+            y=get_value(map_zone.value, 'y').result,
         ).result
         map_zone.gather({'result': result})
         wg.outputs.result = map_zone.outputs.result
@@ -572,8 +571,8 @@ def aggregate_sum(data: spec.dynamic(Any)) -> int:
 with WorkGraph('AddAggregate') as wg:
     with Map(data) as map_zone:
         added_numbers = add(
-            x=get_value(map_zone.item.value, 'x').result,
-            y=get_value(map_zone.item.value, 'y').result,
+            x=get_value(map_zone.value, 'x').result,
+            y=get_value(map_zone.value, 'y').result,
         ).result
         map_zone.gather({'result': added_numbers})
     wg.outputs.result = aggregate_sum(map_zone.outputs.result).result

--- a/docs/gallery/advanced/autogen/node_graph_programming.py
+++ b/docs/gallery/advanced/autogen/node_graph_programming.py
@@ -202,8 +202,8 @@ def calc_sum(data: spec.dynamic(Any)) -> int:
 
 # %%
 # To use the ``Map`` task, you define a ``source`` which is a dictionary.
-# The tasks inside the `map_zone` will be executed for each `item` in the source,
-# where `item` represents the value of each key-value pair.
+# The tasks inside the `map_zone` are executed once per key-value pair in the source.
+# Use ``map_task.value`` for the value of each pair, and ``map_task.key`` for its key.
 #
 
 wg = WorkGraph('map_task_example')
@@ -214,8 +214,8 @@ data_task = wg.add_task(generate_data, N=4)
 # Create a Map Zone, with the source being the dictionary from generate_data
 map_task = wg.add_task('workgraph.map_zone', source=data_task.outputs.result)
 
-# Inside the Map Zone, add 1 to each item
-add_task_in_map = map_task.add_task(add, x=map_task.item.value, y=1)
+# Inside the Map Zone, add 1 to each value
+add_task_in_map = map_task.add_task(add, x=map_task.value, y=1)
 
 map_task.gather({'result': add_task_in_map.outputs.result})
 

--- a/src/aiida_workgraph/manager.py
+++ b/src/aiida_workgraph/manager.py
@@ -11,8 +11,6 @@ from contextlib import contextmanager
 from aiida_workgraph.socket import TaskSocket
 from aiida_workgraph.tasks.task_pool import TaskPool
 
-DEFAULT_MAP_PLACEHOLDER = 'map_input'
-
 
 class CurrentGraphManager:
     _instance = None
@@ -167,12 +165,15 @@ def While(condition_socket: TaskSocket, max_iterations: int = 10000):
 
 
 @contextmanager
-def Map(source_socket: TaskSocket, placeholder: str = DEFAULT_MAP_PLACEHOLDER):
-    """
-    Context manager to create a "map zone" in the current graph.
+def Map(source_socket: TaskSocket):
+    """Iterate a set of tasks over a dynamic namespace (a dict).
 
-    :param source_socket: A TaskSocket or boolean-like object (e.g. sum_ > 0)
-    :param placeholder: The placeholder string to use as the input for the mapped tasks
+    The ``with`` block is a template body that runs once per entry of the
+    source. Inside it, the yielded zone exposes ``.value`` and ``.key`` as
+    placeholders for the current entry's value and key, and ``.gather(...)``
+    to collect per-entry results into the zone's outputs.
+
+    :param source_socket: A dynamic-namespace (dict) output socket to map over.
     """
 
     wg = get_current_graph()

--- a/src/aiida_workgraph/tasks/builtins.py
+++ b/src/aiida_workgraph/tasks/builtins.py
@@ -91,7 +91,12 @@ class If(Zone):
 
 
 class Map(Zone):
-    """Map"""
+    """Run a set of tasks once per entry of a dynamic-namespace (dict) source.
+
+    A Map iterates keyed entries, not a bare sequence. While building the body,
+    ``value`` and ``key`` are placeholders for the current entry; the engine
+    clones the body once per entry and binds them.
+    """
 
     _default_spec = TaskSpec(
         identifier='workgraph.map_zone',
@@ -107,14 +112,22 @@ class Map(Zone):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @property
-    def item(self):
+    def _map_item_task(self) -> Task:
+        """Return the single ``map_item`` child, creating it on first access."""
         for child in self.children:
             if child.identifier == 'workgraph.map_item':
-                return child.outputs
-        # create a child map_item_task if it does not exist
-        map_item_task = self.add_task('workgraph.map_item')
-        return map_item_task.outputs
+                return child
+        return self.add_task('workgraph.map_item')
+
+    @property
+    def value(self) -> BaseSocket:
+        """Placeholder for the current entry's value while iterating the source."""
+        return self._map_item_task().outputs.value
+
+    @property
+    def key(self) -> BaseSocket:
+        """Placeholder for the current entry's key while iterating the source."""
+        return self._map_item_task().outputs.key
 
     @property
     def gather_item_task(self) -> Task | None:
@@ -124,7 +137,8 @@ class Map(Zone):
         gather_item = self.add_task('workgraph.gather_item')
         return gather_item
 
-    def gather(self, sockets: Dict[str, BaseSocket]) -> None:
+    def gather(self, sockets: Dict[str, BaseSocket]) -> BaseSocket:
+        """Collect per-entry results into the zone outputs, one namespace per name."""
         gather_item = self.gather_item_task
         for name in sockets:
             gather_item.add_input_spec('workgraph.any', name=name)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -48,7 +48,7 @@ def test_map(decorated_add):
     with WorkGraph() as wg:
         outputs = generate_list(N)
         with Map(source_socket=outputs.result) as map_zone:
-            outputs1 = decorated_add(x=map_zone.item.value, y=1)
+            outputs1 = decorated_add(x=map_zone.value, y=1)
             map_zone.gather({'result': outputs1.result})
         outputs2 = sum_values(data=map_zone.outputs.result)
         wg.run()

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -28,6 +28,18 @@ def calc_sum(data: Annotated[dict, dynamic(orm.Int)]) -> float:
     return sum(data.values())
 
 
+@task()
+def echo(text: str) -> str:
+    """Return the input unchanged."""
+    return text
+
+
+@task()
+def join_keys(data: Annotated[dict, dynamic(orm.Str)]) -> str:
+    """Join all provided strings in sorted order."""
+    return ','.join(sorted(data.values()))
+
+
 def test_map_zone():
     x = 1
     y = 2
@@ -35,11 +47,27 @@ def test_map_zone():
     with WorkGraph('add_graph') as wg:
         data = generate_data(n=n).data
         with Map(data) as map_zone:
-            out1 = add(x=map_zone.item.value, y=x).result
-            out2 = add(x=map_zone.item.value, y=y).result
+            out1 = add(x=map_zone.value, y=x).result
+            out2 = add(x=map_zone.value, y=y).result
             map_zone.gather({'sum1': out1, 'sum2': out2})
         out3 = calc_sum(data=map_zone.outputs.sum1).result
         out4 = calc_sum(data=map_zone.outputs.sum2).result
         wg.run()
         assert out3.value == 6
         assert out4.value == 9
+
+
+def test_map_value_and_key():
+    """z.value and z.key resolve to the same per-element item and both flow (#785)."""
+    with WorkGraph('map_value_key') as wg:
+        data = generate_data(n=2).data
+        with Map(data) as z:
+            s = add(x=z.value, y=10).result
+            k = echo(text=z.key).result
+            z.gather({'sum': s, 'k': k})
+        total = calc_sum(data=z.outputs.sum).result
+        joined = join_keys(data=z.outputs.k).result
+        wg.run()
+    # values 0, 1 -> (0+10)+(1+10) = 21; keys are the user's own source keys
+    assert total.value == 21
+    assert joined.value == 'key_0,key_1'


### PR DESCRIPTION
A `Map` zone always iterates a dynamic namespace (a dict), but the per-element handle `z.item` never made that obvious: it was a namespace whose `.value`/`.key` ports you had to discover, passing bare `z.item` raised a cryptic node_graph error, and the name suggested sequence iteration (#785).

This replaces `z.item` with two explicit handles on the zone, `z.value` for the current entry's value and `z.key` for its key:

```python
with Map(make_items()) as z:
    sink(dct=z.value)      # was: z.item.value
    label(text=z.key)      # was: z.item.key
```

Since there is no stable release, `z.item` is dropped fully rather than deprecated. Also drops an unused `placeholder` parameter from the `Map` context manager.

The generic node_graph "top-level output socket without a parent" message (seen when linking any bare namespace into a leaf input) is left as a separate upstream follow-up.

Closes #785