### PR TITLE
♻️ Adopt node-graph's `GraphTaskHandle` for `@task.graph` decorators

### DIFF
--- a/src/aiida_workgraph/decorator.py
+++ b/src/aiida_workgraph/decorator.py
@@ -178,8 +178,9 @@ class TaskDecoratorCollection:
 
         def decorator(func) -> TaskHandle:
             from aiida_workgraph.tasks.graph_task import _build_graph_task_taskspec
+            from aiida_workgraph.task import GraphTaskHandle
 
-            handle = TaskHandle(
+            handle = GraphTaskHandle(
                 _build_graph_task_taskspec(
                     func,
                     identifier=identifier,

--- a/src/aiida_workgraph/task.py
+++ b/src/aiida_workgraph/task.py
@@ -11,7 +11,7 @@ from aiida_workgraph.socket_spec import SocketSpecAPI
 from node_graph.task_spec import TaskSpec
 
 if TYPE_CHECKING:
-    pass
+    from aiida_workgraph.workgraph import WorkGraph
 
 
 class Task(GraphTask):
@@ -231,15 +231,36 @@ class TaskHandle(BaseHandle):
 
         return outputs
 
-    def run(self, /, *args, **kwargs):
+
+class GraphTaskHandle(TaskHandle):
+    """Handle for ``@task.graph`` callables.
+
+    node-graph #150 made ``build`` graph-only by handle type (it moved from
+    ``BaseHandle`` to node-graph's ``GraphTaskHandle``). Mirror that here:
+    ``build``/``run``/``run_get_graph``/``submit`` all materialize a WorkGraph,
+    which only makes sense for graph specs — on plain task handles they only
+    ever raised.
+
+    ``build`` delegates to node-graph's implementation unbound rather than
+    inheriting it, because node-graph's ``GraphTaskHandle.__init__`` takes
+    ``spec`` only, while ours must also wire ``get_current_graph`` and
+    ``graph_class=WorkGraph``.
+    """
+
+    def build(self, /, *args: Any, **kwargs: Any) -> WorkGraph:
+        from node_graph.task_spec import GraphTaskHandle as _NGGraphTaskHandle
+
+        return _NGGraphTaskHandle.build(self, *args, **kwargs)
+
+    def run(self, /, *args: Any, **kwargs: Any) -> Any:
         graph = self.build(*args, **kwargs)
         return graph.run()
 
-    def run_get_graph(self, /, *args, **kwargs):
+    def run_get_graph(self, /, *args: Any, **kwargs: Any) -> tuple[Any, WorkGraph]:
         graph = self.build(*args, **kwargs)
         return graph.run(), graph
 
-    def submit(self, /, *args, **kwargs):
+    def submit(self, /, *args: Any, **kwargs: Any) -> WorkGraph:
         graph = self.build(*args, **kwargs)
         graph.submit()
         return graph


### PR DESCRIPTION
## Problem

node-graph #150 made `build` graph-only by handle type: it removed the method (and its runtime `task_type != "GRAPH"` guard) from `BaseHandle` and moved it to a new `GraphTaskHandle`. node-graph's own decorator now dispatches on the spec type:

```python
handle = GraphTaskHandle(spec) if is_graph_task else TaskHandle(spec)
```

aiida-workgraph's graph decorator still returns a plain `TaskHandle`, so when paired with `node-graph > 0.6.5` every `@task.graph` handle loses `build`/`run`/`run_get_graph`/`submit`:

```
AttributeError: 'TaskHandle' object has no attribute 'build'
```
## Change

Mirror the upstream pattern:

- New `aiida_workgraph.task.GraphTaskHandle(TaskHandle)`, returned by the `@task.graph` decorator.
- `build` delegates to node-graph's `GraphTaskHandle.build` rather than inheriting it, because node-graph's `__init__` takes `spec` only, while ours must also wire `get_current_graph` and `graph_class=WorkGraph`. The delegation only needs `self._spec` / `self._graph_class` / `self.identifier`, all present here.
- `run`, `run_get_graph` and `submit` move from `TaskHandle` onto `GraphTaskHandle`. They all materialize a `WorkGraph` via `self.build`, which only makes sense for graph specs; on plain task handles they only ever raised. Plain handles now keep node-graph's direct-execute `run` semantics, matching the behaviour of #150

## Compatibility

#150 is unreleased at the time of writing; the `node-graph` version pin should be bumped upon the next node-graph release, and this PR should not be merged prior.
