### PR TITLE
🐛 Deserialize objects in the body of a task.graph

### DIFF
--- a/src/aiida_workgraph/serialization.py
+++ b/src/aiida_workgraph/serialization.py
@@ -7,6 +7,21 @@ from aiida_pythonjob.utils import serialize_ports
 from node_graph.serializer import SerializationAdapter
 from node_graph.utils import resolve_tagged_values
 
+# Socket identifiers whose declared type is a Python primitive. When the
+# persisted value round-trips through AiiDA storage it becomes the matching
+# ``orm.BaseType`` node (``orm.Float``, ``orm.Int``, ``orm.Str``,
+# ``orm.Bool``); ``deserialize`` must strip that wrapper before the value
+# reaches a user-written ``@task.graph`` body whose signature declared a
+# primitive type.
+_PRIMITIVE_SOCKET_IDENTIFIERS = frozenset(
+    {
+        'workgraph.float',
+        'workgraph.int',
+        'workgraph.string',
+        'workgraph.bool',
+    }
+)
+
 
 class AiidaSerializationAdapter(SerializationAdapter):
     id: str = 'aiida'
@@ -27,6 +42,25 @@ class AiidaSerializationAdapter(SerializationAdapter):
             serializers=self.serializers,
             user=self.user,
         )
+
+    def deserialize(self, value: Any, socket: Any) -> Any:
+        """Unwrap ``orm.BaseType`` to its Python value for primitive sockets.
+
+        Symmetric counterpart to ``serialize``: where the write path
+        auto-serialises primitive inputs into ``orm.Float`` / ``orm.Int`` /
+        ``orm.Str`` / ``orm.Bool`` for provenance, the read path (invoked
+        just before a ``@task.graph`` body is called) hands the body the
+        primitive that its signature actually declared. Non-primitive sockets
+        (``workgraph.any``, AiiDA-typed sockets, etc.) pass through.
+        """
+        from aiida import orm
+
+        if not isinstance(value, orm.BaseType):
+            return value
+        identifier = getattr(socket, '_identifier', None)
+        if identifier in _PRIMITIVE_SOCKET_IDENTIFIERS:
+            return value.value
+        return value
 
     def serialize_ports(self, python_data: Any, port_schema: Any, *, store: bool) -> Any:
         resolve_tagged_values(python_data)

--- a/src/aiida_workgraph/serialization.py
+++ b/src/aiida_workgraph/serialization.py
@@ -52,14 +52,34 @@ class AiidaSerializationAdapter(SerializationAdapter):
         just before a ``@task.graph`` body is called) hands the body the
         primitive that its signature actually declared. Non-primitive sockets
         (``workgraph.any``, AiiDA-typed sockets, etc.) pass through.
+
+        Dataclass-typed sockets get the same unwrap applied to their
+        fields. Without this the ``cls(**value)`` reconstruction in
+        ``node_graph.utils.struct_utils.coerce_structured_value`` re-packs
+        node-promoted scalars into the dataclass, so a field declared
+        ``int`` lands as ``orm.Int`` and downstream stdlib calls
+        (``range(self.ntyp)``, etc.) fail with ``TypeError`` because
+        ``orm.Int`` doesn't implement ``__index__``.
         """
+        from dataclasses import fields, is_dataclass, replace
+
         from aiida import orm
 
-        if not isinstance(value, orm.BaseType):
+        if isinstance(value, orm.BaseType):
+            identifier = getattr(socket, '_identifier', None)
+            if identifier in _PRIMITIVE_SOCKET_IDENTIFIERS:
+                return value.value
             return value
-        identifier = getattr(socket, '_identifier', None)
-        if identifier in _PRIMITIVE_SOCKET_IDENTIFIERS:
-            return value.value
+
+        if is_dataclass(value) and not isinstance(value, type):
+            field_updates = {
+                f.name: getattr(value, f.name).value
+                for f in fields(value)
+                if isinstance(getattr(value, f.name), orm.BaseType)
+            }
+            if field_updates:
+                return replace(value, **field_updates)
+
         return value
 
     def serialize_ports(self, python_data: Any, port_schema: Any, *, store: bool) -> Any:

--- a/src/aiida_workgraph/serialization.py
+++ b/src/aiida_workgraph/serialization.py
@@ -71,6 +71,17 @@ class AiidaSerializationAdapter(SerializationAdapter):
                 return value.value
             return value
 
+        # Same unwrap for container-typed sockets: a plain dict/list built in
+        # a parent graph body is promoted to ``orm.Dict`` / ``orm.List`` for
+        # provenance, but a body whose signature declares ``dict`` / ``list``
+        # expects the plain container (e.g. ``get_protocol_inputs`` calls
+        # ``overrides.copy()``, which ``orm.Dict`` doesn't implement).
+        identifier = getattr(socket, '_identifier', None)
+        if isinstance(value, orm.Dict) and identifier == 'workgraph.dict':
+            return value.get_dict()
+        if isinstance(value, orm.List) and identifier == 'workgraph.list':
+            return value.get_list()
+
         if is_dataclass(value) and not isinstance(value, type):
             field_updates = {
                 f.name: getattr(value, f.name).value


### PR DESCRIPTION
## Problem

The write path auto-serialises primitive task inputs into `orm.Float` / `orm.Int` / `orm.Str` / `orm.Bool` for provenance, but there was no symmetric read path: `SerializationAdapter.deserialize` existed in the node-graph base API and was never implemented here. A `@task.graph` body whose signature declared `nspin: int`  could therefore receive an `orm.Int` after a round-trip through AiiDA storage, with two failure modes:

- silently wrong logic: `if nspin == 2:` style comparisons against a node object
- hard crashes at stdlib or AiiDA boundaries: `conv_thr = 1.0e-9 * nelec`, `QueryBuilder` / `orm.Dict` interfaces.

The same asymmetry bites dataclass-typed sockets crossing a `@task.graph` boundary: field values are node-promoted, then `coerce_structured_value` rebuilds the dataclass via `cls(**value)` with the fields still wrapped, so a field declared `int` arrives as `orm.Int` and e.g. `range(self.ntyp)` raises `TypeError` (`orm.Int` has no `__index__`).

## Change

Implement `AiidaSerializationAdapter.deserialize` as the symmetric counterpart to `serialize`, invoked just before a `@task.graph` body runs:

- For sockets whose declared type is a `float` / `int` / `string` / `bool`): unwrap `orm.BaseType` to its `.value`, so the body sees the primitive its signature declared.
- Container-typed sockets get the same treatment: values persisted as orm.Dict/orm.List are unwrapped to plain dict/list on deserialize, so a @task.graph body that declared dict/list receives the Python container rather than the ORM node.
- For dataclass instances: unwrap any `orm.BaseType`-wrapped field via `dataclasses.replace` (frozen-safe).
- Everything else (`workgraph.any`, Aiass structures) passes through unchanged

## Compatibility

Requires the node-graph side actually calling the adapter on the read path: the `materialize_graph` deserialize-on-read hook and routing of structured-namespace values through `adapter.deserialize` (today `_deserialize_inputs` only recurses into dicts). Both are part of the node-graph dynamic-namespace/deserialize work targeting node-graph main and not yet in a released node-graph, hence draft.