### PR TITLE
Flatten Enum members to bare values on the serialize path

### DIFF
--- a/src/aiida_workgraph/serialization.py
+++ b/src/aiida_workgraph/serialization.py
@@ -12,19 +12,43 @@ from node_graph.utils import resolve_tagged_values
 def _flatten_enums(value: Any) -> Any:
     """Replace ``Enum`` members with their bare ``.value``, recursively.
 
-    ``node_graph`` declares that an enum-typed socket's serialized form is
-    its bare value (``socket_spec`` records ``structured_type`` extras so
-    ``coerce_inputs_from_spec`` can rebuild the member before a task body
-    runs). The write path has to honour that contract: without this,
-    ``serialize_ports`` hands the raw ``Enum`` instance to
-    ``general_serializer``, which has no serializer for it and fails at
-    submit time. ``isinstance`` also matches wrapt proxies (TaggedValue)
-    around enum members.
+    ``general_serializer`` (aiida-pythonjob) has no serializer for ``Enum``
+    members: a raw ``Enum`` -- or one nested in a dict/list/tuple -- reaches
+    it and the whole submission fails at submit time with an opaque
+    serialization error. Collapsing members to their ``.value`` here keeps
+    the payload JSON-serializable so ``serialize_ports`` succeeds. The
+    ``isinstance`` check also matches wrapt proxies (node-graph's
+    ``TaggedValue``) wrapping an enum member.
+
+    This is a one-way flattening, *not* a round-trip. Under the pinned
+    ``node_graph`` the read side (``coerce_inputs_from_spec``) rebuilds only
+    structured *models* -- dataclass/pydantic/TypedDict -- and records no
+    ``structured_type`` extra for ``Enum`` sockets, so it never reconstructs
+    the member. Task bodies therefore receive the bare value, not the
+    ``Enum`` they declared. This is harmless for ``IntEnum`` / ``str, Enum``
+    consumed by value or equality, but a body that tests ``x is Color.RED``
+    or ``x == Color.RED`` against a *plain* ``Enum`` sees ``False``. See
+    ``tests/test_serializer.py::test_body_receives_bare_value_not_member``.
+
+    ``set``/``frozenset`` are deliberately left untouched: a set fails in
+    ``general_serializer`` regardless of its contents (not JSON-serializable,
+    no registered serializer), so descending into one to flatten enums would
+    not make it serializable -- see
+    ``tests/test_serializer.py::test_flatten_leaves_sets_untouched``.
     """
     if isinstance(value, Enum):
         return _flatten_enums(value.value)
     if isinstance(value, dict):
-        return {_flatten_enums(k): _flatten_enums(v) for k, v in value.items()}
+        out: Dict[Any, Any] = {}
+        for k, v in value.items():
+            flat_key = _flatten_enums(k)
+            if flat_key in out:
+                # Two distinct keys (e.g. an Enum member and its bare value,
+                # or two members sharing a ``.value``) collapse to one; raise
+                # rather than silently drop an entry.
+                raise ValueError(f'Enum key flattening collision: multiple keys map to {flat_key!r}')
+            out[flat_key] = _flatten_enums(v)
+        return out
     if isinstance(value, list):
         return [_flatten_enums(v) for v in value]
     if isinstance(value, tuple):

--- a/src/aiida_workgraph/serialization.py
+++ b/src/aiida_workgraph/serialization.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, Dict, Optional
 
 from aiida_pythonjob.data.serializer import all_serializers
 from aiida_pythonjob.utils import serialize_ports
 from node_graph.serializer import SerializationAdapter
 from node_graph.utils import resolve_tagged_values
