### PR TITLE
🐛 Do not require the children of an omitted optional namespace

### DIFF
--- a/src/aiida_workgraph/workgraph.py
+++ b/src/aiida_workgraph/workgraph.py
@@ -120,11 +120,24 @@ class WorkGraph(node_graph.Graph):
         missing_inputs = []
         for sub_socket in socket:
             if isinstance(sub_socket, TaskSocketNamespace):
+                # The children of an optional namespace are required only *within* it:
+                # they say what a caller must provide if they provide the namespace at
+                # all. A namespace left entirely empty is therefore not missing anything.
+                if not sub_socket._metadata.required and not self.is_socket_provided(sub_socket):
+                    continue
                 missing_inputs.extend(self.find_missing_inputs(sub_socket))
             else:
                 if sub_socket._metadata.required and sub_socket.value is None and len(sub_socket._links) == 0:
                     missing_inputs.append(f'{sub_socket._task.name}.{sub_socket._scoped_name}')
         return missing_inputs
+
+    def is_socket_provided(self, socket: BaseSocket) -> bool:
+        """Check whether a socket carries a value or a link, anywhere in its subtree."""
+        if len(socket._links) > 0:
+            return True
+        if not isinstance(socket, TaskSocketNamespace):
+            return socket.value is not None
+        return any(self.is_socket_provided(sub_socket) for sub_socket in socket)
 
     def check_modified_tasks(self) -> None:
         """Check if there are modified tasks compared to the existing process.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,6 +22,77 @@ def test_validate_required_inputs():
         my_graph.run(a=1, b={'x': 1})
 
 
+# The default makes the namespace optional; it is deliberately not ``None``.
+# Up to Python 3.10 ``get_type_hints`` rewrites a ``None``-defaulted annotation
+# as ``Optional[...]``, and deduplicating that union hashes the ``Annotated``
+# metadata — which holds a dict, so the spec fails to build.
+@task
+def consume_optional_namespace(payload: Annotated[dict, namespace(x=int, y=int)] = {}):
+    return payload
+
+
+@task
+def consume_required_namespace(payload: Annotated[dict, namespace(x=int, y=int)]):
+    return payload
+
+
+def test_optional_namespace_left_empty_is_not_missing():
+    """An optional namespace socket that the caller never touched is complete.
+
+    Its children are required only *within* the namespace — they say what must be
+    supplied if the namespace is supplied at all. Recursing into an untouched
+    optional namespace reported every child as missing, which made an optional
+    grouped input (e.g. a ``TypedDict | None``) impossible to omit.
+    """
+    wg = WorkGraph('optional-namespace')
+    wg.add_task(consume_optional_namespace, name='consumer')
+
+    assert wg.find_missing_inputs(wg.tasks.consumer.inputs) == []
+    wg.check_required_inputs()
+
+
+def test_partially_filled_optional_namespace_reports_its_gaps():
+    """Once an optional namespace is used at all, its children are back in force."""
+    wg = WorkGraph('optional-namespace-partial')
+    task_ = wg.add_task(consume_optional_namespace, name='consumer')
+    task_.inputs.payload.x.value = 1
+
+    assert wg.find_missing_inputs(task_.inputs) == ['consumer.payload.y']
+    with pytest.raises(ValueError, match=re.escape('consumer.payload.y')):
+        wg.check_required_inputs()
+
+
+@task
+def produce_namespace() -> Annotated[dict, namespace(x=int, y=int)]:
+    return {'x': 1, 'y': 2}
+
+
+def test_optional_namespace_with_a_linked_child_reports_its_gaps():
+    """A link into a single child counts as using the namespace.
+
+    The link sits on the child, so the namespace itself has neither a value nor a
+    link of its own; deciding on those alone would skip it and hide the sibling
+    that the caller still has to provide.
+    """
+    wg = WorkGraph('optional-namespace-linked-child')
+    producer = wg.add_task(produce_namespace, name='producer')
+    consumer = wg.add_task(consume_optional_namespace, name='consumer')
+    consumer.inputs.payload.x = producer.outputs.x
+
+    assert wg.find_missing_inputs(consumer.inputs) == ['consumer.payload.y']
+
+
+def test_required_namespace_left_empty_still_reports_its_children():
+    """A required namespace is unaffected: omitting it is still an error."""
+    wg = WorkGraph('required-namespace')
+    task_ = wg.add_task(consume_required_namespace, name='consumer')
+
+    assert sorted(wg.find_missing_inputs(task_.inputs)) == [
+        'consumer.payload.x',
+        'consumer.payload.y',
+    ]
+
+
 @pytest.mark.parametrize(
     'name, reason',
     [


### PR DESCRIPTION
### Problem

An optional namespace input cannot be omitted. If a task declares a grouped input that may be left out entirely — a `TypedDict | None` parameter, for instance — `check_before_run()` wrongly reports every one of that namespace's children as a missing required input:

```python
class Window(TypedDict):
    """An energy window: both bounds, or neither."""

    lower: float
    upper: float


@task
def count_states(energies: list, window: Window | None = None) -> int:
    """Count the energies, optionally restricted to a window."""
    if window is None:
        return len(energies)
    return len([e for e in energies if window['lower'] <= e <= window['upper']])


wg = WorkGraph('example')
wg.add_task(count_states, name='count_states', energies=[-1.0, 0.5, 2.0])
wg.run()
```

`window` has a `None` default and the function handles its absence, but the graph will not run:

```
ValueError: Missing required inputs:
  • count_states.window.lower
  • count_states.window.upper
```

The namespace socket itself is correctly marked `required = False`; only its children are required. `find_missing_inputs` recurses into the children without consulting the parent, so their requiredness is read as absolute rather than conditional on the namespace being supplied at all.

### Changes

- An optional namespace nobody filled in is not missing anything: in this instance skip the recursion.
- Add `WorkGraph.is_socket_provided`, which performs this "anything in the subtree" test (doing so recursively to catch namespaces whose child is linked from an upstream task).
- A namespace that is partially supplied still reports its missing children, and a required namespace is unaffected.

### Testing

`tests/test_validation.py` covers four cases:

- An optional namespace left entirely empty reports nothing. This is the desired fix, and fails without the change.
- An optional namespace with one of two children supplied still reports the other.
- An optional namespace with one child linked from an upstream task output likewise still reports the unlinked child.
- A required namespace left empty still reports both children, i.e. existing behaviour is untouched.

Reverting the source change leaves the last three passing but fails the first.