+
+
+def _flatten_enums(value: Any) -> Any:
+    """Replace ``Enum`` members with their bare ``.value``, recursively.
+
+    ``node_graph`` declares that an enum-typed socket's serialized form is
+    its bare value (``socket_spec`` records ``structured_type`` extras so
+    ``coerce_inputs_from_spec`` can rebuild the member before a task body
+    runs). The write path has to honour that contract: without this,
+    ``serialize_ports`` hands the raw ``Enum`` instance to
+    ``general_serializer``, which has no serializer for it and fails at
+    submit time. ``isinstance`` also matches wrapt proxies (TaggedValue)
+    around enum members.
+    """
+    if isinstance(value, Enum):
+        return _flatten_enums(value.value)
+    if isinstance(value, dict):
+        return {_flatten_enums(k): _flatten_enums(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_flatten_enums(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_flatten_enums(v) for v in value)
+    return value
 
 
 class AiidaSerializationAdapter(SerializationAdapter):
@@ -21,6 +45,7 @@ class AiidaSerializationAdapter(SerializationAdapter):
             return value
         spec = socket._to_spec()
         resolve_tagged_values(value)
+        value = _flatten_enums(value)
         return serialize_ports(
             python_data=value,
             port_schema=spec,
@@ -30,6 +55,7 @@ class AiidaSerializationAdapter(SerializationAdapter):
 
     def serialize_ports(self, python_data: Any, port_schema: Any, *, store: bool) -> Any:
         resolve_tagged_values(python_data)
+        python_data = _flatten_enums(python_data)
         return serialize_ports(
             python_data=python_data,
             port_schema=port_schema,

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,9 @@
+from enum import Enum, IntEnum
+
 from aiida_workgraph import WorkGraph, task
 import pytest
+
+from aiida_workgraph.serialization import AiidaSerializationAdapter, _flatten_enums
 
 
 @task.graph()
@@ -14,3 +18,90 @@ def test_func_as_input(capsys):
     wg.add_task(sub_workflow, func=add, name='sub_workflow')
     with pytest.raises(Exception, match='Cannot serialize the provided object'):
         wg.save()
+
+
+class Color(Enum):
+    """Plain enum whose value is a bare string."""
+
+    RED = 'red'
+    BLUE = 'blue'
+
+
+class Priority(IntEnum):
+    """Enum whose value is a bare int."""
+
+    LOW = 1
+    HIGH = 9
+
+
+class Flavour(str, Enum):
+    """Enum member that is itself a ``str`` subclass."""
+
+    SWEET = 'sweet'
+    SOUR = 'sour'
+
+
+def test_flatten_bare_enum_member():
+    """A lone member collapses to its ``.value``, not a mangled ``Color.RED``."""
+    assert _flatten_enums(Color.RED) == 'red'
+    assert not isinstance(_flatten_enums(Color.RED), Enum)
+
+
+def test_flatten_intenum_and_str_enum_yield_bare_value():
+    """The bare value's own type is preserved (int stays int, str stays str)."""
+    assert _flatten_enums(Priority.HIGH) == 9
+    assert type(_flatten_enums(Priority.HIGH)) is int
+    assert _flatten_enums(Flavour.SWEET) == 'sweet'
+    assert type(_flatten_enums(Flavour.SWEET)) is str
+
+
+def test_flatten_dict_keys_and_values():
+    """Enums appearing as dict keys *and* values both flatten."""
+    assert _flatten_enums({Color.RED: Color.BLUE, 'n': Priority.LOW}) == {'red': 'blue', 'n': 1}
+
+
+def test_flatten_list_and_tuple_preserve_container_type():
+    """Sequences recurse element-wise and keep list-vs-tuple identity."""
+    assert _flatten_enums([Color.RED, 1, 'x']) == ['red', 1, 'x']
+    out = _flatten_enums((Color.RED, Priority.HIGH))
+    assert out == ('red', 9)
+    assert isinstance(out, tuple)
+
+
+def test_flatten_mixed_nesting():
+    """Enums buried in a dict/list/tuple mixture are all reached."""
+    payload = {
+        'a': [Color.RED, {'b': Priority.LOW}],
+        Color.BLUE: ('x', Flavour.SOUR),
+    }
+    assert _flatten_enums(payload) == {
+        'a': ['red', {'b': 1}],
+        'blue': ('x', 'sour'),
+    }
+
+
+def test_flatten_passthrough_of_enum_free_payload():
+    """An enum-free payload comes back with identical values."""
+    payload = {'n': 3, 'items': [1, 'two', (3.0, None)], 'flag': True}
+    assert _flatten_enums(payload) == payload
+
+
+def test_flatten_wrapt_proxied_enum_member():
+    """A wrapt ``ObjectProxy`` (as TaggedValue wraps members) still flattens."""
+    wrapt = pytest.importorskip('wrapt')
+    proxied = wrapt.ObjectProxy(Color.RED)
+    assert _flatten_enums(proxied) == 'red'
+    assert _flatten_enums({proxied: proxied}) == {'red': 'red'}
+
+
+def test_serialize_ports_accepts_enum_value(aiida_profile):
+    """End-to-end through the adapter: an enum-valued namespace entry serializes
+    without raising, landing as the flattened bare value (needs a profile so the
+    downstream ``general_serializer`` can build the node)."""
+    from aiida import orm
+    from node_graph.socket_spec import SocketMeta, SocketSpec
+
+    spec = SocketSpec(identifier='node_graph.namespace', meta=SocketMeta(dynamic=True))
+    out = AiidaSerializationAdapter().serialize_ports({'c': Color.RED, 'n': 3}, spec, store=False)
+    assert isinstance(out['c'], orm.Str)
+    assert out['c'].value == 'red'

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -94,6 +94,30 @@ def test_flatten_wrapt_proxied_enum_member():
     assert _flatten_enums({proxied: proxied}) == {'red': 'red'}
 
 
+def test_flatten_dict_key_collision_raises():
+    """Two distinct keys collapsing to the same flattened key raises rather than
+    silently dropping an entry. Here ``Color.RED`` (a plain Enum, so distinct in
+    identity and hash from the bare string) and ``'red'`` are separate keys that
+    both flatten to ``'red'``."""
+    payload = {Color.RED: 1, 'red': 2}
+    assert len(payload) == 2  # distinct keys before flattening
+    with pytest.raises(ValueError, match='collision'):
+        _flatten_enums(payload)
+
+
+def test_flatten_leaves_sets_untouched():
+    """``set``/``frozenset`` are not descended into: they fail in
+    ``general_serializer`` regardless of contents, so flattening enums inside
+    them would not make them serializable. Pin that they pass through unchanged
+    (still holding Enum members)."""
+    s = {Color.RED, Color.BLUE}
+    out = _flatten_enums(s)
+    assert out is s
+    assert Color.RED in out
+    fs = frozenset({Priority.LOW})
+    assert _flatten_enums(fs) is fs
+
+
 def test_serialize_ports_accepts_enum_value(aiida_profile):
     """End-to-end through the adapter: an enum-valued namespace entry serializes
     without raising, landing as the flattened bare value (needs a profile so the
@@ -105,3 +129,29 @@ def test_serialize_ports_accepts_enum_value(aiida_profile):
     out = AiidaSerializationAdapter().serialize_ports({'c': Color.RED, 'n': 3}, spec, store=False)
     assert isinstance(out['c'], orm.Str)
     assert out['c'].value == 'red'
+
+
+@task(outputs=['type_name', 'is_enum', 'eq_member'])
+def _observe_enum(c: Color) -> dict:
+    """Report what the body actually receives for an Enum-typed input."""
+    return {
+        'type_name': type(c).__name__,
+        'is_enum': isinstance(c, Color),
+        'eq_member': c == Color.RED,
+    }
+
+
+def test_body_receives_bare_value_not_member(aiida_profile):
+    """Pin the real round-trip behaviour under the pinned ``node_graph``: a task
+    body declaring a *plain* ``Enum`` input receives the BARE value, not the
+    member. ``node_graph`` records ``structured_type`` extras only for
+    dataclass/pydantic/TypedDict, so ``coerce_inputs_from_spec`` never rebuilds
+    an ``Enum``. If node-graph later adds enum reconstruction, this test flips
+    loudly and the docstring/PR claim must be revisited."""
+    wg = WorkGraph('enum_roundtrip')
+    t = wg.add_task(_observe_enum, name='observe', c=Color.RED)
+    wg.run()
+    assert wg.state == 'FINISHED'
+    assert t.outputs['type_name'].value.value == 'str'
+    assert t.outputs['is_enum'].value.value is False
+    assert t.outputs['eq_member'].value.value is False


### PR DESCRIPTION
## Problem

`aiida-pythonjob`'s `general_serializer` has no serializer for `Enum` members. A raw `Enum` instance (or a dict/list containing one, e.g. a parameters dict with an enum-valued entry) flows straight into `serialize_ports`, which hands it to `general_serializer`, and the whole submission fails at submit time with an opaque serialization error.

## Change

A small `_flatten_enums` helper replaces `Enum` members with their `.value`, recursively through dicts (keys and values), lists and tuples, and is applied in both `AiidaSerializationAdapter.serialize` and `AiidaSerializationAdapter.serialize_ports` immediately after `resolve_tagged_values`. The `isinstance(value, Enum)` check also matches wrapt proxies (`TaggedValue`) wrapping enum members, so tagged graph inputs are handled by the same path.

This is a one-way flattening on the write path, not a round-trip. Under the pinned `node-graph` (0.6.5) the read side (`coerce_inputs_from_spec`) reconstructs only structured *models* — dataclass/pydantic/TypedDict — and records no `structured_type` extra for `Enum` sockets, so it never rebuilds the member. Task bodies therefore receive the bare `.value`, not the `Enum` they declared. This is harmless for `IntEnum` / `str, Enum` consumed by value or equality, but a body that tests `x is Color.RED` / `x == Color.RED` against a *plain* `Enum` will see `False`. True reconstruction would need an enum branch in node-graph's `structured_type_info`/`coerce_structured_value` and is left as follow-up there.

Two edge cases are handled explicitly: `set`/`frozenset` are left untouched (a set fails in `general_serializer` regardless of its contents — not JSON-serializable, no registered serializer — so descending into one to flatten enums would not make it serializable; documented as a limitation), and dict-key flattening now raises on a collision (two distinct keys collapsing to one, e.g. an `Enum` member and its bare value) rather than silently dropping an entry.

## Testing
New unit tests in `tests/test_serializer.py`, including `test_body_receives_bare_value_not_member`, which drives a real `wg.run()` and asserts a plain-`Enum` input reaches the body as the bare value — pinning the actual (non-round-trip) behaviour so it flips loudly if node-graph later adds enum reconstruction — plus tests for the set passthrough and the key-collision guard.

Exercised end-to-end by the downstream Koopmans package, whose workgraphs pass enum-valued settings (e.g. functional and spin-treatment enums) through `@task.graph` inputs: before the change every such submission failed in `general_serializer`; after it, the graphs submit (the bodies receive the bare enum value, per the note above).